### PR TITLE
Add new Application Callback (non-breaking) for early intercept of inbou...

### DIFF
--- a/QuickFIXn/IApplicationExt.cs
+++ b/QuickFIXn/IApplicationExt.cs
@@ -3,18 +3,24 @@
 namespace QuickFix
 {
     /// <summary>
-    /// This is the optional extension interface for processing session messages, and facilitates early interception of inbound messages.
-	/// 'Early', in this context, means after structure, length and checksum have been validated, but before any further validation has been performed.
+    /// This is the optional extension interface for processing inbound messages,
+    /// and facilitates early interception of such messages. 'Early', in this context,
+    /// means after structure, length and checksum have been validated, but before any
+    /// further validation has been performed.
+    /// This interface will not normally be required, and it should be used only with caution:
+    /// it allows modfications to be made to irregular inbound messages that would otherwise
+    /// fail validation against the Fix dictionary, an provides an alternative to dictionary
+    /// customisation as a means of dealing with such messages.
     /// </summary>
-	public interface IApplicationExt : IApplication
-	{
-		/// <summary>
-		/// This callback provides early notification of when an administrative or application  message is sent from a counterparty to your FIX engine.
-		/// This can be useful for doing pre-processing of an inbound message after its structure, checksum and length have been validated, but before
-		/// any further validation has been performed on it.
-		/// </summary>
-		/// <param name="message">received message</param>
-		/// <param name="sessionID">session on which message received</param>
-		void FromEarlyIntercept(Message message, SessionID sessionID);
-	}
+    public interface IApplicationExt : IApplication
+    {
+        /// <summary>
+        /// This callback provides early notification of when an administrative or application  message is sent from a counterparty to your FIX engine.
+        /// This can be useful for doing pre-processing of an inbound message after its structure, checksum and length have been validated, but before
+        /// any further validation has been performed on it.
+        /// </summary>
+        /// <param name="message">received message</param>
+        /// <param name="sessionID">session on which message received</param>
+        void FromEarlyIntercept(Message message, SessionID sessionID);
+    }
 }

--- a/QuickFIXn/IApplicationExt.cs
+++ b/QuickFIXn/IApplicationExt.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace QuickFix
+{
+    /// <summary>
+    /// This is the optional extension interface for processing session messages, and facilitates early interception of inbound messages.
+	/// 'Early', in this context, means after structure, length and checksum have been validated, but before any further validation has been performed.
+    /// </summary>
+	public interface IApplicationExt : IApplication
+	{
+		/// <summary>
+		/// This callback provides early notification of when an administrative or application  message is sent from a counterparty to your FIX engine.
+		/// This can be useful for doing pre-processing of an inbound message after its structure, checksum and length have been validated, but before
+		/// any further validation has been performed on it.
+		/// </summary>
+		/// <param name="message">received message</param>
+		/// <param name="sessionID">session on which message received</param>
+		void FromEarlyIntercept(Message message, SessionID sessionID);
+	}
+}

--- a/QuickFIXn/QuickFix.csproj
+++ b/QuickFIXn/QuickFix.csproj
@@ -67,6 +67,7 @@
     <Compile Include="FileStoreFactory.cs" />
     <Compile Include="FixValues.cs" />
     <Compile Include="IApplication.cs" />
+    <Compile Include="IApplicationExt.cs" />
     <Compile Include="IInitiator.cs" />
     <Compile Include="ILog.cs" />
     <Compile Include="ILogFactory.cs" />

--- a/QuickFIXn/Session.cs
+++ b/QuickFIXn/Session.cs
@@ -22,6 +22,7 @@ namespace QuickFix
         private SessionSchedule schedule_;
         private SessionState state_;
         private IMessageFactory msgFactory_;
+        private bool appDoesEarlyIntercept_;
         private static readonly HashSet<string> AdminMsgTypes = new HashSet<string>() { "0", "A", "1", "2", "3", "4", "5" };
 
         #endregion
@@ -211,6 +212,7 @@ namespace QuickFix
             this.DataDictionaryProvider = new DataDictionaryProvider(dataDictProvider);
             this.schedule_ = sessionSchedule;
             this.msgFactory_ = msgFactory;
