### PR TITLE
AllowToSetSevralFieldsAtTheSameTime

### DIFF
--- a/QuickFIXn/Message/FieldMap.cs
+++ b/QuickFIXn/Message/FieldMap.cs
@@ -94,6 +94,17 @@ namespace QuickFix
         }
 
         /// <summary>
+        /// set many fields once
+        /// </summary>
+        public void SetFields(IEnumerable<Fields.IField> fields)
+        {
+            foreach (var field in fields)
+            {
+                _fields[field.Tag] = field;
+            }
+        }
+
+        /// <summary>
         /// Set field, with optional override check
         /// </summary>
         /// <param name="field"></param>

--- a/QuickFIXn/Message/FieldMap.cs
+++ b/QuickFIXn/Message/FieldMap.cs
@@ -94,7 +94,7 @@ namespace QuickFix
         }
 
         /// <summary>
-        /// set many fields once
+        /// set many fields at the same time
         /// </summary>
         public void SetFields(IEnumerable<Fields.IField> fields)
         {

--- a/UnitTests/MessageTests.cs
+++ b/UnitTests/MessageTests.cs
@@ -890,5 +890,24 @@ namespace UnitTests
             // 2 levels deep
             StringAssert.Contains(String.Join(Message.SOH, new string[] { "311=underlyingsymbol", "312=WI", "309=underlyingsecurityid", "305=1" }), msg.ToString());
         }
+
+        [Test]
+        public void SetFieldsTest()
+        {
+            var message = new Message();
+            var allocId = new AllocID("123456");
+            var allocAccount = new AllocAccount("QuickFixAccount");
+            var allocAccountType = new AllocAccountType(AllocAccountType.HOUSE_TRADER);
+            message.SetFields(new IField[] { allocAccount, allocAccountType, allocId });
+
+            Assert.AreEqual(true, message.IsSetField(Tags.AllocID));
+            Assert.AreEqual("123456", message.GetField(Tags.AllocID));
+
+            Assert.AreEqual(true, message.IsSetField(Tags.AllocAccount));
+            Assert.AreEqual("QuickFixAccount", message.GetField(Tags.AllocAccount));
+
+            Assert.AreEqual(true, message.IsSetField(Tags.AllocAccountType));
+            Assert.AreEqual(AllocAccountType.HOUSE_TRADER, message.GetInt(Tags.AllocAccountType));
+        }
     }
 }


### PR DESCRIPTION
When using QuickFix/n dll, i'd to set many fields to create a message. So i added an extended method in my project to do it. I add this method in QF/n project now because it's more efficient.