### PR TITLE
Multithreading fix to please NUnit 2.6.3 and above

### DIFF
--- a/QuickFIXn/ThreadedSocketReactor.cs
+++ b/QuickFIXn/ThreadedSocketReactor.cs
@@ -81,7 +81,12 @@ namespace QuickFix
         /// </summary>
         public void Run()
         {
-            tcpListener_.Start();
+            lock (sync_)
+            {
+                if (State.SHUTDOWN_REQUESTED != state_)
+                    tcpListener_.Start();
+            }
+
             while (State.RUNNING == ReactorState)
             {
                 try


### PR DESCRIPTION
This PR fixes issue #401. Because of slightly different threads orchestration in different versions on NUnit this bug was not observed before. In unit test ThreadedSocketAcceptorTests.TestRecreation there is sequence of calls: `acceptor.Start(); acceptor.Dispose();` Internally in ThreadedSocketReactor Start() method creates new Thread with method Run. That method may not yet be executed while calling Dispose (on acceptor) right after Start call. This leads to unhandled exception from #401 issue.