### PR TITLE
Fix for issue #340 (TreadedSocketAcceptor does not dispose underlying sessions on stop)

### DIFF
--- a/QuickFIXn/IAcceptor.cs
+++ b/QuickFIXn/IAcceptor.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System;
+using System.Net;
 using System.Collections.Generic;
 
 namespace QuickFix
@@ -6,7 +7,7 @@ namespace QuickFix
     /// <summary>
     /// Accepts connections from FIX clients and manages the associated sessions.
     /// </summary>
-    public interface IAcceptor
+    public interface IAcceptor : IDisposable
     {
         /// <summary>
         /// Start accepting connections

--- a/QuickFIXn/ThreadedSocketAcceptor.cs
+++ b/QuickFIXn/ThreadedSocketAcceptor.cs
@@ -68,6 +68,7 @@ namespace QuickFix
         private Dictionary<IPEndPoint, AcceptorSocketDescriptor> socketDescriptorForAddress_ = new Dictionary<IPEndPoint, AcceptorSocketDescriptor>();
         private SessionFactory sessionFactory_;
         private bool isStarted_ = false;
+        private bool _disposed = false;
         private object sync_ = new object();
 
         #region Constructors
@@ -286,12 +287,23 @@ namespace QuickFix
             */
         }
 
+        private void DisposeSessions()
+        {
+            foreach (var session in sessions_.Values)
+            {
+                session.Dispose();
+            }
+        }
+
         #endregion
 
         #region Acceptor Members
 
         public void Start()
         {
+            if (_disposed)
+                throw new ObjectDisposedException(GetType().Name);
+
             lock (sync_)
             {
                 if (!isStarted_)
@@ -309,8 +321,14 @@ namespace QuickFix
 
         public void Stop(bool force)
         {
+            if (_disposed)
+                throw new ObjectDisposedException(GetType().Name);
+
             StopAcceptingConnections();
             LogoutAllSessions(force);
+            DisposeSessions();
+            sessions_.Clear();
+
             /// FIXME StopSessionTimer();
             /// FIXME Session.UnregisterSessions(GetSessions());
         }
@@ -346,5 +364,34 @@ namespace QuickFix
         }
 
         #endregion
+
+        /// <summary>
+        /// Any subclasses of ThreadedSocketAcceptor should override this if they have resources to dispose
+        /// Any override should call base.Dispose(disposing).
+        /// </summary>
+        /// <param name="disposing"></param>
+        protected virtual void Dispose(bool disposing)
+        {
+            try
+            {
+                Stop();
+                _disposed = true;
+            }
+            catch (ObjectDisposedException)
+            {
+                // ignore
+            }
+        }
+
+        /// <summary>
+        /// Disposes created sessions
+        /// </summary>
+        /// <remarks>
+        /// To simply stop the acceptor without disposing sessions, use Stop() or Stop(bool)
+        /// </remarks>
+        public void Dispose()
+        {
+            Stop();
+        }
     }
 }

--- a/UnitTests/ThreadedSocketAcceptorTests.cs
+++ b/UnitTests/ThreadedSocketAcceptorTests.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+using QuickFix;
+
+namespace UnitTests
+{
+    [TestFixture]
+    public class ThreadedSocketAcceptorTests
+    {
+        private const string Config = @"
+[DEFAULT]
+StartTime = 00:00:00
+EndTime = 23:59:59
+ConnectionType = acceptor
+SocketAcceptHost = 127.0.0.1
+SocketAcceptPort = 10000
+FileStorePath = store
+FileLogPath = log
+UseDataDictionary = N
+
+[SESSION]
+SenderCompID = sender
+TargetCompID = target
+BeginString = FIX.4.4
+";
+
+        private static SessionSettings CreateSettings()
+        {
+            return new SessionSettings(new StringReader(Config));
+        }
+
+        private static ThreadedSocketAcceptor CreateAcceptor()
+        {
+            var settings = CreateSettings();
+            return new ThreadedSocketAcceptor(
+                new NullApplication(),
+                new FileStoreFactory(settings),
+                settings,
+                new FileLogFactory(settings));
+        }
+
+        [Test]
+        public void TestRecreation()
+        {
+            StartStopAcceptor();
+            StartStopAcceptor();
+            StartStopAcceptor();
+        }
+
+        private static void StartStopAcceptor()
+        {
+            var acceptor = CreateAcceptor();
+            acceptor.Start();
+            acceptor.Dispose();
+        }
+    }
+}

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -107,6 +107,7 @@
     <Compile Include="SessionTest.cs" />
     <Compile Include="SettingsTest.cs" />
     <Compile Include="StringUTF8Tests.cs" />
+    <Compile Include="ThreadedSocketAcceptorTests.cs" />
     <Compile Include="Util\UtcDateTimeSerializerTests.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
`IAcceptor` now derives from `IDisposable`
`ThreadedSocketAcceptor` disposes the underlying sessions on stop
Unit tests added

(https://github.com/connamara/quickfixn/issues/340)