+            appDoesEarlyIntercept_ = app is IApplicationExt;
 
             this.SenderDefaultApplVerID = senderDefaultApplVerID;
 
@@ -546,6 +548,9 @@ namespace QuickFix
                 Reset("Out of SessionTime (Session.Next(message))", "Message received outside of session time");
                 return;
             }
+
+            if (appDoesEarlyIntercept_)
+                ((IApplicationExt)Application).FromEarlyIntercept(message, this.SessionID);
 
             if (IsNewSession)
                 state_.Reset("New session (detected in Next(Message))");

--- a/UnitTests/SessionTest.cs
+++ b/UnitTests/SessionTest.cs
@@ -119,7 +119,7 @@ namespace UnitTests
     {
         public HashSet<string> InterceptedMessageTypes = new HashSet<string>();
 
-       #region Application Members
+        #region Application Members
 
         public void ToAdmin(QuickFix.Message message, QuickFix.SessionID sessionID)
         {
@@ -768,18 +768,18 @@ namespace UnitTests
         {
             var mockApp = new MockApplicationExt();
             session = new QuickFix.Session(mockApp, new QuickFix.MemoryStoreFactory(), sessionID,
-             new QuickFix.DataDictionaryProvider(), new QuickFix.SessionSchedule(config), 0, new QuickFix.ScreenLogFactory(settings), new QuickFix.DefaultMessageFactory(), "blah");
+                new QuickFix.DataDictionaryProvider(), new QuickFix.SessionSchedule(config), 0, new QuickFix.ScreenLogFactory(settings), new QuickFix.DefaultMessageFactory(), "blah");
             session.SetResponder(responder);
             session.CheckLatency = false;
 
             Logon();
             QuickFix.FIX42.NewOrderSingle order = new QuickFix.FIX42.NewOrderSingle(
-                 new QuickFix.Fields.ClOrdID("1"),
-                 new QuickFix.Fields.HandlInst(QuickFix.Fields.HandlInst.MANUAL_ORDER),
-                 new QuickFix.Fields.Symbol("IBM"),
-                 new QuickFix.Fields.Side(QuickFix.Fields.Side.BUY),
-                 new QuickFix.Fields.TransactTime(),
-                 new QuickFix.Fields.OrdType(QuickFix.Fields.OrdType.LIMIT));
+                new QuickFix.Fields.ClOrdID("1"),
+                new QuickFix.Fields.HandlInst(QuickFix.Fields.HandlInst.MANUAL_ORDER),
+                new QuickFix.Fields.Symbol("IBM"),
+                new QuickFix.Fields.Side(QuickFix.Fields.Side.BUY),
+                new QuickFix.Fields.TransactTime(),
+                new QuickFix.Fields.OrdType(QuickFix.Fields.OrdType.LIMIT));
 
             order.Header.SetField(new QuickFix.Fields.TargetCompID(sessionID.SenderCompID));
             order.Header.SetField(new QuickFix.Fields.SenderCompID(sessionID.TargetCompID));
@@ -790,6 +790,6 @@ namespace UnitTests
             Assert.That(mockApp.InterceptedMessageTypes.Count, Is.EqualTo(2));
             Assert.True(mockApp.InterceptedMessageTypes.Contains(QuickFix.Fields.MsgType.LOGON));
             Assert.True(mockApp.InterceptedMessageTypes.Contains(QuickFix.Fields.MsgType.NEWORDERSINGLE));
-       }
+        }
     }
 }

--- a/UnitTests/SessionTest.cs
+++ b/UnitTests/SessionTest.cs
@@ -112,8 +112,49 @@ namespace UnitTests
         public void OnLogon(QuickFix.SessionID sessionID)
         {
         }
-
         #endregion
