### PR TITLE
TimeZone problem and Daylight Saving Time

### DIFF
--- a/QuickFIXn/SessionSchedule.cs
+++ b/QuickFIXn/SessionSchedule.cs
@@ -59,7 +59,12 @@ namespace QuickFix
             else if (adjusted.TimeOfDay < EndTime)
                 daysBack = 1;
 
-            return (adjusted.Date + new TimeSpan(-daysBack, 0, 0, 0) + EndTime).ToUniversalTime();
+            adjusted = adjusted.Date + new TimeSpan(-daysBack, 0, 0, 0) + EndTime;
+            return UseLocalTime
+                ? adjusted.ToUniversalTime() 
+                : TimeZone == null 
+                    ? adjusted 
+                    : TimeZoneInfo.ConvertTimeToUtc(adjusted, TimeZone);
         }
 
         private bool CheckDay(System.DateTime time)

--- a/UnitTests/SessionScheduleTests.cs
+++ b/UnitTests/SessionScheduleTests.cs
@@ -355,11 +355,16 @@ namespace UnitTests
             Assert.AreEqual(thisDayEnd, sched.LastEndTime(new DateTime(2012, 10, 18, 17, 00, 00, DateTimeKind.Utc)));
 
             // ==========
+            // Timezone specific
+            string timezoneid = "Eastern Standard Time";
+            TimeZoneInfo timezone = System.TimeZoneInfo.FindSystemTimeZoneById(timezoneid);
+            DateTime starttime = TimeZoneInfo.ConvertTimeFromUtc(new DateTime(2012, 10, 18, 9, 30, 00, DateTimeKind.Utc), timezone);
+            DateTime endtime = TimeZoneInfo.ConvertTimeFromUtc(new DateTime(2012, 10, 18, 16, 00, 00, DateTimeKind.Utc), timezone);
             // Settings file is specified in a zone (est, -5)
             settings = new QuickFix.Dictionary();
-            settings.SetString(QuickFix.SessionSettings.START_TIME, "04:30:00"); // 09:30:00 utc
-            settings.SetString(QuickFix.SessionSettings.END_TIME, "11:00:00");   // 16:00:00 utc
-            settings.SetString(QuickFix.SessionSettings.TIME_ZONE, "Eastern Standard Time"); //-5
+            settings.SetString(QuickFix.SessionSettings.START_TIME, starttime.ToString("hh:mm:ss"));
+            settings.SetString(QuickFix.SessionSettings.END_TIME, endtime.ToString( "hh:mm:ss"));
+            settings.SetString(QuickFix.SessionSettings.TIME_ZONE, timezoneid);
             sched = new QuickFix.SessionSchedule(settings);
 
             // before starttime
@@ -395,11 +400,17 @@ namespace UnitTests
             Assert.AreEqual(thisWeekEnd, sched.LastEndTime(new DateTime(2012, 10, 19, 17, 00, 00, DateTimeKind.Utc)));
 
             // ==========
+            // Timezone specific
+            string timezoneid = "Eastern Standard Time";
+            TimeZoneInfo timezone = System.TimeZoneInfo.FindSystemTimeZoneById(timezoneid);
+            DateTime starttime = TimeZoneInfo.ConvertTimeFromUtc(new DateTime(2012, 10, 18, 9, 30, 00, DateTimeKind.Utc), timezone);
+            DateTime endtime = TimeZoneInfo.ConvertTimeFromUtc(new DateTime(2012, 10, 18, 16, 00, 00, DateTimeKind.Utc), timezone);
+
             // Settings file is specified in a zone (est, -5)
             settings = new QuickFix.Dictionary();
-            settings.SetString(QuickFix.SessionSettings.START_TIME, "04:30:00"); // 09:30:00 utc
-            settings.SetString(QuickFix.SessionSettings.END_TIME, "11:00:00");   // 16:00:00 utc
-            settings.SetString(QuickFix.SessionSettings.TIME_ZONE, "Eastern Standard Time"); //-5
+            settings.SetString(QuickFix.SessionSettings.START_TIME, starttime.ToString("hh:mm:ss"));
+            settings.SetString(QuickFix.SessionSettings.END_TIME, endtime.ToString("hh:mm:ss"));
+            settings.SetString(QuickFix.SessionSettings.TIME_ZONE, timezoneid); //-5
             settings.SetDay(QuickFix.SessionSettings.START_DAY, System.DayOfWeek.Monday);
             settings.SetDay(QuickFix.SessionSettings.END_DAY, System.DayOfWeek.Friday);
             sched = new QuickFix.SessionSchedule(settings);


### PR DESCRIPTION
We have another problem with TimeZone setting. 2 test fail on my local.
Tests run: 201, Errors: 0, Failures: 2, Inconclusive: 0, Time: 9,7275564 seconds

  Not run: 0, Invalid: 0, Ignored: 0, Skipped: 0

Errors and Failures:
1) Test Failure : UnitTests.SessionScheduleTests.testLastEndTime_DailySessions
     Expected: 2012-10-17 16:00:00.000
  But was:  2012-10-17 09:00:00.000
at UnitTests.SessionScheduleTests.testLastEndTime_DailySessions() in \SessionScheduleTests.cs:line 368

2) Test Failure : UnitTests.SessionScheduleTests.testLastEndTime_WeeklySessions
     Expected: 2012-10-12 16:00:00.000
  But was:  2012-10-12 09:00:00.000
at UnitTests.SessionScheduleTests.testLastEndTime_WeeklySessions() in \SessionScheduleTests.cs:line 410

My local is set on (UTC+01:00) Belgrade, Bratislava, Budapest, Ljubljana, Prague

This PR have fix for that problem
- SessionSchedule.LastEndTime: When TimeZone is specified in setting, result must be converted from that TimeZone to UTC before return
- SessionScheduleTests.testLastEndTime_DailySessions; testLastEndTime_WeeklySessions: Test for TimeZone setting must respect also Daylight Saving Time.
