### PR TITLE
added SkipResetSeqNumFlag

### DIFF
--- a/QuickFIXn/Session.cs
+++ b/QuickFIXn/Session.cs
@@ -132,6 +132,12 @@ namespace QuickFix
         public bool RefreshOnLogon { get; set; }
 
         /// <summary>
+        /// Specifies whether ResetSeqNumFlag should be skipped following 
+        /// a sequence number reset.
+        /// </summary>
+        public bool SkipResetSeqNumFlag { get; set; }
+
+        /// <summary>
         /// Reset sequence numbers on logon request
         /// </summary>
         public bool ResetOnLogon { get; set; }
@@ -996,7 +1002,8 @@ namespace QuickFix
 
         protected bool ShouldSendReset()
         {
-            return (this.SessionID.BeginString.CompareTo(FixValues.BeginString.FIX41) >= 0)
+            return (!this.SkipResetSeqNumFlag)
+                && (this.SessionID.BeginString.CompareTo(FixValues.BeginString.FIX41) >= 0)
                 && (this.ResetOnLogon || this.ResetOnLogout || this.ResetOnDisconnect)
                 && (state_.GetNextSenderMsgSeqNum() == 1)
                 && (state_.GetNextTargetMsgSeqNum() == 1);

--- a/QuickFIXn/SessionFactory.cs
+++ b/QuickFIXn/SessionFactory.cs
@@ -109,6 +109,8 @@ namespace QuickFix
                 session.ResetOnLogout = settings.GetBool(SessionSettings.RESET_ON_LOGOUT);
             if (settings.Has(SessionSettings.RESET_ON_DISCONNECT))
                 session.ResetOnDisconnect = settings.GetBool(SessionSettings.RESET_ON_DISCONNECT);
+            if (settings.Has(SessionSettings.SKIP_RESET_SEQ_NUM_FLAG))
+                session.SkipResetSeqNumFlag = settings.GetBool(SessionSettings.SKIP_RESET_SEQ_NUM_FLAG);
             if (settings.Has(SessionSettings.REFRESH_ON_LOGON))
                 session.RefreshOnLogon = settings.GetBool(SessionSettings.REFRESH_ON_LOGON);
             if (settings.Has(SessionSettings.PERSIST_MESSAGES))

--- a/QuickFIXn/SessionSettings.cs
+++ b/QuickFIXn/SessionSettings.cs
@@ -41,6 +41,7 @@ namespace QuickFix
         public const string RESET_ON_LOGON = "ResetOnLogon";
         public const string RESET_ON_LOGOUT = "ResetOnLogout";
         public const string RESET_ON_DISCONNECT = "ResetOnDisconnect";
+        public const string SKIP_RESET_SEQ_NUM_FLAG = "SkipResetSeqNumFlag";
         public const string VALIDATE_FIELDS_OUT_OF_ORDER = "ValidateFieldsOutOfOrder";
         public const string VALIDATE_FIELDS_HAVE_VALUES = "ValidateFieldsHaveValues";
         public const string VALIDATE_USER_DEFINED_FIELDS = "ValidateUserDefinedFields";

--- a/tutorial/configuration.md
+++ b/tutorial/configuration.md
@@ -205,6 +205,16 @@ QuickFIX Settings
   </tr>
 
   <tr>
+    <td class='setting'>SkipResetSeqNumFlag</td>
+    <td class='description'>Specifies whether ResetSeqNumFlag should be skipped following a sequence number reset.</td>
+    <td class='valid'>
+      <div>Y</div>
+      <div>N</div>
+    </td>
+    <td class='default'>N</td>
+  </tr>
+
+  <tr>
     <td class='setting'>RefreshOnLogon</td>
     <td class='description'>Determines if session state should be restored from persistence layer when logging on.  Useful for creating hot failover sessions.</td>
     <td class='valid'>


### PR DESCRIPTION
Brokers tend to have sequence reset timings separate from session schedules. While it's easy to configure QuickFIXn schedule to match this with reset on either logon or logout, an institutional broker I certified with couldn't handle ResetSeqNum (141=Y) at logon. I ended up adding SkipResetSeqNumFlag setting.