### PR TITLE
Fix distributed deadlock between two sessions

### DIFF
--- a/QuickFIXn/Session.cs
+++ b/QuickFIXn/Session.cs
@@ -1594,7 +1594,7 @@ namespace QuickFix
                         Fields.ResetSeqNumFlag resetSeqNumFlag = new QuickFix.Fields.ResetSeqNumFlag(false);
                         if (message.IsSetField(resetSeqNumFlag))
                             message.GetField(resetSeqNumFlag);
-                        if (resetSeqNumFlag.Obj)
+                        if (resetSeqNumFlag.getValue())
                         {
                             state_.Reset("ResetSeqNumFlag");
                             message.Header.SetField(new Fields.MsgSeqNum(state_.GetNextSenderMsgSeqNum()));


### PR DESCRIPTION
This code gets rid of holding a lock during the call to Send(). In general, it is a good idea not to hold locks while making potentially blocking operations.

I've seen the other pull request, which removes the lock when reading responder_ in HasResponder.

I think that is not correct solution: the responder_ member is a mutable property in Session, and as such needs some kind of synchronization for access. There is no real argument that this would work more than observing the fact that it doesn't seem to cause problems.

Another problem is that the Disconnect() method is also protected by the same monitor, and this patch makes sure that calls to Disconnect also succeed without having to wait for a long Send() to return.

At last, this is what the code in quickfixj does.
