### PR TITLE
Extending IDisposable Implementation

### DIFF
--- a/QuickFIXn/AbstractInitiator.cs
+++ b/QuickFIXn/AbstractInitiator.cs
@@ -108,6 +108,17 @@ namespace QuickFix
                 session.Logon();
         }
 
+        public void Dispose()
+        {
+            lock (sync_)
+            {
+                foreach (SessionID sessionID in disconnected_)
+                {
+                    Session.LookupSession(sessionID).Dispose();
+                }
+            }
+        }
+
         public bool IsLoggedOn()
         {
             lock (sync_)

--- a/QuickFIXn/IInitiator.cs
+++ b/QuickFIXn/IInitiator.cs
@@ -10,7 +10,7 @@ namespace QuickFix
     /// Establishes sessions with FIX servers and manages the associated sessions.
     /// The class AbstractInitiator contains a default base implementation.
     /// </summary>
-    public interface IInitiator
+    public interface IInitiator : IDisposable
     {
         bool IsStopped { get; }
 

--- a/QuickFIXn/Log.cs
+++ b/QuickFIXn/Log.cs
@@ -4,7 +4,7 @@ namespace QuickFix
     /// <summary>
     /// Session log for messages and events
     /// </summary>
-    public interface Log
+    public interface Log : System.IDisposable
     {
         /// <summary>
         /// Clears the log and removes any persistent log data

--- a/QuickFIXn/MemoryStore.cs
+++ b/QuickFIXn/MemoryStore.cs
@@ -71,6 +71,10 @@ namespace QuickFix
         public void Refresh()
         { }
 
+        public void Dispose() {
+        }
+
         #endregion
+
     }
 }

--- a/QuickFIXn/MessageStore.cs
+++ b/QuickFIXn/MessageStore.cs
@@ -5,7 +5,7 @@ namespace QuickFix
     /// <summary>
     /// Used by a Session to store and retrieve messages for resend purposes
     /// </summary>
-    public interface MessageStore
+    public interface MessageStore : System.IDisposable
     {
         /// <summary>
         /// Get messages within sequence number range (inclusive). Used for

--- a/QuickFIXn/NullLog.cs
+++ b/QuickFIXn/NullLog.cs
@@ -20,6 +20,9 @@ namespace QuickFix
         public void OnEvent(string s)
         { }
 
+        public void Dispose()
+        { }
+
         #endregion
     }
 }

--- a/QuickFIXn/ScreenLog.cs
+++ b/QuickFIXn/ScreenLog.cs
@@ -58,6 +58,9 @@ namespace QuickFix
             }
         }
 
+        public void Dispose()
+        { }
+
         #endregion
     }
 }

--- a/QuickFIXn/Session.cs
+++ b/QuickFIXn/Session.cs
@@ -12,7 +12,7 @@ namespace QuickFix
     /// of 1 and ending when the session is reset. The Session could span many sequential
     /// connections (it cannot operate on multiple connections simultaneously).
     /// </summary>
-    public partial class Session
+    public partial class Session : IDisposable
     {
         #region Private Members
 
@@ -1463,6 +1463,10 @@ namespace QuickFix
                     Persist(message, messageString);
                 return Send(messageString);
             }
+        }
+
+        public void Dispose() {
+            if (state_ != null) { state_.Dispose(); }
         }
     }
 }

--- a/QuickFIXn/SessionState.cs
+++ b/QuickFIXn/SessionState.cs
@@ -392,6 +392,12 @@ namespace QuickFix
             lock (sync_) { this.MessageStore.Refresh(); }
         }
 
+        public void Dispose() {
+            if (log_         != null) { log_        .Dispose(); }
+            if (MessageStore != null) { MessageStore.Dispose(); }
+        }
+
         #endregion
+
     }
 }


### PR DESCRIPTION
Several classes within quickfixn maintain open handles to files once
they are instantiated and initialized. These handles prevent other code
from accessing the same files until those instances are properly
disposed.

In our case, we attempted to Stop() the initiator which was using file
logs and stores. If we then attempted to instantiate and initialize a
new instance in the same process, it would throw an exception attempting
to open those same files for writing.

Now, we can call dispose on the properly disconnected set of connections
(is this the right set?) which disposes of all logs and stores and any
file handles they may or may not have open.

I believe this should likely be included in the normal "Stop"
functionality.
