### PR TITLE
A fix for deadlock when sending and receiving large amount of FIX messages simultaneously.

### DIFF
--- a/Examples/FIXClient/App.config
+++ b/Examples/FIXClient/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+    </startup>
+</configuration>

--- a/Examples/FIXClient/Client.cs
+++ b/Examples/FIXClient/Client.cs
@@ -1,0 +1,255 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickFix;
+using QuickFix.Fields;
+
+namespace FIXClient {
+    class Client : MessageCracker, IApplication {
+
+        private Session m_Session;   // The client FIX session.
+
+        private double m_AvgLatency = 0;
+
+        private double m_MaxLatency = 0;
+
+        private Stopwatch m_Stopwatch;
+
+        private Stopwatch m_MessageStopwatch;
+
+        private int m_NumMsgReceived = 0;
+
+        private Thread m_Thread;
+
+        public Client() {
+            m_Thread = new Thread(new ThreadStart(() => {
+                while (true) {
+                    
+                    Thread.Sleep(1000);
+
+                    Console.WriteLine("Ms per message: " + ((double)m_MessageStopwatch.ElapsedMilliseconds / (double)m_NumMsgReceived));
+                } 
+            }));
+        }
+
+        int m_NumOfExeReportsReceived = 0;
+        HashSet<string> m_OpenOrderIds = new HashSet<string>();
+
+        // This variable is a kludge for developer test purposes.  Don't do this on a production application.
+        public IInitiator MyInitiator = null;
+
+        public void OnCreate(SessionID sessionID) { // This method is called whenever a new session is created.
+            m_Session = Session.LookupSession(sessionID);
+        }
+
+        public void OnLogon(SessionID sessionID) {
+            Console.WriteLine("Logon - " + sessionID.ToString());
+        }
+
+        public void OnLogout(SessionID sessionID) {
+            Console.WriteLine("Logout - " + sessionID.ToString());
+        }
+
+        public void FromAdmin(Message message, SessionID sessionID) {
+        }
+
+        public void ToAdmin(Message message, SessionID sessionID) {
+        }
+
+        public void FromApp(Message message, SessionID sessionID) {
+            OnMessage(message, sessionID);
+            string msgType = message.Header.GetString(Tags.MsgType);
+            switch (msgType) {
+                case "8":
+                    OnExecutionReport((QuickFix.FIX42.ExecutionReport)message);
+                    break;
+            }
+        }
+
+        private void OnExecutionReport(QuickFix.FIX42.ExecutionReport executionReport) {
+            lock (m_OpenOrderIds) {
+                m_NumOfExeReportsReceived++;
+                bool flag = m_OpenOrderIds.Remove(executionReport.OrderID.getValue());
+                if (!flag) {
+                    Console.WriteLine("Unexpecpted OrderID. Something must be wrong.");
+                }
+                if (m_OpenOrderIds.Count == 0) {
+                    m_Stopwatch.Stop();
+                    Console.WriteLine("\nTotal Time in ms: " + m_Stopwatch.ElapsedMilliseconds);
+                    Console.WriteLine("Average Time in ms: " + (double)m_Stopwatch.ElapsedMilliseconds / (double)m_NumOfExeReportsReceived);
+                    Console.WriteLine("Execution report received: " + m_NumOfExeReportsReceived);
+                    m_OpenOrderIds.Clear();
+                    m_NumOfExeReportsReceived = 0;
+                }
+            }
+        }
+
+        public void ToApp(Message message, SessionID sessionID) {
+            try {
+                bool possDupFlag = false;
+                if (message.Header.IsSetField(QuickFix.Fields.Tags.PossDupFlag)) {
+                    possDupFlag = QuickFix.Fields.Converters.BoolConverter.Convert(
+                        message.Header.GetField(QuickFix.Fields.Tags.PossDupFlag)); /// FIXME
+                }
+                if (possDupFlag)
+                    throw new DoNotSend();
+            } catch (FieldNotFoundException) { }
+        }
+
+        public void OnMessage(Message msg, SessionID s) {
+            m_NumMsgReceived++;
+        }
+
+        public void Run() {
+            while (true) {
+                try {
+                    char action = QueryAction();
+                    if (action == '1') {
+                        QueryEnterOrder();
+                    }  else if (action == '2') {
+                        QueryMarketDataRequest();
+                    } else if (action == 'q' || action == 'Q')
+                        break;
+                } catch (System.Exception e) {
+                    Console.WriteLine("Message Not Sent: " + e.Message);
+                    Console.WriteLine("StackTrace: " + e.StackTrace);
+                }
+            }
+            Console.WriteLine("Program shutdown.");
+        }
+
+        private char QueryAction() {
+            // Commands 'g' and 'x' are intentionally hidden.
+            Console.Write("\n"
+                + "1) Benchmark Order Latency\n"
+                + "2) Market data test\n"
+                + "Q) Quit\n"
+                + "Action: "
+            );
+
+            HashSet<string> validActions = new HashSet<string>("1,2,,4,q,Q".Split(','));
+
+            string cmd = Console.ReadLine().Trim();
+            if (cmd.Length != 1 || validActions.Contains(cmd) == false)
+                throw new System.Exception("Invalid action");
+
+            return cmd.ToCharArray()[0];
+        }
+
+        private void QueryLatency() {
+            Console.WriteLine(string.Format("The number of received msg: {0}", m_NumMsgReceived));
+            Console.WriteLine(string.Format("Max latency in milliseconds: {0}", m_MaxLatency));
+            Console.WriteLine(string.Format("Average latency in milliseconds: {0}", m_AvgLatency));
+            Console.WriteLine();
+        }
+
+        private void SendMessage(Message m) {
+            if (m_Session != null) {
+                m_Session.Send(m);
+            } else {
+                // This probably won't ever happen.
+                Console.WriteLine("Can't send message: session not created.");
+            }
+        }
+
+
+        private int QueryNumOfOrders() {
+            int numOfOrders = 0;
+            Console.Write("Num of Orders: ");
+            string str = Console.ReadLine().Trim();
+            int.TryParse(str, out numOfOrders);
+            return numOfOrders;
+        }
+
+        private void QueryEnterOrder() {
+            int numOfOrders = QueryNumOfOrders();
+            Console.WriteLine("\nIssuing " + numOfOrders + " orders.");
+            Queue<QuickFix.FIX42.NewOrderSingle> orders = CreateOrders(numOfOrders);
+
+            m_OpenOrderIds.Clear();
+            m_NumOfExeReportsReceived = 0;
+            m_Stopwatch = Stopwatch.StartNew();
+            int numOrdersSent = 0;
+            while (orders.Count > 0) {
+                QuickFix.FIX42.NewOrderSingle order = orders.Dequeue();
+                ++numOrdersSent;
+                lock (m_OpenOrderIds)
+                    m_OpenOrderIds.Add(order.ClOrdID.getValue());
+                SendMessage(order);
+
+                if (numOrdersSent % 1000 == 0) {
+                    Console.WriteLine("Order sent: " + numOrdersSent);
+                }
+            }
+        }
+
+        private Queue<QuickFix.FIX42.NewOrderSingle> CreateOrders(int n) {
+            Queue<QuickFix.FIX42.NewOrderSingle> orders = new Queue<QuickFix.FIX42.NewOrderSingle>(n);
+            for (int i = 0; i < n; i++) { 
+                ClOrdID cloudOrderId = new ClOrdID(Guid.NewGuid().ToString());
+                HandlInst handlInst = new HandlInst(HandlInst.AUTOMATED_EXECUTION_ORDER_PRIVATE_NO_BROKER_INTERVENTION);
+                Symbol symbol = new Symbol("MSFT");
+                Side side = new Side(Side.BUY);
+                TransactTime time = new TransactTime();
+                OrdType orderType = new OrdType(OrdType.LIMIT);
+                QuickFix.FIX42.NewOrderSingle order = new QuickFix.FIX42.NewOrderSingle(cloudOrderId, handlInst, symbol, side, time, orderType);
+                order.Account = new Account("Account");
+                order.OrderQty = new OrderQty(100);
+                order.ExDestination = new ExDestination("*");
+                order.TimeInForce = new TimeInForce(TimeInForce.DAY);
+                order.Price = new Price(50m);
+                order.SecurityType = new SecurityType(SecurityType.COMMON_STOCK);
+                orders.Enqueue(order);
+            }
+            return orders;
+        }
+
+        private void QueryMarketDataRequest() {
+            Console.WriteLine("\nMarketDataRequest");
+
+            QuickFix.FIX42.MarketDataRequest m = QueryMarketDataRequest42(QueryProductName());
+
+            if (m != null) {
+                m_MessageStopwatch = Stopwatch.StartNew();
+                m_Thread.Start();
+                SendMessage(m);
+            }
+        }
+
+        private string QueryProductName() {
+            Console.Write("Product Name: ");
+            return Console.ReadLine().Trim();
+        } 
+
+        private bool QueryConfirm(string query) {
+            Console.WriteLine();
+            Console.WriteLine(query + "?: ");
+            string line = Console.ReadLine().Trim();
+            return (line[0].Equals('y') || line[0].Equals('Y'));
+        }
+
+        public QuickFix.FIX42.MarketDataRequest QueryMarketDataRequest42(string productName) {
+            MDReqID mdReqID = new MDReqID("MARKETDATAID");
+            SubscriptionRequestType subType = new SubscriptionRequestType(SubscriptionRequestType.SNAPSHOT_PLUS_UPDATES);
+            MarketDepth marketDepth = new MarketDepth(1);
+
+            QuickFix.FIX42.MarketDataRequest.NoMDEntryTypesGroup marketDataEntryGroup = new QuickFix.FIX42.MarketDataRequest.NoMDEntryTypesGroup();
+            marketDataEntryGroup.Set(new MDEntryType(MDEntryType.BID));
+
+            QuickFix.FIX42.MarketDataRequest.NoRelatedSymGroup symbolGroup = new QuickFix.FIX42.MarketDataRequest.NoRelatedSymGroup();
+            symbolGroup.Set(new Symbol(productName));
+            symbolGroup.Set(new SecurityExchange("*"));
+            symbolGroup.Set(new SecurityType(SecurityType.COMMON_STOCK));
+
+            QuickFix.FIX42.MarketDataRequest message = new QuickFix.FIX42.MarketDataRequest(mdReqID, subType, marketDepth);
+            message.AddGroup(marketDataEntryGroup);
+            message.AddGroup(symbolGroup);
+
+            return message;
+        }
+    }
+}

