### PR TITLE
20150918 - CE - Fix "SetGroup" to correctly include repeating groups …

### DIFF
--- a/QuickFIXn/Message/Message.cs
+++ b/QuickFIXn/Message/Message.cs
@@ -491,7 +491,7 @@ namespace QuickFix
             {
                 grpPos = pos;
                 StringField f = ExtractField(msgstr, ref pos, sessionDataDictionary, appDD);
-                if (f.Tag == grpEntryDelimiterTag)
+                if (f.Tag == grpEntryDelimiterTag || (dd.IsField(f.Tag) && (grp == null || grp.IsSetField(f.Tag))))
                 {
                     // This is the start of a group entry.
 


### PR DESCRIPTION
…that do not begin with delimerTag.

We found an issue when this code was not present.  The issue would develop into an infinite loop because of BodyLength() not matching receivedBodyLength in Validate() function.

(error when getting following as part of message ....  453=3 448=X 447=X 452=X 447=X  447X .....
