### PR TITLE
SessionState.Store (FileStore) is not threadsafe on .Set and .Get

### DIFF
--- a/QuickFIXn/SessionState.cs
+++ b/QuickFIXn/SessionState.cs
@@ -275,7 +275,10 @@ namespace QuickFix
 
         public void Get(int begSeqNo, int endSeqNo, List<string> messages)
         {
-            MessageStore.Get(begSeqNo, endSeqNo, messages);
+            lock (sync_)
+            {
+              MessageStore.Get(begSeqNo, endSeqNo, messages);
+            }
         }
 
         public void SetResendRange(int begin, int end, int chunkEnd=-1)


### PR DESCRIPTION
During a resendrequest - a .Get is done on the SessionState.Store.  This
get is not synchronized with .Set calls done on sending messages.  

If sending a message is initiated concurrently garbled or incorrect message data can
be read from the store and sent.  An IOException can also occur - because of the global file object used.

This pull request includes a unit test and suggested lock.

Associated with Issue below:

https://github.com/connamara/quickfixn/issues/258