--- a/Examples/FIXClient/FIXClient.csproj
+++ b/Examples/FIXClient/FIXClient.csproj
@@ -1,0 +1,88 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{7479F3B9-E7AC-4FB4-B9AC-87A487FF0DC1}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>FIXClient</RootNamespace>
+    <AssemblyName>FIXClient</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>x64</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>obj\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>x64</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\..\Library\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>..\..\Library\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>..\..\Library\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Client.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="client.cfg">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\QuickFIXn\QuickFix.csproj">
+      <Project>{d67079da-6c49-48b2-93ab-1c3e879f5a0b}</Project>
+      <Name>QuickFix</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Examples/FIXClient/Program.cs
+++ b/Examples/FIXClient/Program.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using QuickFix;
+
+namespace FIXClient {
+    class Program {
+        static void Main(string[] args) {
+            string file = "client.cfg";
+
+            try {
+                QuickFix.SessionSettings settings = new QuickFix.SessionSettings(file);
+                Client application = new Client();
+                QuickFix.IMessageStoreFactory storeFactory = new QuickFix.FileStoreFactory(settings);
+                //QuickFix.ILogFactory logFactory = new QuickFix.ScreenLogFactory(settings);
+                QuickFix.Transport.SocketInitiator initiator = new QuickFix.Transport.SocketInitiator(application, storeFactory, settings);
+
+                // this is a developer-test kludge.  do not emulate.
+                application.MyInitiator = initiator;
+
+                initiator.Start();
+                application.Run();
+                initiator.Stop();
+            } catch (System.Exception e) {
+                Console.WriteLine(e.Message);
+                Console.WriteLine(e.StackTrace);
+            }
+            Environment.Exit(1);
+        }
+    }
+}

