### PR TITLE
generator doc update + deletion script

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ Code Generation
 ---------------
 To regenerate the message and field class source from the Data Dictionaries, you need Ruby and the Nokogiri gem:
 
-    gem install nokogiri
+    gem install nokogiri -v 1.6.8.1
     generate.bat
+
+(Nokogiri versions 1.7+ require Ruby 2.0, so we must use this older version.)
 
 
 Build

--- a/generator/delete-generated
+++ b/generator/delete-generated
@@ -1,0 +1,33 @@
+#!/usr/bin/env ruby
+
+require 'fileutils'
+
+FILE_ROOT = File.expand_path('../../QuickFIXn', __FILE__)
+
+puts "FILE_ROOT: #{FILE_ROOT}"
+
+files_to_delete = [
+  File.join(FILE_ROOT, 'FixMessages.csproj'),
+  File.join(FILE_ROOT, 'Fields/Fields.cs'),
+  File.join(FILE_ROOT, 'Fields/FieldTags.cs')
+]
+
+dir_pattern = File.join(FILE_ROOT, 'Message/FIX*')
+dirs_to_delete = Dir.glob(dir_pattern)
+
+
+puts '--Deleting generated code--'
+puts 'Files:'
+
+files_to_delete.each do |f|
+  puts "* Attempting to delete file: #{f}"
+  File.delete f
+end
+
+puts 'Dirs:'
+
+dirs_to_delete.each do |d|
+  puts "* Attempting to delete directory: #{d}/"
+  FileUtils.rm_r d
+end
+


### PR DESCRIPTION
Add a script to delete all generated files, which is useful to verify that future generator revisions are going to recreate everything that needs recreating.

Also document which nokogiri version is compatible with Ruby 1.9.3.