### PR TITLE
Encode and decode strings leaving byte values including those from 128-255 intact

### DIFF
--- a/QuickFIXn/SocketInitiatorThread.cs
+++ b/QuickFIXn/SocketInitiatorThread.cs
@@ -81,7 +81,7 @@ namespace QuickFix
             {
                 int bytesRead = ReadSome(readBuffer_, 1000);
                 if (bytesRead > 0)
-                    parser_.AddToStream(System.Text.Encoding.UTF8.GetString(readBuffer_, 0, bytesRead));
+                    parser_.AddToStream(readBuffer_, 0, bytesRead);
                 else if (null != session_)
                 {
                     session_.Next();

--- a/QuickFIXn/SocketReader.cs
+++ b/QuickFIXn/SocketReader.cs
@@ -43,7 +43,7 @@ namespace QuickFix
             {
                 int bytesRead = ReadSome(readBuffer_, 1000);
                 if (bytesRead > 0)
-                    parser_.AddToStream(System.Text.Encoding.UTF8.GetString(readBuffer_, 0, bytesRead));
+                    parser_.AddToStream(readBuffer_, 0, bytesRead);
                 else if (null != qfSession_)
                 {
                     qfSession_.Next();


### PR DESCRIPTION
This is the first of two steps to correctly implement the DATA type as defined in http://www.fixtradingcommunity.org/FIXimate/FIXimate3.0/en/FIX.4.4/fix_datatypes.html

> DATA 
> 
> Raw data with no format or content restrictions. Data fields are always immediately preceded by a length field. The length field should specify the number of bytes of the value of the data field (up to but not including the terminating SOH). Caution: the value of one of these fields may contain the delimiter (SOH) character. Note that the value specified for this field should be followed by the delimiter (SOH) character as all fields are terminated with an "SOH".
> 

This first step preserves the whole byte range of the FIX stream, including the byte range of 128-255 currently mangled due to Utf8 conversion. We now use an 8 bit transparent encoding, Latin-1. That does NOT mean strings have to be Latin-1. It means whatever characters in the range of 0-255 are put on the wire will be put back into the decoded string as-is.

QuickFIX/n users can write/read non-ASCII fields thusly:

```
// we cannot use ASCII or UTF-8 etc., as they mangle bytes > 7F,
static readonly Encoding _8BitTranspEnc = Encoding.GetEncoding("iso-8859-1");

static string Serialize(string s, Encoding enc)
{
    return _8BitTranspEnc.GetString(enc.GetBytes(s));
}

static string Deserialize(string s, Encoding enc)
{
    return enc.GetString(_8BitTranspEnc.GetBytes(s));
}

void Example()
{
    // we use UTF-8 here, but this can be any encoding
    Encoding myEncoding = new UTF8Encoding(false);

            
    // write encoded text
    string str = "Olé!漢字もできるんだ";
    message.SetField(new EncodedText(Serialize(str, myEncoding)));

    // read encoded text
    string encodedStr = message.GetField(Tags.EncodedText);
    string unencodedStr = Deserialize(encodedStr, myEncoding);
}
```
Still, the parser is not yet able to handle SOH bytes inside a DATA field. That fix has to wait for another day, as it requires quite a bit of refactoring of the Parser class. That refactoring might include converting the parser to work on byte streams internally, not on strings, for reasons of efficiency (memory and cpu).

Related to #41 #97 #100 #155 #156 #216 #217 #285

Note that this change may break users who (for whatever reason) assumed that QuickFIX would (as it in fact does, without this change) treat the bytes on the FIX stream as a UTF-8 encoded string.

But in general, FIX string values are 7 Bit ASCII. For cases where ASCII does not suffice, the "Encoded" fields like e.g. EncodedText (355), the non-ASCII equivalent of Text (58), got added. There is also MessageEncoding (347) to explicitly set the encoding of a message's "Encoded" fields. In the wild, I have seen specifications that use "Encoded" fields, but omit MessageEncoding (347), i.e. the encoding is specified out-of-band, in the specification document.

In any event, anyone relying on QuickFIX/n using the UTF-8 encoding would have to upgrade their code to do something along the lines of above example. Though this change may break some of those users, it will allow other users to use QuickFIX/n that cannot use the current version - I'm one of those, as the FIX format I currently have to implement uses Shift-JIS encoding.
