### PR TITLE
Issue #278: Resend bug in Session.NextResendRequest

### DIFF
--- a/NEXT_VERSION.md
+++ b/NEXT_VERSION.md
@@ -32,4 +32,4 @@ Changes since the last version (oldest first):
 * (patch)  #80 - fixes to tag-141-related sequence resets (TomasVetrovsky,akamyshanov,gbirchmeier)
 * (patch) #315 - make config file section headers be case-insensitive, for parity with QF/j (gbirchmeier)
 * (minor) #314 - New feature: add/remove sessions dynamically (martinadams)
-
+* (patch) #278 - fix for mis-sequenced gap fills in re-requested messages (martinadams)

--- a/QuickFIXn/Session.cs
+++ b/QuickFIXn/Session.cs
@@ -793,14 +793,10 @@ namespace QuickFix
                         current = msgSeqNum + 1;
                     }
 
-                    if (endSeqNo > msgSeqNum)
+                    int nextSeqNum = state_.GetNextSenderMsgSeqNum();
+                    if (++endSeqNo > nextSeqNum)
                     {
-                        endSeqNo = endSeqNo + 1;
-                        int next = state_.GetNextSenderMsgSeqNum();
-                        if (endSeqNo > next)
-                        {
-                            endSeqNo = next;
-                        }
+                        endSeqNo = nextSeqNum;
                     }
 
                     if (begin == 0)

--- a/QuickFIXn/Session.cs
+++ b/QuickFIXn/Session.cs
@@ -793,11 +793,6 @@ namespace QuickFix
                         current = msgSeqNum + 1;
                     }
 
-                    if (begin != 0)
-                    {
-                        GenerateSequenceReset(resendReq, begin, msgSeqNum + 1);
-                    }
-
                     if (endSeqNo > msgSeqNum)
                     {
                         endSeqNo = endSeqNo + 1;
@@ -806,7 +801,16 @@ namespace QuickFix
                         {
                             endSeqNo = next;
                         }
-                        GenerateSequenceReset(resendReq, begSeqNo, endSeqNo);
+                    }
+
+                    if (begin == 0)
+                    {
+                        begin = current;
+                    }
+
+                    if (endSeqNo > begin)
+                    {
+                        GenerateSequenceReset(resendReq, begin, endSeqNo);
                     }
                 }
                 msgSeqNum = resendReq.Header.GetInt(Tags.MsgSeqNum);


### PR DESCRIPTION
UT added to verify the fix: with the original code, a spurious mis-sequenced gap fill message is generated.