### PR TITLE
Added SocketSendBufferSize and SocketReceiveBufferSize settings.

### DIFF
--- a/QuickFIXn/SessionSettings.cs
+++ b/QuickFIXn/SessionSettings.cs
@@ -56,6 +56,8 @@ namespace QuickFix
         public const string MAX_MESSAGES_IN_RESEND_REQUEST = "MaxMessagesInResendRequest";
         public const string SEND_LOGOUT_BEFORE_TIMEOUT_DISCONNECT = "SendLogoutBeforeDisconnectFromTimeout";
         public const string SOCKET_NODELAY = "SocketNodelay";
+        public const string SOCKET_SEND_BUFFER_SIZE = "SocketSendBufferSize";
+        public const string SOCKET_RECEIVE_BUFFER_SIZE = "SocketReceiveBufferSize";
         public const string IGNORE_POSSDUP_RESEND_REQUESTS = "IgnorePossDupResendRequests";
         public const string RESETSEQUENCE_MESSAGE_REQUIRES_ORIGSENDINGTIME = "RequiresOrigSendingTime";
         public const string CHECK_LATENCY = "CheckLatency";

--- a/QuickFIXn/SocketSettings.cs
+++ b/QuickFIXn/SocketSettings.cs
@@ -16,6 +16,8 @@ namespace QuickFix
     public class SocketSettings
     {
         public bool SocketNodelay = true;
+        public Nullable<int> SocketReceiveBufferSize;
+        public Nullable<int> SocketSendBufferSize;
 
         #region SSL Settings
 
@@ -118,6 +120,12 @@ namespace QuickFix
         {
             if (dictionary.Has(SessionSettings.SOCKET_NODELAY))
                 SocketNodelay = dictionary.GetBool(SessionSettings.SOCKET_NODELAY);
+
+            if (dictionary.Has(SessionSettings.SOCKET_RECEIVE_BUFFER_SIZE))
+                SocketReceiveBufferSize = dictionary.GetInt(SessionSettings.SOCKET_RECEIVE_BUFFER_SIZE);
+
+            if (dictionary.Has(SessionSettings.SOCKET_SEND_BUFFER_SIZE))
+                SocketSendBufferSize = dictionary.GetInt(SessionSettings.SOCKET_SEND_BUFFER_SIZE);
 
             if (dictionary.Has(SessionSettings.SSL_SERVERNAME))
                 ServerCommonName = dictionary.GetString(SessionSettings.SSL_SERVERNAME);

--- a/QuickFIXn/ThreadedSocketReactor.cs
+++ b/QuickFIXn/ThreadedSocketReactor.cs
@@ -114,6 +114,14 @@ namespace QuickFix
         {
             client.LingerState = new LingerOption(false, 0);
             client.NoDelay = socketSettings.SocketNodelay;
+            if (socketSettings.SocketReceiveBufferSize.HasValue)
+            {
+                client.ReceiveBufferSize = socketSettings.SocketReceiveBufferSize.Value;
+            }
+            if (socketSettings.SocketSendBufferSize.HasValue)
+            {
+                client.SendBufferSize = socketSettings.SocketSendBufferSize.Value;
+            }
         }
 
         private void ShutdownClientHandlerThreads()

--- a/QuickFIXn/Transport/StreamFactory.cs
+++ b/QuickFIXn/Transport/StreamFactory.cs
@@ -28,6 +28,14 @@ namespace QuickFix.Transport
         {
             var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
             socket.NoDelay = settings.SocketNodelay;
+            if (settings.SocketReceiveBufferSize.HasValue)
+            {
+                socket.ReceiveBufferSize = settings.SocketReceiveBufferSize.Value;
+            }
+            if (settings.SocketSendBufferSize.HasValue)
+            {
+                socket.SendBufferSize = settings.SocketSendBufferSize.Value;
+            }
             socket.Connect(endpoint);
             Stream stream = new NetworkStream(socket, ownsSocket: true);
 


### PR DESCRIPTION
Added settings to set the socket send and receive buffer sizes. These settings were available in quickfixj and we used them, so I added them migrating to quickfixn (I was surprised to find that they are not available in the "standard" quickfix version, at least not according to http://www.quickfixengine.org/quickfix/doc/html/configuration.html .)
