### PR TITLE
Issue #312: non-spec gap fill behavior

### DIFF
--- a/NEXT_VERSION.md
+++ b/NEXT_VERSION.md
@@ -32,4 +32,5 @@ Changes since the last version (oldest first):
 * (patch)  #80 - fixes to tag-141-related sequence resets (TomasVetrovsky,akamyshanov,gbirchmeier)
 * (patch) #315 - make config file section headers be case-insensitive, for parity with QF/j (gbirchmeier)
 * (minor) #314 - New feature: add/remove sessions dynamically (martinadams)
+* (minor) #312 - New config option: can force session-level rejects to be resent (martinadams)
 

--- a/QuickFIXn/Session.cs
+++ b/QuickFIXn/Session.cs
@@ -153,6 +153,11 @@ namespace QuickFix
         public bool SendRedundantResendRequests { get; set; }
 
         /// <summary>
+        /// Whether to resend session level rejects (msg type '3') when servicing a resend request
+        /// </summary>
+        public bool ResendSessionLevelRejects { get; set; }
+
+        /// <summary>
         /// Whether to validate length and checksum of messages
         /// </summary>
         public bool ValidateLengthAndChecksum { get; set; }
@@ -238,6 +243,7 @@ namespace QuickFix
             this.PersistMessages = true;
             this.ResetOnDisconnect = false;
             this.SendRedundantResendRequests = false;
+            this.ResendSessionLevelRejects = false;
             this.ValidateLengthAndChecksum = true;
             this.CheckCompID = true;
             this.MillisecondsInTimeStamp = true;
@@ -767,7 +773,7 @@ namespace QuickFix
                             begin = current;
                         }
 
-                        if (IsAdminMessage(msg))
+                        if (IsAdminMessage(msg) && !(this.ResendSessionLevelRejects && msg.Header.GetString(Tags.MsgType) == MsgType.REJECT))
                         {
                             if (begin == 0)
                             {

--- a/QuickFIXn/SessionFactory.cs
+++ b/QuickFIXn/SessionFactory.cs
@@ -86,6 +86,8 @@ namespace QuickFix
 
             if (settings.Has(SessionSettings.SEND_REDUNDANT_RESENDREQUESTS))
                 session.SendRedundantResendRequests = settings.GetBool(SessionSettings.SEND_REDUNDANT_RESENDREQUESTS);
+            if (settings.Has(SessionSettings.RESEND_SESSION_LEVEL_REJECTS))
+                session.ResendSessionLevelRejects = settings.GetBool(SessionSettings.RESEND_SESSION_LEVEL_REJECTS);
             /** FIXME - implement optional settings
             if (settings.Has(SessionSettings.CHECK_COMPID))
                 session.SetCheckCompId(settings.GetBool(SessionSettings.CHECK_COMPID));

--- a/QuickFIXn/SessionSettings.cs
+++ b/QuickFIXn/SessionSettings.cs
@@ -51,6 +51,7 @@ namespace QuickFix
         public const string LOGON_TIMEOUT = "LogonTimeout";
         public const string LOGOUT_TIMEOUT = "LogoutTimeout";
         public const string SEND_REDUNDANT_RESENDREQUESTS = "SendRedundantResendRequests";
+        public const string RESEND_SESSION_LEVEL_REJECTS = "ResendSessionLevelRejects";
         public const string MILLISECONDS_IN_TIMESTAMP = "MillisecondsInTimeStamp";
         public const string ENABLE_LAST_MSG_SEQ_NUM_PROCESSED = "EnableLastMsgSeqNumProcessed";
         public const string MAX_MESSAGES_IN_RESEND_REQUEST = "MaxMessagesInResendRequest";

--- a/UnitTests/SessionFactoryTest.cs
+++ b/UnitTests/SessionFactoryTest.cs
@@ -80,6 +80,7 @@ namespace UnitTests
             Dictionary settings = new Dictionary();
             settings.SetString(SessionSettings.USE_DATA_DICTIONARY, "N");
             settings.SetString(SessionSettings.SEND_REDUNDANT_RESENDREQUESTS, "Y");
+            settings.SetString(SessionSettings.RESEND_SESSION_LEVEL_REJECTS, "Y");
             settings.SetString(SessionSettings.MILLISECONDS_IN_TIMESTAMP, "Y");
             settings.SetString(SessionSettings.CONNECTION_TYPE, "initiator");
             settings.SetString(SessionSettings.HEARTBTINT, "30");
@@ -93,13 +94,16 @@ namespace UnitTests
             Session session = factory.Create(sessionID, settings);
 
             Assert.That(session.SendRedundantResendRequests);
+            Assert.That(session.ResendSessionLevelRejects);
             Assert.That(session.MillisecondsInTimeStamp);
 
             settings.SetString(SessionSettings.SEND_REDUNDANT_RESENDREQUESTS, "N");
+            settings.SetString(SessionSettings.RESEND_SESSION_LEVEL_REJECTS, "N");
             settings.SetString(SessionSettings.MILLISECONDS_IN_TIMESTAMP, "N");
             session = factory.Create(sessionID, settings);
 
             Assert.That(!session.SendRedundantResendRequests);
+            Assert.That(!session.ResendSessionLevelRejects);
             Assert.That(!session.MillisecondsInTimeStamp);
             Assert.That(session.EnableLastMsgSeqNumProcessed);
             Assert.That(session.MaxMessagesInResendRequest, Is.EqualTo(2500));

--- a/UnitTests/SessionTest.cs
+++ b/UnitTests/SessionTest.cs
@@ -405,15 +405,15 @@ namespace UnitTests
             Assert.That(DISCONNECTED());
         }
 
-	[Test]
-	public void HeartBeatCheckAfterMessageProcess()
-	{
-	    Logon();
-	    Thread.Sleep(2000);
+        [Test]
+        public void HeartBeatCheckAfterMessageProcess()
+        {
+            Logon();
+            Thread.Sleep(2000);
 
             SendNOSMessage();
             Assert.That(SENT_HEART_BEAT());
-	}
+        }
 
         [Test]
         public void NextResendRequestNoMessagePersist()
@@ -430,6 +430,30 @@ namespace UnitTests
             SendResendRequest(1, 4);
             Assert.That(SENT_RESEND());
             Assert.IsFalse(RESENT());
+        }
+
+        [Test]
+        public void TestResendSessionLevelReject()
+        {
+            Assert.False(session.ResendSessionLevelRejects); // check for correct default
+            Logon(); 
+
+            QuickFix.FIX42.Reject reject = new QuickFix.FIX42.Reject(
+                new QuickFix.Fields.RefSeqNum(10));
+
+            reject.Header.SetField(new QuickFix.Fields.TargetCompID(sessionID.TargetCompID));
+            reject.Header.SetField(new QuickFix.Fields.SenderCompID(sessionID.SenderCompID));
+            session.Send(reject);
+
+            responder.msgLookup.Clear();
+            session.ResendSessionLevelRejects = true;
+            SendResendRequest(1, 100);
+            Assert.That(responder.msgLookup.ContainsKey(QuickFix.Fields.MsgType.REJECT));
+
+            responder.msgLookup.Clear();
+            session.ResendSessionLevelRejects = false;
+            SendResendRequest(1, 100);
+            Assert.False(responder.msgLookup.ContainsKey(QuickFix.Fields.MsgType.REJECT));
         }
 
         public void AssertMsInTag(string msgType, int tag, bool shouldHaveMs)


### PR DESCRIPTION
New Y/N config option added: "ResendSessionLevelRejects", defaults to N.
Also, tab -> space formatting tidy-up on unrelated UT.
