### PR TITLE
Use Cake build system to reduce unnecessary dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ Examples/SimpleAcceptor/obj/*
 upload_to_s3.rb
 *~
 *.suo
+tools/

--- a/build.cake
+++ b/build.cake
@@ -1,6 +1,4 @@
-#tool "nuget:?package=NUnit.Runners&version=2.6.0"
-
-using System.Xml.Xsl;
+#tool "nuget:?package=NUnit.Runners&version=2.6.4"
 
 var target = Argument<string>("target", "Default");
 var buildTarget = Argument<string>("buildTarget", "Rebuild");
@@ -35,22 +33,12 @@ Task("Unit-Tests")
             Error(exception.Message);
         }
         
-        XsltProcessor("TestResult.xml", "../../nunit.xsl", "UnitTests.html");
+        XmlTransform(File("../../nunit.xsl"), File("TestResult.xml"), File("UnitTests.html"));
     }
 });
 
 Task("Default")
     .IsDependentOn("Unit-Tests");
-
-// As suggested here: https://github.com/connamara/quickfixn/issues/104
-public void XsltProcessor(string inputFile, string styleSheet, string outputFile)
-{
-    var xslTransform = new XslCompiledTransform();
-
-    xslTransform.Load(styleSheet);
-    
-    xslTransform.Transform(inputFile, outputFile);
-}
 
 class CurrentDirectory : IDisposable
 {

--- a/build.cake
+++ b/build.cake
@@ -1,0 +1,71 @@
+#tool "nuget:?package=NUnit.Runners&version=2.6.0"
+
+using System.Xml.Xsl;
+
+var target = Argument<string>("target", "Default");
+var buildTarget = Argument<string>("buildTarget", "Rebuild");
+var buildConfiguration = Argument<string>("buildConfiguration", "Release");
+var netVersion = Argument<string>("netVersion", "v3.5");
+
+Task("Build")
+    .Does(() =>
+{
+    DotNetBuild("./QuickFIXn.sln", settings => settings
+        .WithTarget(buildTarget)
+        .SetConfiguration(buildConfiguration)
+        .WithProperty("TargetFrameworkVersion", netVersion));
+});
+
+Task("Unit-Tests")
+    .IsDependentOn("Build")
+    .Does(() =>
+{
+    using (new CurrentDirectory("UnitTests/bin/Release/"))
+    {
+        DeleteFiles("TestResult.xml");
+        DeleteFiles("UnitTests.html");
+        
+        try 
+        {
+            NUnit("UnitTests.dll");
+        } 
+        catch (Exception exception) 
+        {
+            // Report Nunit exit code -100 (unhandled exceptions in test assembly)
+            Error(exception.Message);
+        }
+        
+        XsltProcessor("TestResult.xml", "../../nunit.xsl", "UnitTests.html");
+    }
+});
+
+Task("Default")
+    .IsDependentOn("Unit-Tests");
+
+// As suggested here: https://github.com/connamara/quickfixn/issues/104
+public void XsltProcessor(string inputFile, string styleSheet, string outputFile)
+{
+    var xslTransform = new XslCompiledTransform();
+
+    xslTransform.Load(styleSheet);
+    
+    xslTransform.Transform(inputFile, outputFile);
+}
+
+class CurrentDirectory : IDisposable
+{
+    private readonly string previousCurrentDir;
+    
+    public CurrentDirectory(string currentDirectory)
+    {
+        previousCurrentDir = System.IO.Directory.GetCurrentDirectory();
+        Environment.CurrentDirectory = currentDirectory;
+    }
+    
+    public void Dispose()
+    {
+        Environment.CurrentDirectory =  previousCurrentDir;
+    }
+}
+
+RunTarget(target);

--- a/build.cake
+++ b/build.cake
@@ -22,16 +22,8 @@ Task("Unit-Tests")
     {
         DeleteFiles("TestResult.xml");
         DeleteFiles("UnitTests.html");
-        
-        try 
-        {
-            NUnit("UnitTests.dll");
-        } 
-        catch (Exception exception) 
-        {
-            // Report Nunit exit code -100 (unhandled exceptions in test assembly)
-            Error(exception.Message);
-        }
+
+        NUnit("UnitTests.dll");
         
         XmlTransform(File("../../nunit.xsl"), File("TestResult.xml"), File("UnitTests.html"));
     }

--- a/buildcake.ps1
+++ b/buildcake.ps1
@@ -1,0 +1,145 @@
+##########################################################################
+# This is the Cake bootstrapper script for PowerShell.
+# This file was downloaded from https://github.com/cake-build/resources
+# Feel free to change this file to fit your needs.
+##########################################################################
+
+<#
+
+.SYNOPSIS
+This is a Powershell script to bootstrap a Cake build.
+
+.DESCRIPTION
+This Powershell script will download NuGet if missing, restore NuGet tools (including Cake)
+and execute your Cake build script with the parameters you provide.
+
+.PARAMETER Script
+The build script to execute.
+.PARAMETER Target
+The build script target to run.
+.PARAMETER Configuration
+The build configuration to use.
+.PARAMETER Verbosity
+Specifies the amount of information to be displayed.
+.PARAMETER Experimental
+Tells Cake to use the latest Roslyn release.
+.PARAMETER WhatIf
+Performs a dry run of the build script.
+No tasks will be executed.
+.PARAMETER Mono
+Tells Cake to use the Mono scripting engine.
+.PARAMETER SkipToolPackageRestore
+Skips restoring of packages.
+.PARAMETER ScriptArgs
+Remaining arguments are added here.
+
+.LINK
+http://cakebuild.net
+
+#>
+
+[CmdletBinding()]
+Param(
+    [string]$Script = "build.cake",
+    [string]$Target = "Default",
+    [string]$Configuration = "Release",
+    [ValidateSet("Quiet", "Minimal", "Normal", "Verbose", "Diagnostic")]
+    [string]$Verbosity = "Verbose",
+    [switch]$Experimental,
+    [Alias("DryRun","Noop")]
+    [switch]$WhatIf,
+    [switch]$Mono,
+    [switch]$SkipToolPackageRestore,
+    [Parameter(Position=0,Mandatory=$false,ValueFromRemainingArguments=$true)]
+    [string[]]$ScriptArgs
+)
+
+Write-Host "Preparing to run build script..."
+
+$PSScriptRoot = split-path -parent $MyInvocation.MyCommand.Definition;
+$TOOLS_DIR = Join-Path $PSScriptRoot "tools"
+$NUGET_EXE = Join-Path $TOOLS_DIR "nuget.exe"
+$NUGET_URL = "http://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
+$CAKE_EXE = Join-Path $TOOLS_DIR "Cake/Cake.exe"
+$PACKAGES_CONFIG = Join-Path $TOOLS_DIR "packages.config"
+
+# Should we use mono?
+$UseMono = "";
+if($Mono.IsPresent) {
+    Write-Verbose -Message "Using the Mono based scripting engine."
+    $UseMono = "-mono"
+}
+
+# Should we use the new Roslyn?
+$UseExperimental = "";
+if($Experimental.IsPresent -and !($Mono.IsPresent)) {
+    Write-Verbose -Message "Using experimental version of Roslyn."
+    $UseExperimental = "-experimental"
+}
+
+# Is this a dry run?
+$UseDryRun = "";
+if($WhatIf.IsPresent) {
+    $UseDryRun = "-dryrun"
+}
+
+# Make sure tools folder exists
+if ((Test-Path $PSScriptRoot) -and !(Test-Path $TOOLS_DIR)) {
+    Write-Verbose -Message "Creating tools directory..."
+    New-Item -Path $TOOLS_DIR -Type directory | out-null
+}
+
+# Make sure that packages.config exist.
+if (!(Test-Path $PACKAGES_CONFIG)) {
+    Write-Verbose -Message "Downloading packages.config..."
+    try { Invoke-WebRequest -Uri http://cakebuild.net/download/bootstrapper/packages -OutFile $PACKAGES_CONFIG } catch {
+        Throw "Could not download packages.config."
+    }
+}
+
+# Try find NuGet.exe in path if not exists
+if (!(Test-Path $NUGET_EXE)) {
+    Write-Verbose -Message "Trying to find nuget.exe in PATH..."
+    $existingPaths = $Env:Path -Split ';' | Where-Object { (![string]::IsNullOrEmpty($_)) -and (Test-Path $_) }
+    $NUGET_EXE_IN_PATH = Get-ChildItem -Path $existingPaths -Filter "nuget.exe" | Select -First 1
+    if ($NUGET_EXE_IN_PATH -ne $null -and (Test-Path $NUGET_EXE_IN_PATH.FullName)) {
+        Write-Verbose -Message "Found in PATH at $($NUGET_EXE_IN_PATH.FullName)."
+        $NUGET_EXE = $NUGET_EXE_IN_PATH.FullName
+    }
+}
+
+# Try download NuGet.exe if not exists
+if (!(Test-Path $NUGET_EXE)) {
+    Write-Verbose -Message "Downloading NuGet.exe..."
+    try {
+        (New-Object System.Net.WebClient).DownloadFile($NUGET_URL, $NUGET_EXE)
+    } catch {
+        Throw "Could not download NuGet.exe."
+    }
+}
+
+# Save nuget.exe path to environment to be available to child processed
+$ENV:NUGET_EXE = $NUGET_EXE
+
+# Restore tools from NuGet?
+if(-Not $SkipToolPackageRestore.IsPresent) {
+    Push-Location
+    Set-Location $TOOLS_DIR
+    Write-Verbose -Message "Restoring tools from NuGet..."
+    $NuGetOutput = Invoke-Expression "&`"$NUGET_EXE`" install -ExcludeVersion -OutputDirectory `"$TOOLS_DIR`""
+    if ($LASTEXITCODE -ne 0) {
+        Throw "An error occured while restoring NuGet tools."
+    }
+    Write-Verbose -Message ($NuGetOutput | out-string)
+    Pop-Location
+}
+
+# Make sure that Cake has been installed.
+if (!(Test-Path $CAKE_EXE)) {
+    Throw "Could not find Cake.exe at $CAKE_EXE"
+}
+
+# Start Cake
+Write-Host "Running build script..."
+Invoke-Expression "& `"$CAKE_EXE`" `"$Script`" -target=`"$Target`" -configuration=`"$Configuration`" -verbosity=`"$Verbosity`" $UseMono $UseDryRun $UseExperimental $ScriptArgs"
+exit $LASTEXITCODE1

--- a/buildcake.sh
+++ b/buildcake.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+##########################################################################
+# This is the Cake bootstrapper script for Linux and OS X.
+# This file was downloaded from https://github.com/cake-build/resources
+# Feel free to change this file to fit your needs.
+##########################################################################
+
+# Define directories.
+SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+TOOLS_DIR=$SCRIPT_DIR/tools
+NUGET_EXE=$TOOLS_DIR/nuget.exe
+CAKE_EXE=$TOOLS_DIR/Cake/Cake.exe
+
+# Define default arguments.
+SCRIPT="build.cake"
+TARGET="Default"
+CONFIGURATION="Release"
+VERBOSITY="verbose"
+DRYRUN=
+SHOW_VERSION=false
+SCRIPT_ARGUMENTS=()
+
+# Parse arguments.
+for i in "$@"; do
+    case $1 in
+        -s|--script) SCRIPT="$2"; shift ;;
+        -t|--target) TARGET="$2"; shift ;;
+        -c|--configuration) CONFIGURATION="$2"; shift ;;
+        -v|--verbosity) VERBOSITY="$2"; shift ;;
+        -d|--dryrun) DRYRUN="-dryrun" ;;
+        --version) SHOW_VERSION=true ;;
+        --) shift; SCRIPT_ARGUMENTS+=("$@"); break ;;
+        *) SCRIPT_ARGUMENTS+=("$1") ;;
+    esac
+    shift
+done
+
+# Make sure the tools folder exist.
+if [ ! -d "$TOOLS_DIR" ]; then
+  mkdir "$TOOLS_DIR"
+fi
+
+# Make sure that packages.config exist.
+if [ ! -f "$TOOLS_DIR/packages.config" ]; then
+    echo "Downloading packages.config..."
+    curl -Lsfo "$TOOLS_DIR/packages.config" http://cakebuild.net/download/bootstrapper/packages
+    if [ $? -ne 0 ]; then
+        echo "An error occured while downloading packages.config."
+        exit 1
+    fi
+fi
+
+# Download NuGet if it does not exist.
+if [ ! -f "$NUGET_EXE" ]; then
+    echo "Downloading NuGet..."
+    curl -Lsfo "$NUGET_EXE" https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
+    if [ $? -ne 0 ]; then
+        echo "An error occured while downloading nuget.exe."
+        exit 1
+    fi
+fi
+
+# Restore tools from NuGet.
+pushd "$TOOLS_DIR" >/dev/null
+mono "$NUGET_EXE" install -ExcludeVersion
+if [ $? -ne 0 ]; then
+    echo "Could not restore NuGet packages."
+    exit 1
+fi
+popd >/dev/null
+
+# Make sure that Cake has been installed.
+if [ ! -f "$CAKE_EXE" ]; then
+    echo "Could not find Cake.exe at '$CAKE_EXE'."
+    exit 1
+fi
+
+# Start Cake
+if $SHOW_VERSION; then
+    exec mono "$CAKE_EXE" -version
+else
+    exec mono "$CAKE_EXE" $SCRIPT -verbosity=$VERBOSITY -configuration=$CONFIGURATION -target=$TARGET $DRYRUN "${SCRIPT_ARGUMENTS[@]}"
+fi


### PR DESCRIPTION
This pull request introduces Cake build system. For now build and unit-test targets were rewritten. This change allows remove dependency on xsltproc (possibly in future Ruby as well). At this point old build scripts (build.bat, build.sh, unit_test.bat, unit_test.sh) can be removed. This change was tested on Windows and Linux (mono) as well. No packages (cake, nuget, nunit) are initially required, cake bootstrapper (buildcake.ps1, buildcake.sh) will download them automatically.

Notes:
- On Linux i was able to build with .Net 4.0 target / v3.5 doesn't work  (probably not an issue/I have the same problem while using current build.sh)

- On Windows passing parameters to default cake bootstrapper is a bit tricky:  
`./buildcake.ps1 "--netVersion='v4.0'"` 

  this can be change by modifying default bootstrapper powershell script