### PR TITLE
LENGTH data type is integer

### DIFF
--- a/generator/fields_gen.rb
+++ b/generator/fields_gen.rb
@@ -11,9 +11,9 @@ class FieldGen
     case field[:fldtype]
       when 'CHAR' 
         {:cs_class => 'CharField', :base_type=>'char'}
-      when 'INT', 'NUMINGROUP', 'SEQNUM'
+      when 'INT', 'NUMINGROUP', 'SEQNUM', 'LENGTH'
         {:cs_class => 'IntField', :base_type=>'int'}
-      when 'AMT', 'PERCENTAGE', 'PRICE', 'QTY', 'PRICEOFFSET', 'LENGTH', 'FLOAT'
+      when 'AMT', 'PERCENTAGE', 'PRICE', 'QTY', 'PRICEOFFSET', 'FLOAT'
         {:cs_class => 'DecimalField', :base_type=>'Decimal'}
       when 'UTCTIMESTAMP', 'TZTIMESTAMP', 'TIME', 'DATE', 'UTCDATE'
         {:cs_class => 'DateTimeField', :base_type=>'DateTime'}


### PR DESCRIPTION
According to: http://fixprotocol.org/FIXimate3.0/en/FIX.5.0SP2/fix_datatypes.html, LENGTH is an integer datatype, just fixing this in the generated code, probably not a huge show stopper but would be nice to have.