+    }
+
+    class MockApplicationExt : QuickFix.IApplicationExt
+    {
+        public HashSet<string> InterceptedMessageTypes = new HashSet<string>();
+
+       #region Application Members
+
+        public void ToAdmin(QuickFix.Message message, QuickFix.SessionID sessionID)
+        {
+        }
+
+        public void FromAdmin(QuickFix.Message message, QuickFix.SessionID sessionID)
+        {
+        }
+
+        public void ToApp(QuickFix.Message message, QuickFix.SessionID sessionId)
+        {
+        }
+
+        public void FromApp(QuickFix.Message message, QuickFix.SessionID sessionID)
+        {
+        }
+
+        public void OnCreate(QuickFix.SessionID sessionID)
+        {
+        }
+
+        public void OnLogout(QuickFix.SessionID sessionID)
+        {
+        }
+
+        public void OnLogon(QuickFix.SessionID sessionID)
+        {
+        }
+
+        public void FromEarlyIntercept(QuickFix.Message message, QuickFix.SessionID sessionID)
+        {
+            InterceptedMessageTypes.Add(message.Header.GetString(QuickFix.Fields.Tags.MsgType));
+        }
+        #endregion
+
     }
 
     [TestFixture]
@@ -126,6 +167,7 @@ namespace UnitTests
         MockApplication application = null;
         QuickFix.Session session = null;
         QuickFix.Session session2 = null;
+        QuickFix.Dictionary config = null;
         int seqNum = 1;
         Regex msRegex = new Regex(@"\.[\d]{1,3}$");
 
@@ -137,7 +179,7 @@ namespace UnitTests
             application = new MockApplication();
             settings = new QuickFix.SessionSettings();
 
-            QuickFix.Dictionary config = new QuickFix.Dictionary();
+            config = new QuickFix.Dictionary();
             config.SetBool(QuickFix.SessionSettings.PERSIST_MESSAGES, false);
             config.SetString(QuickFix.SessionSettings.CONNECTION_TYPE, "initiator");
             config.SetString(QuickFix.SessionSettings.START_TIME, "00:00:00");
@@ -719,5 +761,35 @@ namespace UnitTests
             SendResendRequest(1, 0);
             Assert.False(SENT_NOS());
         }
+
+
+        [Test]
+        public void TestApplicationExtension()
+        {
+            var mockApp = new MockApplicationExt();
+            session = new QuickFix.Session(mockApp, new QuickFix.MemoryStoreFactory(), sessionID,
+             new QuickFix.DataDictionaryProvider(), new QuickFix.SessionSchedule(config), 0, new QuickFix.ScreenLogFactory(settings), new QuickFix.DefaultMessageFactory(), "blah");
+            session.SetResponder(responder);
+            session.CheckLatency = false;
+
+            Logon();
+            QuickFix.FIX42.NewOrderSingle order = new QuickFix.FIX42.NewOrderSingle(
+                 new QuickFix.Fields.ClOrdID("1"),
+                 new QuickFix.Fields.HandlInst(QuickFix.Fields.HandlInst.MANUAL_ORDER),
+                 new QuickFix.Fields.Symbol("IBM"),
+                 new QuickFix.Fields.Side(QuickFix.Fields.Side.BUY),
+                 new QuickFix.Fields.TransactTime(),
+                 new QuickFix.Fields.OrdType(QuickFix.Fields.OrdType.LIMIT));
+
+            order.Header.SetField(new QuickFix.Fields.TargetCompID(sessionID.SenderCompID));
+            order.Header.SetField(new QuickFix.Fields.SenderCompID(sessionID.TargetCompID));
+            order.Header.SetField(new QuickFix.Fields.MsgSeqNum(2));
+
+            session.Next(order);
+
+            Assert.That(mockApp.InterceptedMessageTypes.Count, Is.EqualTo(2));
+            Assert.True(mockApp.InterceptedMessageTypes.Contains(QuickFix.Fields.MsgType.LOGON));
+            Assert.True(mockApp.InterceptedMessageTypes.Contains(QuickFix.Fields.MsgType.NEWORDERSINGLE));
+       }
     }
 }


### PR DESCRIPTION
...nd messages.

Add an IApplicationExt interface that extends IApplication and facilitates early
intercept of inbound messages on the part of the Application.

This is a bit similar to the late outbound intercept afforded by ToApp/ToAdmin,
and permits alteration of field values prior to their being validated by the engine.
The difference is that, with the new interface, only one callback is provided for
both App and Admin messages.

Usage of the existing IApplication interface is unaffected.