### PR TITLE
Ensure ClientHandlerThread releases resources.

### DIFF
--- a/NEXT_VERSION.md
+++ b/NEXT_VERSION.md
@@ -22,6 +22,7 @@ Changes since the last version (oldest first):
 * (patch) #256 - bug in 247, defaults override config (akamyshanov)
 * (patch) #258 - threadsafe SessionState.Get/Set to fix garbled message issue (jacsuper)
 * (patch) #251 - restore the session type check in AbstractInitiator.Start (oract)
+* (patch) #255 - release ClientHandlerThread resources on client disconnect (mgatny)
 * (patch) #266 - Session not explicitly handling DoNotSend from Application::ToApp (cbusbey)
 * (patch) #267 - Resent Messages not being relayed to Application::ToApp (cbusbey)
 * (minor) #286 - FieldBase.Equals() and .GetHashcode() (steffanu)

--- a/QuickFIXn/ClientHandlerThread.cs
+++ b/QuickFIXn/ClientHandlerThread.cs
@@ -14,7 +14,7 @@ namespace QuickFix
     /// </summary>
     public class ClientHandlerThread : IResponder, IDisposable
     {
-        public class ExitedEventArgs : EventArgs
+        internal class ExitedEventArgs : EventArgs
         {
             public ClientHandlerThread ClientHandlerThread { get; private set; }
 
@@ -24,8 +24,8 @@ namespace QuickFix
             }
         }
 
-        public delegate void ExitedEventHandler(object sender, ClientHandlerThread.ExitedEventArgs e);
-        public event ExitedEventHandler Exited;
+        internal delegate void ExitedEventHandler(object sender, ClientHandlerThread.ExitedEventArgs e);
+        internal event ExitedEventHandler Exited;
 
         public long Id { get; private set; }
 

--- a/QuickFIXn/ThreadedSocketReactor.cs
+++ b/QuickFIXn/ThreadedSocketReactor.cs
@@ -31,7 +31,7 @@ namespace QuickFix
         private State state_ = State.RUNNING;
         private long nextClientId_ = 0;
         private Thread serverThread_ = null;
-        private LinkedList<ClientHandlerThread> clientThreads_ = new LinkedList<ClientHandlerThread>();
+        private Dictionary<long, ClientHandlerThread> clientThreads_ = new Dictionary<long, ClientHandlerThread>();
         private TcpListener tcpListener_;
         private SocketSettings socketSettings_;
         private QuickFix.Dictionary sessionDict_;
@@ -89,9 +89,10 @@ namespace QuickFix
                     TcpClient client = tcpListener_.AcceptTcpClient();
                     ApplySocketOptions(client, socketSettings_);
                     ClientHandlerThread t = new ClientHandlerThread(client, nextClientId_++, sessionDict_, socketSettings_);
+                    t.Exited += OnClientHandlerThreadExited;
                     lock (sync_)
                     {
-                        clientThreads_.AddLast(t);
+                        clientThreads_.Add(t.Id, t);
                     }
                     // FIXME set the client thread's exception handler here
                     t.Log("connected");
@@ -104,6 +105,20 @@ namespace QuickFix
                 }
             }
             ShutdownClientHandlerThreads();
+        }
+
+        public void OnClientHandlerThreadExited(object sender, ClientHandlerThread.ExitedEventArgs e)
+        {
+            lock(sync_)
+            {
+                ClientHandlerThread t = null;
+                if(clientThreads_.TryGetValue(e.ClientHandlerThread.Id, out t))
+                {
+                    clientThreads_.Remove(t.Id);
+                    t.Dispose();
+                    t = null;
+                }
+            }
         }
 
         /// <summary>
@@ -123,10 +138,10 @@ namespace QuickFix
                 if (State.SHUTDOWN_COMPLETE != state_)
                 {
                     this.Log("shutting down...");
-                    while (clientThreads_.Count > 0)
+
+                    foreach (ClientHandlerThread t in clientThreads_.Values)
                     {
-                        ClientHandlerThread t = clientThreads_.First.Value;
-                        clientThreads_.RemoveFirst();
+                        t.Exited -= OnClientHandlerThreadExited;
                         t.Shutdown("reactor is shutting down");
                         try
                         {
@@ -136,7 +151,9 @@ namespace QuickFix
                         {
                             t.Log("Error shutting down: " + e.Message);
                         }
+                        t.Dispose();
                     }
+                    clientThreads_.Clear();
                     state_ = State.SHUTDOWN_COMPLETE;
                 }
             }

--- a/QuickFIXn/ThreadedSocketReactor.cs
+++ b/QuickFIXn/ThreadedSocketReactor.cs
@@ -107,7 +107,7 @@ namespace QuickFix
             ShutdownClientHandlerThreads();
         }
 
-        public void OnClientHandlerThreadExited(object sender, ClientHandlerThread.ExitedEventArgs e)
+        internal void OnClientHandlerThreadExited(object sender, ClientHandlerThread.ExitedEventArgs e)
         {
             lock(sync_)
             {


### PR DESCRIPTION
Previously did not dispose of its FileLog handle, etc.
Verified in Resource Monitor that resources are released when clients disconnect.

See #255.