### PR TITLE
Transform the beginString into the the correct spec file name. Before…

### DIFF
--- a/QuickFIXn/SessionFactory.cs
+++ b/QuickFIXn/SessionFactory.cs
@@ -137,7 +137,7 @@ namespace QuickFix
             if (settings.Has(settingsKey))
                 path = settings.GetString(settingsKey);
             else
-                path = beginString.Replace("\\.", "") + ".xml";
+                path = beginString.Replace(".", "") + ".xml";
 
             if (!dictionariesByPath_.TryGetValue(path, out dd))
             {


### PR DESCRIPTION
… the change FIX.4.2 becomes FIX.4.2.xml. After the change FIX.4.2 becomes FIX42.xml, which agrees with the file name in the spec file.