### PR TITLE
Support international characters

### DIFF
--- a/QuickFIXn/Fields/FieldBase.cs
+++ b/QuickFIXn/Fields/FieldBase.cs
@@ -72,8 +72,7 @@ namespace QuickFix.Fields
         {
             if (_changed)
                 makeStringFields();
-
-            return _stringField.Length + 1; // +1 for SOH
+            return System.Text.Encoding.UTF8.GetByteCount(_stringField) + 1; // +1 for SOH
         }
 
         /// <summary>
@@ -85,9 +84,10 @@ namespace QuickFix.Fields
                 makeStringFields();
 
             int sum = 0;
-            foreach (char c in _stringField)
+            byte[] array = System.Text.Encoding.UTF8.GetBytes(_stringField);
+            foreach (byte b in array)
             {
-                sum += (int)c;
+                sum += b;
             }
             return (sum + 1); // +1 for SOH
         }

--- a/QuickFIXn/SocketInitiatorThread.cs
+++ b/QuickFIXn/SocketInitiatorThread.cs
@@ -66,7 +66,7 @@ namespace QuickFix
                     int bytesRead = socket_.Receive(readBuffer_);
                     if (0 == bytesRead)
                         throw new SocketException(System.Convert.ToInt32(SocketError.ConnectionReset));
-                    parser_.AddToStream(System.Text.Encoding.UTF8.GetString(readBuffer_, 0, bytesRead));
+                    parser_.AddToStream(ref readBuffer_, bytesRead);
                 }
                 else if (null != session_)
                 {

--- a/QuickFIXn/SocketReader.cs
+++ b/QuickFIXn/SocketReader.cs
@@ -30,7 +30,7 @@ namespace QuickFix
                     int bytesRead = tcpClient_.Client.Receive(readBuffer_);
                     if (bytesRead < 1)
                         throw new SocketException(System.Convert.ToInt32(SocketError.ConnectionReset));
-                    parser_.AddToStream(System.Text.Encoding.UTF8.GetString(readBuffer_, 0, bytesRead));
+                    parser_.AddToStream(ref readBuffer_, bytesRead);
                 }
                 else if (null != qfSession_)
                 {


### PR DESCRIPTION
There is a problem with Parser.cs and FieldBase.cs - they expect every character in a string to be one byte, which is not necessarily true.
The dependency is based on the field BodyLength, which in FIX should refer to the _number of bytes_ of the message after the BodyLength field.

These changes switches to use a BinaryBuffer instead of String in Parser.cs, and changes FieldBase.cs to correctly calculate the length in bytes instead of characters.
