### PR TITLE
Added the ability to load datadictionary files via a stream

### DIFF
--- a/QuickFIXn/DataDictionary/DataDictionary.cs
+++ b/QuickFIXn/DataDictionary/DataDictionary.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Xml;
 using System.Xml.XPath;
 
@@ -41,6 +42,15 @@ namespace QuickFix.DataDictionary
 		{
 			Load(path);
 		}
+
+        /// <summary>
+        /// Initialize a data dictionary from a stream
+        /// </summary>
+        /// <param name="stream"></param>
+        public DataDictionary(Stream stream)
+        {
+            Load(stream);
+        }
 
 		/// <summary>
 		/// Copy a data dictionary
@@ -406,10 +416,17 @@ namespace QuickFix.DataDictionary
 			return Trailer.IsField(tag);
 		}
 
-		public void Load(String path) {
+		public void Load(String path)
+		{
+			var stream = new FileStream(path, FileMode.Open, FileAccess.Read);
+			Load(stream);
+		}
+
+		public void Load(Stream stream)
+		{
 			XmlDocument doc = new XmlDocument();
 			RootDoc = doc;
-			doc.Load(path);
+			doc.Load(stream);
 			setVersionInfo(doc);
 			parseFields(doc);
 			parseMessages(doc);

--- a/UnitTests/DataDictionaryTests.cs
+++ b/UnitTests/DataDictionaryTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using NUnit.Framework;
 using QuickFix;
 
@@ -30,6 +31,18 @@ namespace UnitTests
             Assert.That(dd.FieldsByTag[1].EnumDict.Count, Is.EqualTo(0));
             Assert.That(dd.FieldsByTag[QuickFix.Fields.Tags.StatusValue].EnumDict.Count, Is.EqualTo(4));
         }
+
+		[Test]
+		public void LoadFieldsFromStreamTest()
+		{
+			QuickFix.DataDictionary.DataDictionary dd = new QuickFix.DataDictionary.DataDictionary();
+			Stream stream = new FileStream("../../../spec/fix/FIX44.xml", FileMode.Open, FileAccess.Read);
+			dd.Load(stream);
+			Assert.That(dd.FieldsByTag[1].Name, Is.EqualTo("Account"));
+			Assert.That(dd.FieldsByName["Account"].Tag, Is.EqualTo(1));
+			Assert.That(dd.FieldsByTag[1].EnumDict.Count, Is.EqualTo(0));
+			Assert.That(dd.FieldsByTag[QuickFix.Fields.Tags.StatusValue].EnumDict.Count, Is.EqualTo(4));
+		}
 
         [Test]
         public void FieldHasValueTest()


### PR DESCRIPTION
We needed to load the datadictionary files from an embedded resource, so I added the ability to load them from a stream. I also added the appropriate until test.