--- a/Examples/FIXClient/Properties/AssemblyInfo.cs
+++ b/Examples/FIXClient/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("FIXClient")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("FIXClient")]
+[assembly: AssemblyCopyright("Copyright ©  2014")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("9b3c4e8d-58e7-4be1-9cc9-2dfcd090aded")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Examples/FIXClient/client.cfg
+++ b/Examples/FIXClient/client.cfg
@@ -1,0 +1,22 @@
+[DEFAULT]
+ConnectionType=initiator
+ReconnectInterval=1000
+FileStorePath=store
+FileLogPath=log
+StartTime=00:00:00
+EndTime=00:00:00
+UseDataDictionary=Y
+DataDictionary=../../../../spec/fix/FIX42.xml
+SocketConnectHost=127.0.0.1
+SocketConnectPort=8022
+LogoutTimeout=5
+ResetOnLogon=Y
+ResetOnDisconnect=Y
+
+[SESSION]
+# inherit ConnectionType, ReconnectInterval and SenderCompID from default
+BeginString=FIX.4.2
+SenderCompID=Agents
+TargetCompID=MatchingEngine
+HeartBtInt=30 
+

--- a/Examples/FIXServer/App.config
+++ b/Examples/FIXServer/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+    </startup>
+</configuration>

--- a/Examples/FIXServer/FIXServer.csproj
+++ b/Examples/FIXServer/FIXServer.csproj
@@ -1,0 +1,88 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{D27A1441-F024-492A-8194-0ABEF2D74E66}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>FIXServer</RootNamespace>
+    <AssemblyName>FIXServer</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>x64</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>obj\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>x64</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\..\Library\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>..\..\Library\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>..\..\Library\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Server.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="server.cfg">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\QuickFIXn\QuickFix.csproj">
+      <Project>{d67079da-6c49-48b2-93ab-1c3e879f5a0b}</Project>
+      <Name>QuickFix</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Examples/FIXServer/Program.cs
+++ b/Examples/FIXServer/Program.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using QuickFix;
+
+namespace FIXServer {
+    class Program {
+        static void Main(string[] args) {
+            string file = "server.cfg";
+
+            SessionSettings settings = new SessionSettings(file);
+            IApplication executorApp = new Server();
+            IMessageStoreFactory storeFactory = new FileStoreFactory(settings);
+            ThreadedSocketAcceptor acceptor = new ThreadedSocketAcceptor(executorApp, storeFactory, settings);
+
+            acceptor.Start();
+            Console.WriteLine("press <enter> to quit");
+            Console.Read();
+            acceptor.Stop();
+        }
+    }
+}

--- a/Examples/FIXServer/Properties/AssemblyInfo.cs
+++ b/Examples/FIXServer/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("FIXServer")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("FIXServer")]
+[assembly: AssemblyCopyright("Copyright ©  2014")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("e6f5c014-3931-43ce-90ea-1b1341652b04")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Examples/FIXServer/Server.cs
+++ b/Examples/FIXServer/Server.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickFix;
+using QuickFix.Fields;
+
+namespace FIXServer {
+    class Server : QuickFix.MessageCracker, QuickFix.IApplication {
+
+        int orderID = 0;
+        int execID = 0;
+
+        Dictionary<string, QuotePublisher> m_ProductSubscription = new Dictionary<string, QuotePublisher>();
+
+        private string GenOrderID() { return (++orderID).ToString(); }
+        private string GenExecID() { return (++execID).ToString(); }
+
+        public void FromAdmin(Message message, SessionID sessionID) { }
+        public void OnCreate(SessionID sessionID) {
+        }
+        public void OnLogout(SessionID sessionID) {
+            Console.WriteLine(sessionID.ToString() + "logged out");
+            m_ProductSubscription.Clear();
+        }
+        public void OnLogon(SessionID sessionID) {
+            Console.WriteLine(sessionID.ToString() + "logged on");
+        }
+        public void ToAdmin(Message message, SessionID sessionID) { }
+
+        public void FromApp(Message message, SessionID sessionID) {
+            string msgType = message.Header.GetString(Tags.MsgType);
+            switch (msgType) { 
+                case "V":
+                    OnMessage(((QuickFix.FIX42.MarketDataRequest)message), sessionID);
+                    break;
+                case "D":
+                    OnMessage(((QuickFix.FIX42.NewOrderSingle)message), sessionID);
+                    break;
+            }
+        }
+
+        public void ToApp(Message message, SessionID sessionID) {
+            Trace.TraceInformation(message.ToString());
+        }
+
+        private void OnMessage(QuickFix.FIX42.NewOrderSingle n, SessionID s) {
+            QuickFix.FIX42.ExecutionReport executionReport = new QuickFix.FIX42.ExecutionReport(new OrderID(n.ClOrdID.getValue()), new ExecID(Guid.NewGuid().ToString()), new ExecTransType(ExecTransType.NEW), new ExecType(ExecType.NEW), new OrdStatus(OrdStatus.NEW), n.Symbol, n.Side, new LeavesQty(n.OrderQty.getValue()), new CumQty(0), new AvgPx());
+            Session.SendToTarget(executionReport, s);
+        }
+
+        private void OnMessage(QuickFix.FIX42.MarketDataRequest m, SessionID s) {
+            QuickFix.FIX42.MarketDataRequest.NoRelatedSymGroup symbolGroup = new QuickFix.FIX42.MarketDataRequest.NoRelatedSymGroup();
+            m.GetGroup(1, symbolGroup);
+            string symbolName = symbolGroup.Get(new Symbol()).getValue();
+            string mdRequestId = m.MDReqID.ToString();
+            if (!m_ProductSubscription.ContainsKey(symbolName)) {
+                bool fullSpeed = symbolName.StartsWith("B");
+                Console.WriteLine("Subscribe : " + symbolName + ". Full Speed: " + fullSpeed);
+                QuotePublisher publisher = new QuotePublisher(symbolName, mdRequestId, fullSpeed, s);
+                m_ProductSubscription.Add(symbolName, publisher);
+            }
+        }
+
+        private class QuotePublisher {
+
+            private bool m_Start = true;
+
+            private QuickFix.FIX42.MarketDataSnapshotFullRefresh m_Quote;
+
+            private void InitializeQuote(string symbolName, string marketDataRequestId) {
+                m_Quote = new QuickFix.FIX42.MarketDataSnapshotFullRefresh();
+                m_Quote.SetField(new MDReqID(marketDataRequestId));
+                m_Quote.SetField(new SecurityExchange("*"));
+                m_Quote.SetField(new TotalVolumeTraded(10000));
+                m_Quote.SetField(new Symbol(symbolName));
+                m_Quote.SetField(new NoMDEntries(3));
+
+                QuickFix.FIX42.MarketDataSnapshotFullRefresh.NoMDEntriesGroup group1 = new QuickFix.FIX42.MarketDataSnapshotFullRefresh.NoMDEntriesGroup();
+                group1.SetField(new MDEntryType(MDEntryType.BID));
+                group1.SetField(new MDEntryPx(50m));
+                group1.SetField(new MDEntrySize(100));
+                m_Quote.AddGroup(group1);
+
+                QuickFix.FIX42.MarketDataSnapshotFullRefresh.NoMDEntriesGroup group2 = new QuickFix.FIX42.MarketDataSnapshotFullRefresh.NoMDEntriesGroup();
+                group2.SetField(new MDEntryType(MDEntryType.OFFER));
+                group2.SetField(new MDEntryPx(50.01m));
+                group2.SetField(new MDEntrySize(100));
+                m_Quote.AddGroup(group2);
+
+                QuickFix.FIX42.MarketDataSnapshotFullRefresh.NoMDEntriesGroup trade = new QuickFix.FIX42.MarketDataSnapshotFullRefresh.NoMDEntriesGroup();
+                trade.SetField(new MDEntryType(MDEntryType.TRADE));
+                trade.SetField(new MDEntryPx(50.01m));
+                trade.SetField(new MDEntrySize(100));
+                m_Quote.AddGroup(trade);
+            }
+
+            public QuotePublisher(string symbolName, string marketDataRequestId, bool fullSpeed, SessionID s) {
+                InitializeQuote(symbolName, marketDataRequestId);
+                Thread thread = new Thread(new ThreadStart(() => {
+                    while (m_Start) {
+                        Session.SendToTarget(m_Quote, s);
+                        if (!fullSpeed) {
+                            Thread.Sleep(100);
+                        }
+                    }
+                }));
+                thread.IsBackground = true;
+                thread.Start();
+            }
+
+            public void Stop() {
+                m_Start = false;
+            }
+        }
+    }
+}

--- a/Examples/FIXServer/server.cfg
+++ b/Examples/FIXServer/server.cfg
@@ -1,0 +1,17 @@
+[DEFAULT]
+ConnectionType=acceptor
+SocketAcceptPort=8022
+StartTime=00:00:00
+EndTime=00:00:00
+FileLogPath=log
+UseDataDictionary=Y
+ResetOnLogon=Y
+ResetOnLogout=Y
+ResetOnDisconnect=Y
+
+[SESSION]
+BeginString=FIX.4.2
+SenderCompID=MatchingEngine
+TargetCompID=Agents
+FileStorePath=store
+DataDictionary=../../../../spec/fix/FIX42.xml

--- a/QuickFIXn.sln
+++ b/QuickFIXn.sln
@@ -1,6 +1,6 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QuickFix", "QuickFIXn\QuickFix.csproj", "{D67079DA-6C49-48B2-93AB-1C3E879F5A0B}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnitTests", "UnitTests\UnitTests.csproj", "{186A72D8-5A70-4DD0-BABF-E3BB3BA9F419}"
@@ -16,36 +16,70 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Examples.Executor", "Exampl
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Examples.SimpleAcceptor", "Examples\SimpleAcceptor\Examples.SimpleAcceptor.csproj", "{59FC3768-2D8E-4CD2-88B8-C3972BA3ACA8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FIXClient", "Examples\FIXClient\FIXClient.csproj", "{7479F3B9-E7AC-4FB4-B9AC-87A487FF0DC1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FIXServer", "Examples\FIXServer\FIXServer.csproj", "{D27A1441-F024-492A-8194-0ABEF2D74E66}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{D67079DA-6C49-48B2-93AB-1C3E879F5A0B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D67079DA-6C49-48B2-93AB-1C3E879F5A0B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D67079DA-6C49-48B2-93AB-1C3E879F5A0B}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{D67079DA-6C49-48B2-93AB-1C3E879F5A0B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D67079DA-6C49-48B2-93AB-1C3E879F5A0B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D67079DA-6C49-48B2-93AB-1C3E879F5A0B}.Release|x64.ActiveCfg = Release|Any CPU
 		{186A72D8-5A70-4DD0-BABF-E3BB3BA9F419}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{186A72D8-5A70-4DD0-BABF-E3BB3BA9F419}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{186A72D8-5A70-4DD0-BABF-E3BB3BA9F419}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{186A72D8-5A70-4DD0-BABF-E3BB3BA9F419}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{186A72D8-5A70-4DD0-BABF-E3BB3BA9F419}.Release|Any CPU.Build.0 = Release|Any CPU
+		{186A72D8-5A70-4DD0-BABF-E3BB3BA9F419}.Release|x64.ActiveCfg = Release|Any CPU
 		{B02EAF78-6335-4996-BB98-3121A4B6B0B2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B02EAF78-6335-4996-BB98-3121A4B6B0B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B02EAF78-6335-4996-BB98-3121A4B6B0B2}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{B02EAF78-6335-4996-BB98-3121A4B6B0B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B02EAF78-6335-4996-BB98-3121A4B6B0B2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B02EAF78-6335-4996-BB98-3121A4B6B0B2}.Release|x64.ActiveCfg = Release|Any CPU
 		{592C4909-1D3E-41C9-B6F9-505C770533A2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{592C4909-1D3E-41C9-B6F9-505C770533A2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{592C4909-1D3E-41C9-B6F9-505C770533A2}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{592C4909-1D3E-41C9-B6F9-505C770533A2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{592C4909-1D3E-41C9-B6F9-505C770533A2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{592C4909-1D3E-41C9-B6F9-505C770533A2}.Release|x64.ActiveCfg = Release|Any CPU
 		{ADF1BD8E-6149-4D77-89E0-B2B775248139}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{ADF1BD8E-6149-4D77-89E0-B2B775248139}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ADF1BD8E-6149-4D77-89E0-B2B775248139}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{ADF1BD8E-6149-4D77-89E0-B2B775248139}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{ADF1BD8E-6149-4D77-89E0-B2B775248139}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ADF1BD8E-6149-4D77-89E0-B2B775248139}.Release|x64.ActiveCfg = Release|Any CPU
 		{59FC3768-2D8E-4CD2-88B8-C3972BA3ACA8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{59FC3768-2D8E-4CD2-88B8-C3972BA3ACA8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{59FC3768-2D8E-4CD2-88B8-C3972BA3ACA8}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{59FC3768-2D8E-4CD2-88B8-C3972BA3ACA8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{59FC3768-2D8E-4CD2-88B8-C3972BA3ACA8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{59FC3768-2D8E-4CD2-88B8-C3972BA3ACA8}.Release|x64.ActiveCfg = Release|Any CPU
+		{7479F3B9-E7AC-4FB4-B9AC-87A487FF0DC1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7479F3B9-E7AC-4FB4-B9AC-87A487FF0DC1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7479F3B9-E7AC-4FB4-B9AC-87A487FF0DC1}.Debug|x64.ActiveCfg = Debug|x64
+		{7479F3B9-E7AC-4FB4-B9AC-87A487FF0DC1}.Debug|x64.Build.0 = Debug|x64
+		{7479F3B9-E7AC-4FB4-B9AC-87A487FF0DC1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7479F3B9-E7AC-4FB4-B9AC-87A487FF0DC1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7479F3B9-E7AC-4FB4-B9AC-87A487FF0DC1}.Release|x64.ActiveCfg = Release|x64
+		{7479F3B9-E7AC-4FB4-B9AC-87A487FF0DC1}.Release|x64.Build.0 = Release|x64
+		{D27A1441-F024-492A-8194-0ABEF2D74E66}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D27A1441-F024-492A-8194-0ABEF2D74E66}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D27A1441-F024-492A-8194-0ABEF2D74E66}.Debug|x64.ActiveCfg = Debug|x64
+		{D27A1441-F024-492A-8194-0ABEF2D74E66}.Debug|x64.Build.0 = Debug|x64
+		{D27A1441-F024-492A-8194-0ABEF2D74E66}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D27A1441-F024-492A-8194-0ABEF2D74E66}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D27A1441-F024-492A-8194-0ABEF2D74E66}.Release|x64.ActiveCfg = Release|x64
+		{D27A1441-F024-492A-8194-0ABEF2D74E66}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/QuickFIXn/Session.cs
+++ b/QuickFIXn/Session.cs
@@ -190,9 +190,9 @@ namespace QuickFix
         public DataDictionary.DataDictionary ApplicationDataDictionary { get; private set; }
 
         /// <summary>
-        /// Returns whether the Session has a Responder. This method is synchronized
+        /// Returns whether the Session has a Responder.
         /// </summary>
-        public bool HasResponder { get { lock (sync_) { return null != responder_; } } }
+        public bool HasResponder { get { return null != responder_; } }
 
         /// <summary>
         /// Returns whether the Sessions will allow ResetSequence messages sent as

--- a/UnitTests/SessionTest.cs
+++ b/UnitTests/SessionTest.cs
@@ -354,15 +354,15 @@ namespace UnitTests
             Assert.That(DISCONNECTED());
         }
 
-	[Test]
-	public void HeartBeatCheckAfterMessageProcess()
-	{
-	    Logon();
-	    Thread.Sleep(2000);
+	    [Test]
+	    public void HeartBeatCheckAfterMessageProcess()
+	    {
+	        Logon();
+	        Thread.Sleep(2000);
 
-            SendNOSMessage();
-            Assert.That(SENT_HEART_BEAT());
-	}
+                SendNOSMessage();
+                Assert.That(SENT_HEART_BEAT());
+	    }
 
         [Test]
         public void NextResendRequestNoMessagePersist()


### PR DESCRIPTION
We should remove the lock in the Session.HasResponder. This was an overlocking which was causing deadlock when sending and receiving larget amount FIX messages simultaneously.

A detailed description of the issue can be found here:
http://lists.quickfixn.com/pipermail/quickfixn-quickfixn.com/2012q2/000202.html

Removing the lock doesn't affect the current unit tests and acceptance tests.
This issue was hard to be reproduced through unit tests as it requires a TCP
connection between a server and a client. I have attched two additional projects to verify the correctness of the change.
Launch the FIXServer first and then FIXClient. Following the instructions to
issue 10,000 orders from the FIXClient, wihle sending the FIXServer will start
sending execution reports back.
