### PR TITLE
Remove call to Thread.Join that blocks initiator on stop

### DIFF
--- a/QuickFIXn/SocketInitiatorThread.cs
+++ b/QuickFIXn/SocketInitiatorThread.cs
@@ -45,15 +45,6 @@ namespace QuickFix
             thread_.Start(this);
         }
 
-        public void Join()
-        {
-            if (null == thread_)
-                return;
-            Disconnect();
-            thread_.Join(5000);
-            thread_ = null;
-        }
-
         public void Connect()
         {
             Debug.Assert(stream_ == null);

--- a/QuickFIXn/Transport/SocketInitiator.cs
+++ b/QuickFIXn/Transport/SocketInitiator.cs
@@ -69,12 +69,14 @@ namespace QuickFix.Transport
             catch (IOException ex) // Can be exception when connecting, during ssl authentication or when reading
             {
                 t.Session.Log.OnEvent("Connection failed: " + ex.Message);
+                t.Disconnect();
                 t.Initiator.RemoveThread(t);
                 t.Initiator.SetDisconnected(t.Session.SessionID);
             }
             catch (SocketException e) 
             {
                 t.Session.Log.OnEvent("Connection failed: " + e.Message);
+                t.Disconnect();
                 t.Initiator.RemoveThread(t);
                 t.Initiator.SetDisconnected(t.Session.SessionID);
             }
@@ -92,7 +94,6 @@ namespace QuickFix.Transport
         {
             lock (sync_)
             {
-                thread.Join();
                 threads_.Remove(thread.Session.SessionID);
             }
         }


### PR DESCRIPTION
When SocketInitiator stops, the code running SocketInitiatorThread (confusingly in a static method in SocketInitiator), calls RemoveThread, which in turn calls Join on the SocketInitiatorThread. Join is only ever called from the thread that is being joined, and the only reason it ever terminates is the timeout of 5 seconds.  This patch removed this confusing code that makes stopping take 5 seconds \* the number of configured sessions. (There is probably more to do in this section, but at least it gets rid of an annoying problem.)
