### PR TITLE
Automatic FileLog rolling.

### DIFF
--- a/AcceptanceTest/ATRunner.cs
+++ b/AcceptanceTest/ATRunner.cs
@@ -15,7 +15,7 @@ namespace AcceptanceTest
                 System.Environment.Exit(2);
             }
 
-            FileLog debugLog = new FileLog("log", new SessionID("AT", "Application", "Debug")); 
+            FileLog debugLog = new FileLog("log", new SessionID("AT", "Application", "Debug"),false,0); 
             ThreadedSocketAcceptor acceptor = null;
             try
             {

--- a/QuickFIXn/ClientHandlerThread.cs
+++ b/QuickFIXn/ClientHandlerThread.cs
@@ -40,7 +40,7 @@ namespace QuickFix
                 debugLogFilePath = settingsDict.GetString(SessionSettings.FILE_LOG_PATH);
 
             // FIXME - do something more flexible than hardcoding a filelog
-            log_ = new FileLog(debugLogFilePath, new SessionID("ClientHandlerThread", clientId.ToString(), "Debug"));
+            log_ = new FileLog(debugLogFilePath, new SessionID("ClientHandlerThread", clientId.ToString(), "Debug"),false,0);
 
             tcpClient_ = tcpClient;
             id_ = clientId;

--- a/QuickFIXn/FileLog.cs
+++ b/QuickFIXn/FileLog.cs
@@ -15,18 +15,23 @@ namespace QuickFix
         private string messageLogFileName_;
         private string eventLogFileName_;
 
-        public FileLog(string fileLogPath, bool DoRotateLog, int NumDaysToKeep)
+        [System.Obsolete("Use FileLog constructor with log rotation options instead")]
+        public FileLog(string fileLogPath)
         {
-            Init(fileLogPath, "GLOBAL", DoRotateLog, NumDaysToKeep);
+            Init(fileLogPath, "GLOBAL", false, -1);
         }
 
-        public FileLog(string fileLogPath, SessionID sessionID, bool DoRotateLog, int NumDaysToKeep)
+        public FileLog(string fileLogPath, bool DoRotateLog, int RotateLogNumToKeep)
         {
-            Init(fileLogPath, Prefix(sessionID), DoRotateLog, NumDaysToKeep);
+            Init(fileLogPath, "GLOBAL", DoRotateLog, RotateLogNumToKeep);
         }
 
+        public FileLog(string fileLogPath, SessionID sessionID, bool DoRotateLog, int RotateLogNumToKeep)
+        {
+            Init(fileLogPath, Prefix(sessionID), DoRotateLog, RotateLogNumToKeep);
+        }
 
-        private void Init(string fileLogPath, string prefix, bool DoRotateLog, int NumDaysToKeep)
+        private void Init(string fileLogPath, string prefix, bool DoRotateLog, int RotateLogNumToKeep)
         {
             if (!System.IO.Directory.Exists(fileLogPath))
                 System.IO.Directory.CreateDirectory(fileLogPath);
@@ -35,7 +40,7 @@ namespace QuickFix
             eventLogFileName_ = System.IO.Path.Combine(fileLogPath, prefix + ".event.current.log");
 
             if (DoRotateLog)
-                RotateLog(new string[] { messageLogFileName_, eventLogFileName_ }, NumDaysToKeep);
+                RotateLog(new string[] { messageLogFileName_, eventLogFileName_ }, RotateLogNumToKeep);
 
             messageLog_ = new System.IO.StreamWriter(messageLogFileName_,true);
             eventLog_ = new System.IO.StreamWriter(eventLogFileName_,true);
@@ -50,9 +55,9 @@ namespace QuickFix
         /// Doesn't use filesystem creationtime due to file tunneling.
         /// </summary>
         /// <param name="LogFileNames"></param>
-        /// <param name="NumDaysToKeep"></param>
+        /// <param name="RotateLogNumToKeep"></param>
         /// <returns></returns>
-        private static string RotateLog(string[] LogFileNames, int NumDaysToKeep)
+        private static string RotateLog(string[] LogFileNames, int RotateLogNumToKeep)
         {
             try
             {
@@ -65,14 +70,14 @@ namespace QuickFix
                     System.IO.FileInfo fiLog = new System.IO.FileInfo(fn);
                     List<System.IO.FileInfo> oldLogs = new List<System.IO.FileInfo>();
 
-                    if (NumDaysToKeep < 0) NumDaysToKeep = 0;
+                    if (RotateLogNumToKeep < 0) RotateLogNumToKeep = 0;
 
                     foreach (string f in System.IO.Directory.GetFiles(fiLog.DirectoryName, fiLog.Name + ".*", System.IO.SearchOption.TopDirectoryOnly))
                         oldLogs.Add(new System.IO.FileInfo(System.IO.Path.Combine(fiLog.DirectoryName, f)));
 
                     oldLogs.Sort((a, b) => a.LastWriteTimeUtc.CompareTo(b.LastWriteTimeUtc));
 
-                    for (int i = 0; ((oldLogs.Count > NumDaysToKeep) && (i <= (oldLogs.Count - NumDaysToKeep) - 1)); i++)
+                    for (int i = 0; ((oldLogs.Count > RotateLogNumToKeep) && (i <= (oldLogs.Count - RotateLogNumToKeep) - 1)); i++)
                         oldLogs[i].Delete();
 
                 }

--- a/QuickFIXn/FileLogFactory.cs
+++ b/QuickFIXn/FileLogFactory.cs
@@ -24,17 +24,17 @@ namespace QuickFix
         {
             Dictionary sessionSettings = settings_.Get(sessionID);
             bool RotateLog = false; //default if undefined
-            int NumDaysToKeep = 1; //default if undefined
+            int RotateLogNumToKeep = 1; //default if undefined
 
             if (sessionSettings.Has(SessionSettings.FILE_LOG_ROTATE_ON_NEW_SESSION))
                 RotateLog = sessionSettings.GetBool(SessionSettings.FILE_LOG_ROTATE_ON_NEW_SESSION);
 
             if (sessionSettings.Has(SessionSettings.FILE_LOG_ROTATE_NUM_TO_KEEP))
-                NumDaysToKeep = sessionSettings.GetInt(SessionSettings.FILE_LOG_ROTATE_NUM_TO_KEEP);
+                RotateLogNumToKeep = sessionSettings.GetInt(SessionSettings.FILE_LOG_ROTATE_NUM_TO_KEEP);
 
 
 
-            return new FileLog(sessionSettings.GetString(SessionSettings.FILE_LOG_PATH), sessionID, RotateLog, NumDaysToKeep);
+            return new FileLog(sessionSettings.GetString(SessionSettings.FILE_LOG_PATH), sessionID, RotateLog, RotateLogNumToKeep);
         }
 
         #endregion

--- a/QuickFIXn/FileLogFactory.cs
+++ b/QuickFIXn/FileLogFactory.cs
@@ -22,7 +22,19 @@ namespace QuickFix
         /// <returns></returns>
         public Log Create(SessionID sessionID)
         {
-            return new FileLog(settings_.Get(sessionID).GetString(SessionSettings.FILE_LOG_PATH), sessionID);
+            Dictionary sessionSettings = settings_.Get(sessionID);
+            bool RotateLog = false; //default if undefined
+            int NumDaysToKeep = 1; //default if undefined
+
+            if (sessionSettings.Has(SessionSettings.FILE_LOG_ROTATE_ON_NEW_SESSION))
+                RotateLog = sessionSettings.GetBool(SessionSettings.FILE_LOG_ROTATE_ON_NEW_SESSION);
+
+            if (sessionSettings.Has(SessionSettings.FILE_LOG_ROTATE_NUM_TO_KEEP))
+                NumDaysToKeep = sessionSettings.GetInt(SessionSettings.FILE_LOG_ROTATE_NUM_TO_KEEP);
+
+
+
+            return new FileLog(sessionSettings.GetString(SessionSettings.FILE_LOG_PATH), sessionID, RotateLog, NumDaysToKeep);
         }
 
         #endregion

--- a/QuickFIXn/SessionSettings.cs
+++ b/QuickFIXn/SessionSettings.cs
@@ -58,6 +58,8 @@ namespace QuickFix
         public const string SEND_LOGOUT_BEFORE_TIMEOUT_DISCONNECT = "SendLogoutBeforeDisconnectFromTimeout";
         public const string SOCKET_NODELAY = "SocketNodelay";
         public const string IGNORE_POSSDUP_RESEND_REQUESTS = "IgnorePossDupResendRequests";
+        public const string FILE_LOG_ROTATE_ON_NEW_SESSION = "FileLogRotateOnNewSession";
+        public const string FILE_LOG_ROTATE_NUM_TO_KEEP = "FileLogRotateNumToKeep";
 
         #endregion
 

--- a/tutorial/configuration.md
+++ b/tutorial/configuration.md
@@ -566,10 +566,25 @@ QuickFIX Settings
 
   <tr>
     <td class='setting'>DebugFileLogPath</td>
-    <td class='description'>Directory to store ThreadedClientAcceptor thread logs.
+    <td class='description'>Directory to store ThreadedClientAcceptor thread logs.</td>
     <td class='valid'>Valid directory for storing files, must have write access</td>
     <td class='default'>Value of <tt>FileLogPath</tt> if present, else "log".</td>
   </tr>
+
+  <tr>
+    <td class='setting'>FileLogRotateOnNewSession</td>
+    <td class='description'>When set to 'Y', rotates the FileLog from a previous session for archiving at the start of each session.</td>
+    <td class='valid'>'Y' or 'N' (without quotes).</td>
+    <td class='default'>If not specified, defaults to 'N'.</td>
+  </tr>
+
+  <tr>
+    <td class='setting'>FileLogRotateNumToKeep</td>
+    <td class='description'>Number of archived logs to keep before deleting. Requires that FileLogRotateOnNewSession be set to 'Y'.</td>
+    <td class='valid'>An Integer. Example: '1' (without quotes).</td>
+    <td class='default'>If not specified, defaults to '1'.</td>
+  </tr>
+
 </table>
 
 


### PR DESCRIPTION
Implemented Automatic log rotation for FileLog. This was brought up in the mailing list on Oct 4 2012 and here it is. Unit tests passed, I updated the doc (tutorial/configuration.md), and also the AccpetanceTest stuff. Let me know if anything else is needed. We've been using this feature now for a few days in prod and it appears to be working well.
