### PR TITLE
Fix for stack overflow that can occcur because of recursion

### DIFF
--- a/NEXT_VERSION.md
+++ b/NEXT_VERSION.md
@@ -32,4 +32,5 @@ Changes since the last version (oldest first):
 * (patch)  #80 - fixes to tag-141-related sequence resets (TomasVetrovsky,akamyshanov,gbirchmeier)
 * (patch) #315 - make config file section headers be case-insensitive, for parity with QF/j (gbirchmeier)
 * (minor) #314 - New feature: add/remove sessions dynamically (martinadams)
+* (patch) #280 - fix to prevent StackOverflowException due to recursion (martinadams)
 

--- a/QuickFIXn/Session.cs
+++ b/QuickFIXn/Session.cs
@@ -502,6 +502,16 @@ namespace QuickFix
         /// <param name="msgStr"></param>
         public void Next(string msgStr)
         {
+            NextMessage(msgStr);
+            NextQueued();
+        }
+
+        /// <summary>
+        /// Process a message (in string form) from the counterparty
+        /// </summary>
+        /// <param name="msgStr"></param>
+        private void NextMessage(string msgStr)
+        {
             try
             {
                 this.Log.OnIncoming(msgStr);
@@ -654,7 +664,6 @@ namespace QuickFix
                 Disconnect(e.ToString());
             }
 
-            NextQueued();
             Next();
         }
 
@@ -710,7 +719,6 @@ namespace QuickFix
             else
             {
                 state_.IncrNextTargetMsgSeqNum();
-                NextQueued();
             }
 
             if (this.IsLoggedOn)
@@ -723,7 +731,6 @@ namespace QuickFix
                 return;
             GenerateHeartbeat(testRequest);
             state_.IncrNextTargetMsgSeqNum();
-            NextQueued();
         }
 
         protected void NextResendRequest(Message resendReq)
@@ -866,7 +873,6 @@ namespace QuickFix
             if (!Verify(heartbeat))
                 return;
             state_.IncrNextTargetMsgSeqNum();
-            NextQueued();
         }
 
         protected void NextSequenceReset(Message sequenceReset)
@@ -1563,14 +1569,12 @@ namespace QuickFix
                 }
                 else
                 {
-                    Next(msg.ToString());
+                    NextMessage(msg.ToString());
                 }
                 return true;
             }
             return false;
         }
-
-
 
         private bool IsAdminMessage(Message msg)
         {


### PR DESCRIPTION
Recursion occurs when processing received messages that were queued because of a (subsequently filled) sequence gap. If sufficient such messages are pending, a stack overflow will occur when they are processed.
The recursion has been removed: now, instead of the pending queue being checked after every received message (including ones that came from the queue itself) has been processed, it is checked only after a 'live' message is processed.
For testing, a scenario was created with a test client app that reliably reproduced the stack overflow with the pre-fix code: login (seq #1) was sent to QF/n, followed by 2000 app messages (starting at seq #3). Finally a business message (seq #2) was sent to trigger processing of the 2000 queued messages.