### PR TITLE
Use only ipv4 addresses returned by Dns.GetHostAddresses

### DIFF
--- a/QuickFIXn/Transport/SocketInitiator.cs
+++ b/QuickFIXn/Transport/SocketInitiator.cs
@@ -120,7 +120,7 @@ namespace QuickFix.Transport
                 sessionToHostNum_[sessionID] = ++num;
 
                 socketSettings_.ServerCommonName = hostName;
-                return new IPEndPoint(addrs[0], port);
+                return new IPEndPoint(addrs.First(a => a.AddressFamily == InterNetwork), port);
             }
             catch (System.Exception e)
             {

--- a/QuickFIXn/Transport/SocketInitiator.cs
+++ b/QuickFIXn/Transport/SocketInitiator.cs
@@ -120,7 +120,7 @@ namespace QuickFix.Transport
                 sessionToHostNum_[sessionID] = ++num;
 
                 socketSettings_.ServerCommonName = hostName;
-                return new IPEndPoint(addrs.First(a => a.AddressFamily == InterNetwork), port);
+                return new IPEndPoint(addrs.First(a => a.AddressFamily == AddressFamily.InterNetwork), port);
             }
             catch (System.Exception e)
             {


### PR DESCRIPTION
If Dns.GetHostAddresses returns IPv6 addresses, the SocketInitiator tries to use them. Since the acceptor does not bind to IPv6 addresses, this seems illogical.  This patch filters out IPv4 addresses only.

Especially when testing, many machines have an IPv6 address in the host file for localhost.

I believe this is a practical fix until IPv6 support is added to all parts of the code.

Staffan
