### PR TITLE
remove wonky whitespace from generated message classes

### DIFF
--- a/QuickFIXn/Message/FIX40/Advertisement.cs
+++ b/QuickFIXn/Message/FIX40/Advertisement.cs
@@ -494,7 +494,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.Text);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX40/Allocation.cs
+++ b/QuickFIXn/Message/FIX40/Allocation.cs
@@ -886,7 +886,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ClOrdID ClOrdID
+                public QuickFix.Fields.ClOrdID ClOrdID
                 { 
                     get 
                     {
@@ -1028,7 +1028,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ExecID ExecID
+                public QuickFix.Fields.ExecID ExecID
                 { 
                     get 
                     {
@@ -1170,7 +1170,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
+                public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
                 { 
                     get 
                     {
@@ -1281,7 +1281,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AllocAccount AllocAccount
+                public QuickFix.Fields.AllocAccount AllocAccount
                 { 
                     get 
                     {
@@ -1545,7 +1545,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.BrokerOfCredit BrokerOfCredit
+                    public QuickFix.Fields.BrokerOfCredit BrokerOfCredit
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX40/AllocationACK.cs
+++ b/QuickFIXn/Message/FIX40/AllocationACK.cs
@@ -273,7 +273,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.Text);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX40/DontKnowTrade.cs
+++ b/QuickFIXn/Message/FIX40/DontKnowTrade.cs
@@ -310,7 +310,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.Text);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX40/Email.cs
+++ b/QuickFIXn/Message/FIX40/Email.cs
@@ -285,7 +285,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Text Text
+                public QuickFix.Fields.Text Text
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX40/ExecutionReport.cs
+++ b/QuickFIXn/Message/FIX40/ExecutionReport.cs
@@ -1452,7 +1452,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
+                public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX40/Heartbeat.cs
+++ b/QuickFIXn/Message/FIX40/Heartbeat.cs
@@ -46,7 +46,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.TestReqID);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX40/IndicationofInterest.cs
+++ b/QuickFIXn/Message/FIX40/IndicationofInterest.cs
@@ -618,7 +618,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.Text);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX40/ListCancelRequest.cs
+++ b/QuickFIXn/Message/FIX40/ListCancelRequest.cs
@@ -114,7 +114,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.Text);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX40/ListExecute.cs
+++ b/QuickFIXn/Message/FIX40/ListExecute.cs
@@ -114,7 +114,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.Text);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX40/ListStatus.cs
+++ b/QuickFIXn/Message/FIX40/ListStatus.cs
@@ -196,7 +196,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ClOrdID ClOrdID
+                public QuickFix.Fields.ClOrdID ClOrdID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX40/ListStatusRequest.cs
+++ b/QuickFIXn/Message/FIX40/ListStatusRequest.cs
@@ -114,7 +114,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.Text);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX40/Logon.cs
+++ b/QuickFIXn/Message/FIX40/Logon.cs
@@ -147,7 +147,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.RawData);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX40/Logout.cs
+++ b/QuickFIXn/Message/FIX40/Logout.cs
@@ -46,7 +46,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.Text);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX40/NewOrderList.cs
+++ b/QuickFIXn/Message/FIX40/NewOrderList.cs
@@ -1246,7 +1246,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.Text);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX40/NewOrderSingle.cs
+++ b/QuickFIXn/Message/FIX40/NewOrderSingle.cs
@@ -1147,7 +1147,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.Text);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX40/News.cs
+++ b/QuickFIXn/Message/FIX40/News.cs
@@ -217,7 +217,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Text Text
+                public QuickFix.Fields.Text Text
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX40/OrderCancelReject.cs
+++ b/QuickFIXn/Message/FIX40/OrderCancelReject.cs
@@ -240,7 +240,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.Text);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX40/OrderCancelReplaceRequest.cs
+++ b/QuickFIXn/Message/FIX40/OrderCancelReplaceRequest.cs
@@ -1087,7 +1087,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.Text);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX40/OrderCancelRequest.cs
+++ b/QuickFIXn/Message/FIX40/OrderCancelRequest.cs
@@ -527,7 +527,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.Text);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX40/OrderStatusRequest.cs
+++ b/QuickFIXn/Message/FIX40/OrderStatusRequest.cs
@@ -304,7 +304,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.Side);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX40/Quote.cs
+++ b/QuickFIXn/Message/FIX40/Quote.cs
@@ -428,7 +428,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.ValidUntilTime);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX40/QuoteRequest.cs
+++ b/QuickFIXn/Message/FIX40/QuoteRequest.cs
@@ -333,7 +333,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.OrderQty);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX40/Reject.cs
+++ b/QuickFIXn/Message/FIX40/Reject.cs
@@ -83,7 +83,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.Text);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX40/ResendRequest.cs
+++ b/QuickFIXn/Message/FIX40/ResendRequest.cs
@@ -85,7 +85,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EndSeqNo);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX40/SequenceReset.cs
+++ b/QuickFIXn/Message/FIX40/SequenceReset.cs
@@ -83,7 +83,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.NewSeqNo);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX40/TestRequest.cs
+++ b/QuickFIXn/Message/FIX40/TestRequest.cs
@@ -52,7 +52,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.TestReqID);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX41/Advertisement.cs
+++ b/QuickFIXn/Message/FIX41/Advertisement.cs
@@ -804,7 +804,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.LastMkt);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX41/Allocation.cs
+++ b/QuickFIXn/Message/FIX41/Allocation.cs
@@ -1165,7 +1165,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ClOrdID ClOrdID
+                public QuickFix.Fields.ClOrdID ClOrdID
                 { 
                     get 
                     {
@@ -1338,7 +1338,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LastShares LastShares
+                public QuickFix.Fields.LastShares LastShares
                 { 
                     get 
                     {
@@ -1480,7 +1480,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AllocAccount AllocAccount
+                public QuickFix.Fields.AllocAccount AllocAccount
                 { 
                     get 
                     {
@@ -2116,7 +2116,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
+                    public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX41/AllocationACK.cs
+++ b/QuickFIXn/Message/FIX41/AllocationACK.cs
@@ -273,7 +273,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.Text);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX41/DontKnowTrade.cs
+++ b/QuickFIXn/Message/FIX41/DontKnowTrade.cs
@@ -707,7 +707,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.Text);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX41/Email.cs
+++ b/QuickFIXn/Message/FIX41/Email.cs
@@ -351,7 +351,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RelatdSym RelatdSym
+                public QuickFix.Fields.RelatdSym RelatdSym
                 { 
                     get 
                     {
@@ -772,7 +772,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Text Text
+                public QuickFix.Fields.Text Text
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX41/ExecutionReport.cs
+++ b/QuickFIXn/Message/FIX41/ExecutionReport.cs
@@ -1812,7 +1812,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.Text);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX41/Heartbeat.cs
+++ b/QuickFIXn/Message/FIX41/Heartbeat.cs
@@ -46,7 +46,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.TestReqID);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX41/IndicationofInterest.cs
+++ b/QuickFIXn/Message/FIX41/IndicationofInterest.cs
@@ -913,7 +913,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.IOIQualifier IOIQualifier
+                public QuickFix.Fields.IOIQualifier IOIQualifier
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX41/ListCancelRequest.cs
+++ b/QuickFIXn/Message/FIX41/ListCancelRequest.cs
@@ -114,7 +114,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.Text);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX41/ListExecute.cs
+++ b/QuickFIXn/Message/FIX41/ListExecute.cs
@@ -114,7 +114,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.Text);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX41/ListStatus.cs
+++ b/QuickFIXn/Message/FIX41/ListStatus.cs
@@ -196,7 +196,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ClOrdID ClOrdID
+                public QuickFix.Fields.ClOrdID ClOrdID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX41/ListStatusRequest.cs
+++ b/QuickFIXn/Message/FIX41/ListStatusRequest.cs
@@ -114,7 +114,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.Text);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX41/Logon.cs
+++ b/QuickFIXn/Message/FIX41/Logon.cs
@@ -178,7 +178,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.ResetSeqNumFlag);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX41/Logout.cs
+++ b/QuickFIXn/Message/FIX41/Logout.cs
@@ -46,7 +46,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.Text);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX41/NewOrderList.cs
+++ b/QuickFIXn/Message/FIX41/NewOrderList.cs
@@ -1680,7 +1680,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.MaxShow);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX41/NewOrderSingle.cs
+++ b/QuickFIXn/Message/FIX41/NewOrderSingle.cs
@@ -1610,7 +1610,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.PegDifference);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX41/News.cs
+++ b/QuickFIXn/Message/FIX41/News.cs
@@ -285,7 +285,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RelatdSym RelatdSym
+                public QuickFix.Fields.RelatdSym RelatdSym
                 { 
                     get 
                     {
@@ -706,7 +706,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Text Text
+                public QuickFix.Fields.Text Text
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX41/OrderCancelReject.cs
+++ b/QuickFIXn/Message/FIX41/OrderCancelReject.cs
@@ -337,7 +337,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.Text);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX41/OrderCancelReplaceRequest.cs
+++ b/QuickFIXn/Message/FIX41/OrderCancelReplaceRequest.cs
@@ -1581,7 +1581,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.LocateReqd);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX41/OrderCancelRequest.cs
+++ b/QuickFIXn/Message/FIX41/OrderCancelRequest.cs
@@ -740,7 +740,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.Text);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX41/OrderStatusRequest.cs
+++ b/QuickFIXn/Message/FIX41/OrderStatusRequest.cs
@@ -583,7 +583,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.Side);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX41/Quote.cs
+++ b/QuickFIXn/Message/FIX41/Quote.cs
@@ -922,7 +922,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.OrderQty2);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX41/QuoteRequest.cs
+++ b/QuickFIXn/Message/FIX41/QuoteRequest.cs
@@ -674,7 +674,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.OrderQty2);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX41/Reject.cs
+++ b/QuickFIXn/Message/FIX41/Reject.cs
@@ -83,7 +83,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.Text);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX41/ResendRequest.cs
+++ b/QuickFIXn/Message/FIX41/ResendRequest.cs
@@ -85,7 +85,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EndSeqNo);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX41/SequenceReset.cs
+++ b/QuickFIXn/Message/FIX41/SequenceReset.cs
@@ -83,7 +83,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.NewSeqNo);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX41/SettlementInstructions.cs
+++ b/QuickFIXn/Message/FIX41/SettlementInstructions.cs
@@ -1085,7 +1085,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.CashSettlAgentContactPhone);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX41/TestRequest.cs
+++ b/QuickFIXn/Message/FIX41/TestRequest.cs
@@ -52,7 +52,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.TestReqID);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX42/Advertisement.cs
+++ b/QuickFIXn/Message/FIX42/Advertisement.cs
@@ -1083,7 +1083,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.TradingSessionID);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX42/Allocation.cs
+++ b/QuickFIXn/Message/FIX42/Allocation.cs
@@ -1475,7 +1475,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ClOrdID ClOrdID
+                public QuickFix.Fields.ClOrdID ClOrdID
                 { 
                     get 
                     {
@@ -1648,7 +1648,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LastShares LastShares
+                public QuickFix.Fields.LastShares LastShares
                 { 
                     get 
                     {
@@ -1790,7 +1790,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AllocAccount AllocAccount
+                public QuickFix.Fields.AllocAccount AllocAccount
                 { 
                     get 
                     {
@@ -2519,7 +2519,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
+                    public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX42/AllocationACK.cs
+++ b/QuickFIXn/Message/FIX42/AllocationACK.cs
@@ -335,7 +335,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EncodedText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX42/BidRequest.cs
+++ b/QuickFIXn/Message/FIX42/BidRequest.cs
@@ -946,7 +946,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.BidDescriptorType BidDescriptorType
+                public QuickFix.Fields.BidDescriptorType BidDescriptorType
                 { 
                     get 
                     {
@@ -1305,7 +1305,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ListID ListID
+                public QuickFix.Fields.ListID ListID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX42/BidResponse.cs
+++ b/QuickFIXn/Message/FIX42/BidResponse.cs
@@ -124,7 +124,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Commission Commission
+                public QuickFix.Fields.Commission Commission
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX42/BusinessMessageReject.cs
+++ b/QuickFIXn/Message/FIX42/BusinessMessageReject.cs
@@ -240,7 +240,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EncodedText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX42/DontKnowTrade.cs
+++ b/QuickFIXn/Message/FIX42/DontKnowTrade.cs
@@ -959,7 +959,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EncodedText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX42/Email.cs
+++ b/QuickFIXn/Message/FIX42/Email.cs
@@ -444,7 +444,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RoutingType RoutingType
+                public QuickFix.Fields.RoutingType RoutingType
                 { 
                     get 
                     {
@@ -524,7 +524,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RelatdSym RelatdSym
+                public QuickFix.Fields.RelatdSym RelatdSym
                 { 
                     get 
                     {
@@ -1131,7 +1131,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Text Text
+                public QuickFix.Fields.Text Text
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX42/ExecutionReport.cs
+++ b/QuickFIXn/Message/FIX42/ExecutionReport.cs
@@ -2907,7 +2907,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ContraBroker ContraBroker
+                public QuickFix.Fields.ContraBroker ContraBroker
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX42/Heartbeat.cs
+++ b/QuickFIXn/Message/FIX42/Heartbeat.cs
@@ -46,7 +46,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.TestReqID);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX42/IndicationofInterest.cs
+++ b/QuickFIXn/Message/FIX42/IndicationofInterest.cs
@@ -1223,7 +1223,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.IOIQualifier IOIQualifier
+                public QuickFix.Fields.IOIQualifier IOIQualifier
                 { 
                     get 
                     {
@@ -1272,7 +1272,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RoutingType RoutingType
+                public QuickFix.Fields.RoutingType RoutingType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX42/ListCancelRequest.cs
+++ b/QuickFIXn/Message/FIX42/ListCancelRequest.cs
@@ -178,7 +178,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EncodedText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX42/ListExecute.cs
+++ b/QuickFIXn/Message/FIX42/ListExecute.cs
@@ -240,7 +240,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EncodedText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX42/ListStatus.cs
+++ b/QuickFIXn/Message/FIX42/ListStatus.cs
@@ -388,7 +388,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ClOrdID ClOrdID
+                public QuickFix.Fields.ClOrdID ClOrdID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX42/ListStatusRequest.cs
+++ b/QuickFIXn/Message/FIX42/ListStatusRequest.cs
@@ -145,7 +145,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EncodedText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX42/ListStrikePrice.cs
+++ b/QuickFIXn/Message/FIX42/ListStrikePrice.cs
@@ -132,7 +132,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX42/Logon.cs
+++ b/QuickFIXn/Message/FIX42/Logon.cs
@@ -256,7 +256,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RefMsgType RefMsgType
+                public QuickFix.Fields.RefMsgType RefMsgType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX42/Logout.cs
+++ b/QuickFIXn/Message/FIX42/Logout.cs
@@ -108,7 +108,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EncodedText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX42/MarketDataIncrementalRefresh.cs
+++ b/QuickFIXn/Message/FIX42/MarketDataIncrementalRefresh.cs
@@ -93,7 +93,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MDUpdateAction MDUpdateAction
+                public QuickFix.Fields.MDUpdateAction MDUpdateAction
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX42/MarketDataRequest.cs
+++ b/QuickFIXn/Message/FIX42/MarketDataRequest.cs
@@ -258,7 +258,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MDEntryType MDEntryType
+                public QuickFix.Fields.MDEntryType MDEntryType
                 { 
                     get 
                     {
@@ -307,7 +307,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX42/MarketDataRequestReject.cs
+++ b/QuickFIXn/Message/FIX42/MarketDataRequestReject.cs
@@ -176,7 +176,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EncodedText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX42/MarketDataSnapshotFullRefresh.cs
+++ b/QuickFIXn/Message/FIX42/MarketDataSnapshotFullRefresh.cs
@@ -781,7 +781,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MDEntryType MDEntryType
+                public QuickFix.Fields.MDEntryType MDEntryType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX42/MassQuote.cs
+++ b/QuickFIXn/Message/FIX42/MassQuote.cs
@@ -223,7 +223,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.QuoteSetID QuoteSetID
+                public QuickFix.Fields.QuoteSetID QuoteSetID
                 { 
                     get 
                     {
@@ -952,7 +952,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.QuoteEntryID QuoteEntryID
+                    public QuickFix.Fields.QuoteEntryID QuoteEntryID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX42/NewOrderList.cs
+++ b/QuickFIXn/Message/FIX42/NewOrderList.cs
@@ -413,7 +413,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ClOrdID ClOrdID
+                public QuickFix.Fields.ClOrdID ClOrdID
                 { 
                     get 
                     {
@@ -2723,7 +2723,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.AllocAccount AllocAccount
+                    public QuickFix.Fields.AllocAccount AllocAccount
                     { 
                         get 
                         {
@@ -2803,7 +2803,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.TradingSessionID TradingSessionID
+                    public QuickFix.Fields.TradingSessionID TradingSessionID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX42/NewOrderSingle.cs
+++ b/QuickFIXn/Message/FIX42/NewOrderSingle.cs
@@ -2248,7 +2248,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AllocAccount AllocAccount
+                public QuickFix.Fields.AllocAccount AllocAccount
                 { 
                     get 
                     {
@@ -2328,7 +2328,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX42/News.cs
+++ b/QuickFIXn/Message/FIX42/News.cs
@@ -378,7 +378,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RoutingType RoutingType
+                public QuickFix.Fields.RoutingType RoutingType
                 { 
                     get 
                     {
@@ -458,7 +458,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RelatdSym RelatdSym
+                public QuickFix.Fields.RelatdSym RelatdSym
                 { 
                     get 
                     {
@@ -1065,7 +1065,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Text Text
+                public QuickFix.Fields.Text Text
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX42/OrderCancelReject.cs
+++ b/QuickFIXn/Message/FIX42/OrderCancelReject.cs
@@ -494,7 +494,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EncodedText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX42/OrderCancelReplaceRequest.cs
+++ b/QuickFIXn/Message/FIX42/OrderCancelReplaceRequest.cs
@@ -2219,7 +2219,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AllocAccount AllocAccount
+                public QuickFix.Fields.AllocAccount AllocAccount
                 { 
                     get 
                     {
@@ -2299,7 +2299,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX42/OrderCancelRequest.cs
+++ b/QuickFIXn/Message/FIX42/OrderCancelRequest.cs
@@ -1114,7 +1114,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EncodedText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX42/OrderStatusRequest.cs
+++ b/QuickFIXn/Message/FIX42/OrderStatusRequest.cs
@@ -800,7 +800,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.Side);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX42/Quote.cs
+++ b/QuickFIXn/Message/FIX42/Quote.cs
@@ -1201,7 +1201,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.Currency);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX42/QuoteAcknowledgement.cs
+++ b/QuickFIXn/Message/FIX42/QuoteAcknowledgement.cs
@@ -285,7 +285,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.QuoteSetID QuoteSetID
+                public QuickFix.Fields.QuoteSetID QuoteSetID
                 { 
                     get 
                     {
@@ -983,7 +983,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.QuoteEntryID QuoteEntryID
+                    public QuickFix.Fields.QuoteEntryID QuoteEntryID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX42/QuoteCancel.cs
+++ b/QuickFIXn/Message/FIX42/QuoteCancel.cs
@@ -225,7 +225,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX42/QuoteRequest.cs
+++ b/QuickFIXn/Message/FIX42/QuoteRequest.cs
@@ -99,7 +99,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX42/QuoteStatusRequest.cs
+++ b/QuickFIXn/Message/FIX42/QuoteStatusRequest.cs
@@ -703,7 +703,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.TradingSessionID);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX42/Reject.cs
+++ b/QuickFIXn/Message/FIX42/Reject.cs
@@ -238,7 +238,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EncodedText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX42/ResendRequest.cs
+++ b/QuickFIXn/Message/FIX42/ResendRequest.cs
@@ -85,7 +85,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EndSeqNo);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX42/SecurityDefinition.cs
+++ b/QuickFIXn/Message/FIX42/SecurityDefinition.cs
@@ -940,7 +940,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX42/SecurityDefinitionRequest.cs
+++ b/QuickFIXn/Message/FIX42/SecurityDefinitionRequest.cs
@@ -876,7 +876,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX42/SecurityStatus.cs
+++ b/QuickFIXn/Message/FIX42/SecurityStatus.cs
@@ -1137,7 +1137,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.Adjustment);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX42/SecurityStatusRequest.cs
+++ b/QuickFIXn/Message/FIX42/SecurityStatusRequest.cs
@@ -738,7 +738,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.TradingSessionID);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX42/SequenceReset.cs
+++ b/QuickFIXn/Message/FIX42/SequenceReset.cs
@@ -83,7 +83,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.NewSeqNo);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX42/SettlementInstructions.cs
+++ b/QuickFIXn/Message/FIX42/SettlementInstructions.cs
@@ -1149,7 +1149,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.CashSettlAgentContactPhone);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX42/TestRequest.cs
+++ b/QuickFIXn/Message/FIX42/TestRequest.cs
@@ -52,7 +52,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.TestReqID);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX42/TradingSessionStatus.cs
+++ b/QuickFIXn/Message/FIX42/TradingSessionStatus.cs
@@ -488,7 +488,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EncodedText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX42/TradingSessionStatusRequest.cs
+++ b/QuickFIXn/Message/FIX42/TradingSessionStatusRequest.cs
@@ -178,7 +178,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.SubscriptionRequestType);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX43/Advertisement.cs
+++ b/QuickFIXn/Message/FIX43/Advertisement.cs
@@ -1564,7 +1564,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX43/Allocation.cs
+++ b/QuickFIXn/Message/FIX43/Allocation.cs
@@ -2221,7 +2221,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ClOrdID ClOrdID
+                public QuickFix.Fields.ClOrdID ClOrdID
                 { 
                     get 
                     {
@@ -2394,7 +2394,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LastQty LastQty
+                public QuickFix.Fields.LastQty LastQty
                 { 
                     get 
                     {
@@ -2567,7 +2567,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -2647,7 +2647,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -2789,7 +2789,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AllocAccount AllocAccount
+                public QuickFix.Fields.AllocAccount AllocAccount
                 { 
                     get 
                     {
@@ -3549,7 +3549,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -3691,7 +3691,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
+                    public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX43/AllocationACK.cs
+++ b/QuickFIXn/Message/FIX43/AllocationACK.cs
@@ -351,7 +351,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX43/BidRequest.cs
+++ b/QuickFIXn/Message/FIX43/BidRequest.cs
@@ -946,7 +946,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.BidDescriptorType BidDescriptorType
+                public QuickFix.Fields.BidDescriptorType BidDescriptorType
                 { 
                     get 
                     {
@@ -1305,7 +1305,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ListID ListID
+                public QuickFix.Fields.ListID ListID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX43/BidResponse.cs
+++ b/QuickFIXn/Message/FIX43/BidResponse.cs
@@ -124,7 +124,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Commission Commission
+                public QuickFix.Fields.Commission Commission
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX43/BusinessMessageReject.cs
+++ b/QuickFIXn/Message/FIX43/BusinessMessageReject.cs
@@ -240,7 +240,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EncodedText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX43/CrossOrderCancelReplaceRequest.cs
+++ b/QuickFIXn/Message/FIX43/CrossOrderCancelReplaceRequest.cs
@@ -2593,7 +2593,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Side Side
+                public QuickFix.Fields.Side Side
                 { 
                     get 
                     {
@@ -3787,7 +3787,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -3929,7 +3929,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.AllocAccount AllocAccount
+                    public QuickFix.Fields.AllocAccount AllocAccount
                     { 
                         get 
                         {
@@ -4069,7 +4069,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartyID NestedPartyID
+                        public QuickFix.Fields.NestedPartyID NestedPartyID
                         { 
                             get 
                             {
@@ -4213,7 +4213,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -4293,7 +4293,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {
@@ -4373,7 +4373,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX43/CrossOrderCancelRequest.cs
+++ b/QuickFIXn/Message/FIX43/CrossOrderCancelRequest.cs
@@ -1287,7 +1287,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Side Side
+                public QuickFix.Fields.Side Side
                 { 
                     get 
                     {
@@ -1830,7 +1830,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -1973,7 +1973,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX43/DerivativeSecurityList.cs
+++ b/QuickFIXn/Message/FIX43/DerivativeSecurityList.cs
@@ -1250,7 +1250,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                 { 
                     get 
                     {
@@ -1330,7 +1330,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -2586,7 +2586,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -2666,7 +2666,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSymbol LegSymbol
+                    public QuickFix.Fields.LegSymbol LegSymbol
                     { 
                         get 
                         {
@@ -3798,7 +3798,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                        public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX43/DerivativeSecurityListRequest.cs
+++ b/QuickFIXn/Message/FIX43/DerivativeSecurityListRequest.cs
@@ -1372,7 +1372,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX43/DontKnowTrade.cs
+++ b/QuickFIXn/Message/FIX43/DontKnowTrade.cs
@@ -1502,7 +1502,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX43/Email.cs
+++ b/QuickFIXn/Message/FIX43/Email.cs
@@ -444,7 +444,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RoutingType RoutingType
+                public QuickFix.Fields.RoutingType RoutingType
                 { 
                     get 
                     {
@@ -524,7 +524,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -1563,7 +1563,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -1644,7 +1644,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Text Text
+                public QuickFix.Fields.Text Text
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX43/ExecutionReport.cs
+++ b/QuickFIXn/Message/FIX43/ExecutionReport.cs
@@ -4982,7 +4982,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -5124,7 +5124,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ContraBroker ContraBroker
+                public QuickFix.Fields.ContraBroker ContraBroker
                 { 
                     get 
                     {
@@ -5297,7 +5297,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -5377,7 +5377,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -5457,7 +5457,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ContAmtType ContAmtType
+                public QuickFix.Fields.ContAmtType ContAmtType
                 { 
                     get 
                     {
@@ -5568,7 +5568,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -6917,7 +6917,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -6997,7 +6997,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX43/Heartbeat.cs
+++ b/QuickFIXn/Message/FIX43/Heartbeat.cs
@@ -46,7 +46,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.TestReqID);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX43/IndicationOfInterest.cs
+++ b/QuickFIXn/Message/FIX43/IndicationOfInterest.cs
@@ -1812,7 +1812,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -1892,7 +1892,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.IOIQualifier IOIQualifier
+                public QuickFix.Fields.IOIQualifier IOIQualifier
                 { 
                     get 
                     {
@@ -1941,7 +1941,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RoutingType RoutingType
+                public QuickFix.Fields.RoutingType RoutingType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX43/ListCancelRequest.cs
+++ b/QuickFIXn/Message/FIX43/ListCancelRequest.cs
@@ -209,7 +209,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EncodedText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX43/ListExecute.cs
+++ b/QuickFIXn/Message/FIX43/ListExecute.cs
@@ -240,7 +240,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EncodedText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX43/ListStatus.cs
+++ b/QuickFIXn/Message/FIX43/ListStatus.cs
@@ -388,7 +388,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ClOrdID ClOrdID
+                public QuickFix.Fields.ClOrdID ClOrdID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX43/ListStatusRequest.cs
+++ b/QuickFIXn/Message/FIX43/ListStatusRequest.cs
@@ -145,7 +145,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EncodedText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX43/ListStrikePrice.cs
+++ b/QuickFIXn/Message/FIX43/ListStrikePrice.cs
@@ -132,7 +132,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -1450,7 +1450,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX43/Logon.cs
+++ b/QuickFIXn/Message/FIX43/Logon.cs
@@ -349,7 +349,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RefMsgType RefMsgType
+                public QuickFix.Fields.RefMsgType RefMsgType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX43/Logout.cs
+++ b/QuickFIXn/Message/FIX43/Logout.cs
@@ -108,7 +108,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EncodedText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX43/MarketDataIncrementalRefresh.cs
+++ b/QuickFIXn/Message/FIX43/MarketDataIncrementalRefresh.cs
@@ -93,7 +93,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MDUpdateAction MDUpdateAction
+                public QuickFix.Fields.MDUpdateAction MDUpdateAction
                 { 
                     get 
                     {
@@ -2434,7 +2434,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX43/MarketDataRequest.cs
+++ b/QuickFIXn/Message/FIX43/MarketDataRequest.cs
@@ -382,7 +382,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MDEntryType MDEntryType
+                public QuickFix.Fields.MDEntryType MDEntryType
                 { 
                     get 
                     {
@@ -431,7 +431,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -1470,7 +1470,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -1551,7 +1551,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX43/MarketDataRequestReject.cs
+++ b/QuickFIXn/Message/FIX43/MarketDataRequestReject.cs
@@ -176,7 +176,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EncodedText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX43/MarketDataSnapshotFullRefresh.cs
+++ b/QuickFIXn/Message/FIX43/MarketDataSnapshotFullRefresh.cs
@@ -1308,7 +1308,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -1388,7 +1388,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MDEntryType MDEntryType
+                public QuickFix.Fields.MDEntryType MDEntryType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX43/MassQuote.cs
+++ b/QuickFIXn/Message/FIX43/MassQuote.cs
@@ -347,7 +347,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -489,7 +489,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.QuoteSetID QuoteSetID
+                public QuickFix.Fields.QuoteSetID QuoteSetID
                 { 
                     get 
                     {
@@ -1683,7 +1683,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -1763,7 +1763,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.QuoteEntryID QuoteEntryID
+                    public QuickFix.Fields.QuoteEntryID QuoteEntryID
                     { 
                         get 
                         {
@@ -3546,7 +3546,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                        public QuickFix.Fields.SecurityAltID SecurityAltID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX43/MassQuoteAcknowledgement.cs
+++ b/QuickFIXn/Message/FIX43/MassQuoteAcknowledgement.cs
@@ -378,7 +378,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -520,7 +520,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.QuoteSetID QuoteSetID
+                public QuickFix.Fields.QuoteSetID QuoteSetID
                 { 
                     get 
                     {
@@ -1683,7 +1683,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -1763,7 +1763,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.QuoteEntryID QuoteEntryID
+                    public QuickFix.Fields.QuoteEntryID QuoteEntryID
                     { 
                         get 
                         {
@@ -3577,7 +3577,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                        public QuickFix.Fields.SecurityAltID SecurityAltID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX43/MultilegOrderCancelReplaceRequest.cs
+++ b/QuickFIXn/Message/FIX43/MultilegOrderCancelReplaceRequest.cs
@@ -3335,7 +3335,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -3477,7 +3477,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AllocAccount AllocAccount
+                public QuickFix.Fields.AllocAccount AllocAccount
                 { 
                     get 
                     {
@@ -3588,7 +3588,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {
@@ -3668,7 +3668,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3748,7 +3748,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -5066,7 +5066,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -5146,7 +5146,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX43/NewOrderCross.cs
+++ b/QuickFIXn/Message/FIX43/NewOrderCross.cs
@@ -2529,7 +2529,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Side Side
+                public QuickFix.Fields.Side Side
                 { 
                     get 
                     {
@@ -3661,7 +3661,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -3803,7 +3803,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.AllocAccount AllocAccount
+                    public QuickFix.Fields.AllocAccount AllocAccount
                     { 
                         get 
                         {
@@ -3943,7 +3943,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartyID NestedPartyID
+                        public QuickFix.Fields.NestedPartyID NestedPartyID
                         { 
                             get 
                             {
@@ -4087,7 +4087,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -4167,7 +4167,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {
@@ -4247,7 +4247,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX43/NewOrderList.cs
+++ b/QuickFIXn/Message/FIX43/NewOrderList.cs
@@ -506,7 +506,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ClOrdID ClOrdID
+                public QuickFix.Fields.ClOrdID ClOrdID
                 { 
                     get 
                     {
@@ -4087,7 +4087,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -4229,7 +4229,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.AllocAccount AllocAccount
+                    public QuickFix.Fields.AllocAccount AllocAccount
                     { 
                         get 
                         {
@@ -4369,7 +4369,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartyID NestedPartyID
+                        public QuickFix.Fields.NestedPartyID NestedPartyID
                         { 
                             get 
                             {
@@ -4512,7 +4512,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.TradingSessionID TradingSessionID
+                    public QuickFix.Fields.TradingSessionID TradingSessionID
                     { 
                         get 
                         {
@@ -4592,7 +4592,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -4672,7 +4672,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StipulationType StipulationType
+                    public QuickFix.Fields.StipulationType StipulationType
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX43/NewOrderMultileg.cs
+++ b/QuickFIXn/Message/FIX43/NewOrderMultileg.cs
@@ -3240,7 +3240,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -3382,7 +3382,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AllocAccount AllocAccount
+                public QuickFix.Fields.AllocAccount AllocAccount
                 { 
                     get 
                     {
@@ -3493,7 +3493,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {
@@ -3573,7 +3573,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3653,7 +3653,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -4971,7 +4971,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -5051,7 +5051,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX43/NewOrderSingle.cs
+++ b/QuickFIXn/Message/FIX43/NewOrderSingle.cs
@@ -3612,7 +3612,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -3754,7 +3754,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AllocAccount AllocAccount
+                public QuickFix.Fields.AllocAccount AllocAccount
                 { 
                     get 
                     {
@@ -3894,7 +3894,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -4037,7 +4037,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {
@@ -4117,7 +4117,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -4197,7 +4197,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX43/News.cs
+++ b/QuickFIXn/Message/FIX43/News.cs
@@ -378,7 +378,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RoutingType RoutingType
+                public QuickFix.Fields.RoutingType RoutingType
                 { 
                     get 
                     {
@@ -458,7 +458,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -1497,7 +1497,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -1578,7 +1578,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Text Text
+                public QuickFix.Fields.Text Text
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX43/OrderCancelReject.cs
+++ b/QuickFIXn/Message/FIX43/OrderCancelReject.cs
@@ -618,7 +618,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EncodedText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX43/OrderCancelReplaceRequest.cs
+++ b/QuickFIXn/Message/FIX43/OrderCancelReplaceRequest.cs
@@ -3583,7 +3583,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -3725,7 +3725,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AllocAccount AllocAccount
+                public QuickFix.Fields.AllocAccount AllocAccount
                 { 
                     get 
                     {
@@ -3865,7 +3865,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -4008,7 +4008,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {
@@ -4088,7 +4088,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX43/OrderCancelRequest.cs
+++ b/QuickFIXn/Message/FIX43/OrderCancelRequest.cs
@@ -1719,7 +1719,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -1861,7 +1861,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX43/OrderMassCancelReport.cs
+++ b/QuickFIXn/Message/FIX43/OrderMassCancelReport.cs
@@ -2614,7 +2614,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.OrigClOrdID OrigClOrdID
+                public QuickFix.Fields.OrigClOrdID OrigClOrdID
                 { 
                     get 
                     {
@@ -2725,7 +2725,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -2805,7 +2805,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX43/OrderMassCancelRequest.cs
+++ b/QuickFIXn/Message/FIX43/OrderMassCancelRequest.cs
@@ -2428,7 +2428,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -2508,7 +2508,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX43/OrderMassStatusRequest.cs
+++ b/QuickFIXn/Message/FIX43/OrderMassStatusRequest.cs
@@ -2333,7 +2333,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -2475,7 +2475,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -2555,7 +2555,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX43/OrderStatusRequest.cs
+++ b/QuickFIXn/Message/FIX43/OrderStatusRequest.cs
@@ -1281,7 +1281,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -1423,7 +1423,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX43/Quote.cs
+++ b/QuickFIXn/Message/FIX43/Quote.cs
@@ -2457,7 +2457,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -2599,7 +2599,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX43/QuoteCancel.cs
+++ b/QuickFIXn/Message/FIX43/QuoteCancel.cs
@@ -349,7 +349,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -491,7 +491,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -1530,7 +1530,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX43/QuoteRequest.cs
+++ b/QuickFIXn/Message/FIX43/QuoteRequest.cs
@@ -223,7 +223,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -2130,7 +2130,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -2210,7 +2210,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StipulationType StipulationType
+                    public QuickFix.Fields.StipulationType StipulationType
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX43/QuoteRequestReject.cs
+++ b/QuickFIXn/Message/FIX43/QuoteRequestReject.cs
@@ -256,7 +256,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -2163,7 +2163,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -2243,7 +2243,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StipulationType StipulationType
+                    public QuickFix.Fields.StipulationType StipulationType
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX43/QuoteStatusReport.cs
+++ b/QuickFIXn/Message/FIX43/QuoteStatusReport.cs
@@ -2364,7 +2364,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -2506,7 +2506,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX43/QuoteStatusRequest.cs
+++ b/QuickFIXn/Message/FIX43/QuoteStatusRequest.cs
@@ -1308,7 +1308,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -1388,7 +1388,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX43/RFQRequest.cs
+++ b/QuickFIXn/Message/FIX43/RFQRequest.cs
@@ -130,7 +130,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -1324,7 +1324,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX43/RegistrationInstructions.cs
+++ b/QuickFIXn/Message/FIX43/RegistrationInstructions.cs
@@ -382,7 +382,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -524,7 +524,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RegistDetls RegistDetls
+                public QuickFix.Fields.RegistDetls RegistDetls
                 { 
                     get 
                     {
@@ -788,7 +788,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -931,7 +931,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.DistribPaymentMethod DistribPaymentMethod
+                public QuickFix.Fields.DistribPaymentMethod DistribPaymentMethod
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX43/RegistrationInstructionsResponse.cs
+++ b/QuickFIXn/Message/FIX43/RegistrationInstructionsResponse.cs
@@ -322,7 +322,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX43/Reject.cs
+++ b/QuickFIXn/Message/FIX43/Reject.cs
@@ -238,7 +238,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EncodedText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX43/ResendRequest.cs
+++ b/QuickFIXn/Message/FIX43/ResendRequest.cs
@@ -85,7 +85,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EndSeqNo);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX43/SecurityDefinition.cs
+++ b/QuickFIXn/Message/FIX43/SecurityDefinition.cs
@@ -1436,7 +1436,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -1516,7 +1516,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -2648,7 +2648,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX43/SecurityDefinitionRequest.cs
+++ b/QuickFIXn/Message/FIX43/SecurityDefinitionRequest.cs
@@ -1372,7 +1372,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -1452,7 +1452,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -2584,7 +2584,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX43/SecurityList.cs
+++ b/QuickFIXn/Message/FIX43/SecurityList.cs
@@ -196,7 +196,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -1514,7 +1514,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -1594,7 +1594,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSymbol LegSymbol
+                    public QuickFix.Fields.LegSymbol LegSymbol
                     { 
                         get 
                         {
@@ -2726,7 +2726,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                        public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX43/SecurityListRequest.cs
+++ b/QuickFIXn/Message/FIX43/SecurityListRequest.cs
@@ -1341,7 +1341,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX43/SecurityStatus.cs
+++ b/QuickFIXn/Message/FIX43/SecurityStatus.cs
@@ -1711,7 +1711,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX43/SecurityStatusRequest.cs
+++ b/QuickFIXn/Message/FIX43/SecurityStatusRequest.cs
@@ -1219,7 +1219,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX43/SecurityTypeRequest.cs
+++ b/QuickFIXn/Message/FIX43/SecurityTypeRequest.cs
@@ -207,7 +207,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.TradingSessionSubID);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX43/SecurityTypes.cs
+++ b/QuickFIXn/Message/FIX43/SecurityTypes.cs
@@ -382,7 +382,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityType SecurityType
+                public QuickFix.Fields.SecurityType SecurityType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX43/SequenceReset.cs
+++ b/QuickFIXn/Message/FIX43/SequenceReset.cs
@@ -83,7 +83,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.NewSeqNo);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX43/SettlementInstructions.cs
+++ b/QuickFIXn/Message/FIX43/SettlementInstructions.cs
@@ -1475,7 +1475,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX43/TestRequest.cs
+++ b/QuickFIXn/Message/FIX43/TestRequest.cs
@@ -52,7 +52,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.TestReqID);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX43/TradeCaptureReport.cs
+++ b/QuickFIXn/Message/FIX43/TradeCaptureReport.cs
@@ -1880,7 +1880,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -1960,7 +1960,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Side Side
+                public QuickFix.Fields.Side Side
                 { 
                     get 
                     {
@@ -3371,7 +3371,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -3513,7 +3513,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ClearingInstruction ClearingInstruction
+                    public QuickFix.Fields.ClearingInstruction ClearingInstruction
                     { 
                         get 
                         {
@@ -3562,7 +3562,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ContAmtType ContAmtType
+                    public QuickFix.Fields.ContAmtType ContAmtType
                     { 
                         get 
                         {
@@ -3673,7 +3673,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
+                    public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX43/TradeCaptureReportRequest.cs
+++ b/QuickFIXn/Message/FIX43/TradeCaptureReportRequest.cs
@@ -1527,7 +1527,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -1669,7 +1669,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -1749,7 +1749,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradeDate TradeDate
+                public QuickFix.Fields.TradeDate TradeDate
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX43/TradingSessionStatus.cs
+++ b/QuickFIXn/Message/FIX43/TradingSessionStatus.cs
@@ -550,7 +550,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EncodedText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX43/TradingSessionStatusRequest.cs
+++ b/QuickFIXn/Message/FIX43/TradingSessionStatusRequest.cs
@@ -209,7 +209,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.SubscriptionRequestType);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX44/Advertisement.cs
+++ b/QuickFIXn/Message/FIX44/Advertisement.cs
@@ -1967,7 +1967,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -2047,7 +2047,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -2189,7 +2189,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -3507,7 +3507,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -3588,7 +3588,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -5061,7 +5061,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -5141,7 +5141,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX44/AllocationInstruction.cs
+++ b/QuickFIXn/Message/FIX44/AllocationInstruction.cs
@@ -3990,7 +3990,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ClOrdID ClOrdID
+                public QuickFix.Fields.ClOrdID ClOrdID
                 { 
                     get 
                     {
@@ -4285,7 +4285,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.Nested2PartyID Nested2PartyID
+                    public QuickFix.Fields.Nested2PartyID Nested2PartyID
                     { 
                         get 
                         {
@@ -4425,7 +4425,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
+                        public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
                         { 
                             get 
                             {
@@ -4507,7 +4507,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LastQty LastQty
+                public QuickFix.Fields.LastQty LastQty
                 { 
                     get 
                     {
@@ -4711,7 +4711,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -4791,7 +4791,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -4933,7 +4933,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrAttribType InstrAttribType
+                public QuickFix.Fields.InstrAttribType InstrAttribType
                 { 
                     get 
                     {
@@ -5013,7 +5013,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -6486,7 +6486,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -6566,7 +6566,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -6647,7 +6647,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -7965,7 +7965,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -8046,7 +8046,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -8186,7 +8186,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -8267,7 +8267,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -8347,7 +8347,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AllocAccount AllocAccount
+                public QuickFix.Fields.AllocAccount AllocAccount
                 { 
                     get 
                     {
@@ -9572,7 +9572,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -9712,7 +9712,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -9793,7 +9793,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
+                    public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
                     { 
                         get 
                         {
@@ -9935,7 +9935,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SettlInstSource SettlInstSource
+                    public QuickFix.Fields.SettlInstSource SettlInstSource
                     { 
                         get 
                         {
@@ -10044,7 +10044,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SettlPartyID SettlPartyID
+                        public QuickFix.Fields.SettlPartyID SettlPartyID
                         { 
                             get 
                             {
@@ -10184,7 +10184,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.SettlPartySubID SettlPartySubID
+                            public QuickFix.Fields.SettlPartySubID SettlPartySubID
                             { 
                                 get 
                                 {

--- a/QuickFIXn/Message/FIX44/AllocationInstructionAck.cs
+++ b/QuickFIXn/Message/FIX44/AllocationInstructionAck.cs
@@ -537,7 +537,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -677,7 +677,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -758,7 +758,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AllocAccount AllocAccount
+                public QuickFix.Fields.AllocAccount AllocAccount
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX44/AllocationReport.cs
+++ b/QuickFIXn/Message/FIX44/AllocationReport.cs
@@ -4116,7 +4116,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ClOrdID ClOrdID
+                public QuickFix.Fields.ClOrdID ClOrdID
                 { 
                     get 
                     {
@@ -4411,7 +4411,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.Nested2PartyID Nested2PartyID
+                    public QuickFix.Fields.Nested2PartyID Nested2PartyID
                     { 
                         get 
                         {
@@ -4551,7 +4551,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
+                        public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
                         { 
                             get 
                             {
@@ -4633,7 +4633,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LastQty LastQty
+                public QuickFix.Fields.LastQty LastQty
                 { 
                     get 
                     {
@@ -4837,7 +4837,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -4917,7 +4917,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -5059,7 +5059,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrAttribType InstrAttribType
+                public QuickFix.Fields.InstrAttribType InstrAttribType
                 { 
                     get 
                     {
@@ -5139,7 +5139,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -6612,7 +6612,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -6692,7 +6692,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -6773,7 +6773,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -8091,7 +8091,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -8172,7 +8172,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -8312,7 +8312,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -8393,7 +8393,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -8473,7 +8473,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AllocAccount AllocAccount
+                public QuickFix.Fields.AllocAccount AllocAccount
                 { 
                     get 
                     {
@@ -9605,7 +9605,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -9745,7 +9745,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -9826,7 +9826,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
+                    public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
                     { 
                         get 
                         {
@@ -9968,7 +9968,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ClearingInstruction ClearingInstruction
+                    public QuickFix.Fields.ClearingInstruction ClearingInstruction
                     { 
                         get 
                         {
@@ -10017,7 +10017,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SettlInstSource SettlInstSource
+                    public QuickFix.Fields.SettlInstSource SettlInstSource
                     { 
                         get 
                         {
@@ -10126,7 +10126,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SettlPartyID SettlPartyID
+                        public QuickFix.Fields.SettlPartyID SettlPartyID
                         { 
                             get 
                             {
@@ -10266,7 +10266,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.SettlPartySubID SettlPartySubID
+                            public QuickFix.Fields.SettlPartySubID SettlPartySubID
                             { 
                                 get 
                                 {

--- a/QuickFIXn/Message/FIX44/AllocationReportAck.cs
+++ b/QuickFIXn/Message/FIX44/AllocationReportAck.cs
@@ -570,7 +570,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -710,7 +710,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -791,7 +791,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AllocAccount AllocAccount
+                public QuickFix.Fields.AllocAccount AllocAccount
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX44/AssignmentReport.cs
+++ b/QuickFIXn/Message/FIX44/AssignmentReport.cs
@@ -3498,7 +3498,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -3638,7 +3638,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -3719,7 +3719,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3799,7 +3799,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -3941,7 +3941,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                 { 
                     get 
                     {
@@ -4021,7 +4021,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -5494,7 +5494,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -5574,7 +5574,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -5655,7 +5655,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosType PosType
+                public QuickFix.Fields.PosType PosType
                 { 
                     get 
                     {
@@ -5826,7 +5826,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -5966,7 +5966,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -6048,7 +6048,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosAmtType PosAmtType
+                public QuickFix.Fields.PosAmtType PosAmtType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX44/BidRequest.cs
+++ b/QuickFIXn/Message/FIX44/BidRequest.cs
@@ -946,7 +946,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.BidDescriptorType BidDescriptorType
+                public QuickFix.Fields.BidDescriptorType BidDescriptorType
                 { 
                     get 
                     {
@@ -1305,7 +1305,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ListID ListID
+                public QuickFix.Fields.ListID ListID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX44/BidResponse.cs
+++ b/QuickFIXn/Message/FIX44/BidResponse.cs
@@ -124,7 +124,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Commission Commission
+                public QuickFix.Fields.Commission Commission
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX44/BusinessMessageReject.cs
+++ b/QuickFIXn/Message/FIX44/BusinessMessageReject.cs
@@ -240,7 +240,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EncodedText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX44/CollateralAssignment.cs
+++ b/QuickFIXn/Message/FIX44/CollateralAssignment.cs
@@ -4693,7 +4693,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -4833,7 +4833,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -4914,7 +4914,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ExecID ExecID
+                public QuickFix.Fields.ExecID ExecID
                 { 
                     get 
                     {
@@ -4963,7 +4963,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradeReportID TradeReportID
+                public QuickFix.Fields.TradeReportID TradeReportID
                 { 
                     get 
                     {
@@ -5043,7 +5043,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -5123,7 +5123,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -5265,7 +5265,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                 { 
                     get 
                     {
@@ -5345,7 +5345,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -6849,7 +6849,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -6929,7 +6929,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -7010,7 +7010,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
+                public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
                 { 
                     get 
                     {
@@ -7121,7 +7121,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
+                public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
                 { 
                     get 
                     {
@@ -7263,7 +7263,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -7343,7 +7343,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SettlInstSource SettlInstSource
+                public QuickFix.Fields.SettlInstSource SettlInstSource
                 { 
                     get 
                     {
@@ -7452,7 +7452,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SettlPartyID SettlPartyID
+                    public QuickFix.Fields.SettlPartyID SettlPartyID
                     { 
                         get 
                         {
@@ -7592,7 +7592,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SettlPartySubID SettlPartySubID
+                        public QuickFix.Fields.SettlPartySubID SettlPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX44/CollateralInquiry.cs
+++ b/QuickFIXn/Message/FIX44/CollateralInquiry.cs
@@ -4588,7 +4588,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.CollInquiryQualifier CollInquiryQualifier
+                public QuickFix.Fields.CollInquiryQualifier CollInquiryQualifier
                 { 
                     get 
                     {
@@ -4637,7 +4637,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -4777,7 +4777,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -4858,7 +4858,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ExecID ExecID
+                public QuickFix.Fields.ExecID ExecID
                 { 
                     get 
                     {
@@ -4907,7 +4907,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradeReportID TradeReportID
+                public QuickFix.Fields.TradeReportID TradeReportID
                 { 
                     get 
                     {
@@ -4987,7 +4987,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -5067,7 +5067,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -5209,7 +5209,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                 { 
                     get 
                     {
@@ -5289,7 +5289,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -6762,7 +6762,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -6842,7 +6842,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -6923,7 +6923,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
+                public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
                 { 
                     get 
                     {
@@ -7034,7 +7034,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -7114,7 +7114,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SettlInstSource SettlInstSource
+                public QuickFix.Fields.SettlInstSource SettlInstSource
                 { 
                     get 
                     {
@@ -7223,7 +7223,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SettlPartyID SettlPartyID
+                    public QuickFix.Fields.SettlPartyID SettlPartyID
                     { 
                         get 
                         {
@@ -7363,7 +7363,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SettlPartySubID SettlPartySubID
+                        public QuickFix.Fields.SettlPartySubID SettlPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX44/CollateralInquiryAck.cs
+++ b/QuickFIXn/Message/FIX44/CollateralInquiryAck.cs
@@ -3883,7 +3883,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.CollInquiryQualifier CollInquiryQualifier
+                public QuickFix.Fields.CollInquiryQualifier CollInquiryQualifier
                 { 
                     get 
                     {
@@ -3932,7 +3932,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -4072,7 +4072,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -4153,7 +4153,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ExecID ExecID
+                public QuickFix.Fields.ExecID ExecID
                 { 
                     get 
                     {
@@ -4202,7 +4202,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradeReportID TradeReportID
+                public QuickFix.Fields.TradeReportID TradeReportID
                 { 
                     get 
                     {
@@ -4282,7 +4282,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -4362,7 +4362,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -4504,7 +4504,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                 { 
                     get 
                     {
@@ -4584,7 +4584,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -6057,7 +6057,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -6137,7 +6137,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX44/CollateralReport.cs
+++ b/QuickFIXn/Message/FIX44/CollateralReport.cs
@@ -4627,7 +4627,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -4767,7 +4767,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -4848,7 +4848,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ExecID ExecID
+                public QuickFix.Fields.ExecID ExecID
                 { 
                     get 
                     {
@@ -4897,7 +4897,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradeReportID TradeReportID
+                public QuickFix.Fields.TradeReportID TradeReportID
                 { 
                     get 
                     {
@@ -4977,7 +4977,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -5057,7 +5057,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -5199,7 +5199,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                 { 
                     get 
                     {
@@ -5279,7 +5279,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -6752,7 +6752,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -6832,7 +6832,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -6913,7 +6913,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
+                public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
                 { 
                     get 
                     {
@@ -7024,7 +7024,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
+                public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
                 { 
                     get 
                     {
@@ -7166,7 +7166,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -7246,7 +7246,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SettlInstSource SettlInstSource
+                public QuickFix.Fields.SettlInstSource SettlInstSource
                 { 
                     get 
                     {
@@ -7355,7 +7355,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SettlPartyID SettlPartyID
+                    public QuickFix.Fields.SettlPartyID SettlPartyID
                     { 
                         get 
                         {
@@ -7495,7 +7495,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SettlPartySubID SettlPartySubID
+                        public QuickFix.Fields.SettlPartySubID SettlPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX44/CollateralRequest.cs
+++ b/QuickFIXn/Message/FIX44/CollateralRequest.cs
@@ -4443,7 +4443,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -4583,7 +4583,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -4664,7 +4664,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ExecID ExecID
+                public QuickFix.Fields.ExecID ExecID
                 { 
                     get 
                     {
@@ -4713,7 +4713,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradeReportID TradeReportID
+                public QuickFix.Fields.TradeReportID TradeReportID
                 { 
                     get 
                     {
@@ -4793,7 +4793,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -4873,7 +4873,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -5015,7 +5015,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                 { 
                     get 
                     {
@@ -5095,7 +5095,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -6599,7 +6599,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -6679,7 +6679,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -6760,7 +6760,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
+                public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
                 { 
                     get 
                     {
@@ -6871,7 +6871,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
+                public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
                 { 
                     get 
                     {
@@ -7013,7 +7013,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX44/CollateralResponse.cs
+++ b/QuickFIXn/Message/FIX44/CollateralResponse.cs
@@ -4416,7 +4416,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -4556,7 +4556,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -4637,7 +4637,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ExecID ExecID
+                public QuickFix.Fields.ExecID ExecID
                 { 
                     get 
                     {
@@ -4686,7 +4686,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradeReportID TradeReportID
+                public QuickFix.Fields.TradeReportID TradeReportID
                 { 
                     get 
                     {
@@ -4766,7 +4766,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -4846,7 +4846,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -4988,7 +4988,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                 { 
                     get 
                     {
@@ -5068,7 +5068,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -6572,7 +6572,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -6652,7 +6652,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -6733,7 +6733,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
+                public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
                 { 
                     get 
                     {
@@ -6844,7 +6844,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
+                public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
                 { 
                     get 
                     {
@@ -6986,7 +6986,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX44/Confirmation.cs
+++ b/QuickFIXn/Message/FIX44/Confirmation.cs
@@ -4277,7 +4277,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -4417,7 +4417,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -4498,7 +4498,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ClOrdID ClOrdID
+                public QuickFix.Fields.ClOrdID ClOrdID
                 { 
                     get 
                     {
@@ -4793,7 +4793,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.Nested2PartyID Nested2PartyID
+                    public QuickFix.Fields.Nested2PartyID Nested2PartyID
                     { 
                         get 
                         {
@@ -4933,7 +4933,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
+                        public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
                         { 
                             get 
                             {
@@ -5015,7 +5015,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
+                public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
                 { 
                     get 
                     {
@@ -5126,7 +5126,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -5206,7 +5206,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -5348,7 +5348,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrAttribType InstrAttribType
+                public QuickFix.Fields.InstrAttribType InstrAttribType
                 { 
                     get 
                     {
@@ -5428,7 +5428,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -6901,7 +6901,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -6981,7 +6981,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -7062,7 +7062,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -8380,7 +8380,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -8461,7 +8461,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.OrderCapacity OrderCapacity
+                public QuickFix.Fields.OrderCapacity OrderCapacity
                 { 
                     get 
                     {
@@ -8572,7 +8572,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SettlInstSource SettlInstSource
+                public QuickFix.Fields.SettlInstSource SettlInstSource
                 { 
                     get 
                     {
@@ -8681,7 +8681,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SettlPartyID SettlPartyID
+                    public QuickFix.Fields.SettlPartyID SettlPartyID
                     { 
                         get 
                         {
@@ -8821,7 +8821,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SettlPartySubID SettlPartySubID
+                        public QuickFix.Fields.SettlPartySubID SettlPartySubID
                         { 
                             get 
                             {
@@ -8903,7 +8903,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -8983,7 +8983,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
+                public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX44/ConfirmationAck.cs
+++ b/QuickFIXn/Message/FIX44/ConfirmationAck.cs
@@ -306,7 +306,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EncodedText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX44/ConfirmationRequest.cs
+++ b/QuickFIXn/Message/FIX44/ConfirmationRequest.cs
@@ -444,7 +444,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ClOrdID ClOrdID
+                public QuickFix.Fields.ClOrdID ClOrdID
                 { 
                     get 
                     {
@@ -739,7 +739,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.Nested2PartyID Nested2PartyID
+                    public QuickFix.Fields.Nested2PartyID Nested2PartyID
                     { 
                         get 
                         {
@@ -879,7 +879,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
+                        public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX44/CrossOrderCancelReplaceRequest.cs
+++ b/QuickFIXn/Message/FIX44/CrossOrderCancelReplaceRequest.cs
@@ -3521,7 +3521,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Side Side
+                public QuickFix.Fields.Side Side
                 { 
                     get 
                     {
@@ -4839,7 +4839,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -4979,7 +4979,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.PartySubID PartySubID
+                        public QuickFix.Fields.PartySubID PartySubID
                         { 
                             get 
                             {
@@ -5060,7 +5060,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.AllocAccount AllocAccount
+                    public QuickFix.Fields.AllocAccount AllocAccount
                     { 
                         get 
                         {
@@ -5262,7 +5262,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartyID NestedPartyID
+                        public QuickFix.Fields.NestedPartyID NestedPartyID
                         { 
                             get 
                             {
@@ -5402,7 +5402,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
                             { 
                                 get 
                                 {
@@ -5485,7 +5485,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -5565,7 +5565,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -5707,7 +5707,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -7180,7 +7180,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -7260,7 +7260,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -7341,7 +7341,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -8659,7 +8659,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -8740,7 +8740,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {
@@ -8820,7 +8820,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX44/CrossOrderCancelRequest.cs
+++ b/QuickFIXn/Message/FIX44/CrossOrderCancelRequest.cs
@@ -1659,7 +1659,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Side Side
+                public QuickFix.Fields.Side Side
                 { 
                     get 
                     {
@@ -2233,7 +2233,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -2373,7 +2373,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.PartySubID PartySubID
+                        public QuickFix.Fields.PartySubID PartySubID
                         { 
                             get 
                             {
@@ -2455,7 +2455,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -2535,7 +2535,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -2677,7 +2677,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -4150,7 +4150,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -4230,7 +4230,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -4311,7 +4311,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -5629,7 +5629,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX44/DerivativeSecurityList.cs
+++ b/QuickFIXn/Message/FIX44/DerivativeSecurityList.cs
@@ -1684,7 +1684,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                 { 
                     get 
                     {
@@ -1764,7 +1764,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                 { 
                     get 
                     {
@@ -1844,7 +1844,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -3534,7 +3534,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -3614,7 +3614,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -3756,7 +3756,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrAttribType InstrAttribType
+                    public QuickFix.Fields.InstrAttribType InstrAttribType
                     { 
                         get 
                         {
@@ -3836,7 +3836,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSymbol LegSymbol
+                    public QuickFix.Fields.LegSymbol LegSymbol
                     { 
                         get 
                         {
@@ -5154,7 +5154,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                        public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX44/DerivativeSecurityListRequest.cs
+++ b/QuickFIXn/Message/FIX44/DerivativeSecurityListRequest.cs
@@ -1806,7 +1806,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                 { 
                     get 
                     {
@@ -1886,7 +1886,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX44/DontKnowTrade.cs
+++ b/QuickFIXn/Message/FIX44/DontKnowTrade.cs
@@ -1905,7 +1905,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -1985,7 +1985,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -2127,7 +2127,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -3600,7 +3600,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -3680,7 +3680,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -3761,7 +3761,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -5079,7 +5079,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX44/Email.cs
+++ b/QuickFIXn/Message/FIX44/Email.cs
@@ -506,7 +506,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RoutingType RoutingType
+                public QuickFix.Fields.RoutingType RoutingType
                 { 
                     get 
                     {
@@ -586,7 +586,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -1935,7 +1935,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -2015,7 +2015,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -2158,7 +2158,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -3631,7 +3631,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -3711,7 +3711,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -3792,7 +3792,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -5110,7 +5110,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -5191,7 +5191,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Text Text
+                public QuickFix.Fields.Text Text
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX44/ExecutionReport.cs
+++ b/QuickFIXn/Message/FIX44/ExecutionReport.cs
@@ -6811,7 +6811,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -6951,7 +6951,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -7032,7 +7032,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ContraBroker ContraBroker
+                public QuickFix.Fields.ContraBroker ContraBroker
                 { 
                     get 
                     {
@@ -7205,7 +7205,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -7285,7 +7285,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -7427,7 +7427,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -8900,7 +8900,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -8980,7 +8980,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -9061,7 +9061,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -9141,7 +9141,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ContAmtType ContAmtType
+                public QuickFix.Fields.ContAmtType ContAmtType
                 { 
                     get 
                     {
@@ -9252,7 +9252,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -10911,7 +10911,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -10991,7 +10991,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegStipulationType LegStipulationType
+                    public QuickFix.Fields.LegStipulationType LegStipulationType
                     { 
                         get 
                         {
@@ -11071,7 +11071,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -11211,7 +11211,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -11293,7 +11293,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
+                public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX44/Heartbeat.cs
+++ b/QuickFIXn/Message/FIX44/Heartbeat.cs
@@ -46,7 +46,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.TestReqID);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX44/IndicationOfInterest.cs
+++ b/QuickFIXn/Message/FIX44/IndicationOfInterest.cs
@@ -2928,7 +2928,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3008,7 +3008,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -3150,7 +3150,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -4623,7 +4623,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -4703,7 +4703,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -4784,7 +4784,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -4864,7 +4864,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -6244,7 +6244,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -6324,7 +6324,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegStipulationType LegStipulationType
+                    public QuickFix.Fields.LegStipulationType LegStipulationType
                     { 
                         get 
                         {
@@ -6405,7 +6405,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.IOIQualifier IOIQualifier
+                public QuickFix.Fields.IOIQualifier IOIQualifier
                 { 
                     get 
                     {
@@ -6454,7 +6454,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RoutingType RoutingType
+                public QuickFix.Fields.RoutingType RoutingType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX44/ListCancelRequest.cs
+++ b/QuickFIXn/Message/FIX44/ListCancelRequest.cs
@@ -240,7 +240,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EncodedText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX44/ListExecute.cs
+++ b/QuickFIXn/Message/FIX44/ListExecute.cs
@@ -240,7 +240,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EncodedText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX44/ListStatus.cs
+++ b/QuickFIXn/Message/FIX44/ListStatus.cs
@@ -419,7 +419,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ClOrdID ClOrdID
+                public QuickFix.Fields.ClOrdID ClOrdID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX44/ListStatusRequest.cs
+++ b/QuickFIXn/Message/FIX44/ListStatusRequest.cs
@@ -145,7 +145,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EncodedText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX44/ListStrikePrice.cs
+++ b/QuickFIXn/Message/FIX44/ListStrikePrice.cs
@@ -194,7 +194,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -1543,7 +1543,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -1623,7 +1623,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -1766,7 +1766,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -3518,7 +3518,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -3598,7 +3598,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX44/Logon.cs
+++ b/QuickFIXn/Message/FIX44/Logon.cs
@@ -380,7 +380,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RefMsgType RefMsgType
+                public QuickFix.Fields.RefMsgType RefMsgType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX44/Logout.cs
+++ b/QuickFIXn/Message/FIX44/Logout.cs
@@ -108,7 +108,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EncodedText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX44/MarketDataIncrementalRefresh.cs
+++ b/QuickFIXn/Message/FIX44/MarketDataIncrementalRefresh.cs
@@ -155,7 +155,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MDUpdateAction MDUpdateAction
+                public QuickFix.Fields.MDUpdateAction MDUpdateAction
                 { 
                     get 
                     {
@@ -2806,7 +2806,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -2886,7 +2886,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -3028,7 +3028,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                     { 
                         get 
                         {
@@ -4501,7 +4501,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                        public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                         { 
                             get 
                             {
@@ -4581,7 +4581,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                        public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                         { 
                             get 
                             {
@@ -4662,7 +4662,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSymbol LegSymbol
+                    public QuickFix.Fields.LegSymbol LegSymbol
                     { 
                         get 
                         {
@@ -5980,7 +5980,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                        public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX44/MarketDataRequest.cs
+++ b/QuickFIXn/Message/FIX44/MarketDataRequest.cs
@@ -444,7 +444,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MDEntryType MDEntryType
+                public QuickFix.Fields.MDEntryType MDEntryType
                 { 
                     get 
                     {
@@ -493,7 +493,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -1904,7 +1904,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -1984,7 +1984,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -2126,7 +2126,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                     { 
                         get 
                         {
@@ -3599,7 +3599,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                        public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                         { 
                             get 
                             {
@@ -3679,7 +3679,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                        public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                         { 
                             get 
                             {
@@ -3760,7 +3760,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSymbol LegSymbol
+                    public QuickFix.Fields.LegSymbol LegSymbol
                     { 
                         get 
                         {
@@ -5078,7 +5078,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                        public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                         { 
                             get 
                             {
@@ -5160,7 +5160,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX44/MarketDataRequestReject.cs
+++ b/QuickFIXn/Message/FIX44/MarketDataRequestReject.cs
@@ -223,7 +223,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AltMDSourceID AltMDSourceID
+                public QuickFix.Fields.AltMDSourceID AltMDSourceID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX44/MarketDataSnapshotFullRefresh.cs
+++ b/QuickFIXn/Message/FIX44/MarketDataSnapshotFullRefresh.cs
@@ -1649,7 +1649,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -1729,7 +1729,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -1871,7 +1871,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -3344,7 +3344,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -3424,7 +3424,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -3505,7 +3505,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -4823,7 +4823,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -4904,7 +4904,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MDEntryType MDEntryType
+                public QuickFix.Fields.MDEntryType MDEntryType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX44/MassQuote.cs
+++ b/QuickFIXn/Message/FIX44/MassQuote.cs
@@ -378,7 +378,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -518,7 +518,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -599,7 +599,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.QuoteSetID QuoteSetID
+                public QuickFix.Fields.QuoteSetID QuoteSetID
                 { 
                     get 
                     {
@@ -2227,7 +2227,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -2307,7 +2307,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -2387,7 +2387,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.QuoteEntryID QuoteEntryID
+                    public QuickFix.Fields.QuoteEntryID QuoteEntryID
                     { 
                         get 
                         {
@@ -4511,7 +4511,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                        public QuickFix.Fields.SecurityAltID SecurityAltID
                         { 
                             get 
                             {
@@ -4591,7 +4591,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.EventType EventType
+                        public QuickFix.Fields.EventType EventType
                         { 
                             get 
                             {
@@ -4733,7 +4733,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegSymbol LegSymbol
+                        public QuickFix.Fields.LegSymbol LegSymbol
                         { 
                             get 
                             {
@@ -6051,7 +6051,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                             { 
                                 get 
                                 {

--- a/QuickFIXn/Message/FIX44/MassQuoteAcknowledgement.cs
+++ b/QuickFIXn/Message/FIX44/MassQuoteAcknowledgement.cs
@@ -471,7 +471,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -611,7 +611,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -692,7 +692,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.QuoteSetID QuoteSetID
+                public QuickFix.Fields.QuoteSetID QuoteSetID
                 { 
                     get 
                     {
@@ -2289,7 +2289,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -2369,7 +2369,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -2449,7 +2449,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.QuoteEntryID QuoteEntryID
+                    public QuickFix.Fields.QuoteEntryID QuoteEntryID
                     { 
                         get 
                         {
@@ -4604,7 +4604,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                        public QuickFix.Fields.SecurityAltID SecurityAltID
                         { 
                             get 
                             {
@@ -4684,7 +4684,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.EventType EventType
+                        public QuickFix.Fields.EventType EventType
                         { 
                             get 
                             {
@@ -4826,7 +4826,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegSymbol LegSymbol
+                        public QuickFix.Fields.LegSymbol LegSymbol
                         { 
                             get 
                             {
@@ -6144,7 +6144,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                             { 
                                 get 
                                 {

--- a/QuickFIXn/Message/FIX44/MultilegOrderCancelReplaceRequest.cs
+++ b/QuickFIXn/Message/FIX44/MultilegOrderCancelReplaceRequest.cs
@@ -4201,7 +4201,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -4341,7 +4341,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -4422,7 +4422,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AllocAccount AllocAccount
+                public QuickFix.Fields.AllocAccount AllocAccount
                 { 
                     get 
                     {
@@ -4624,7 +4624,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.Nested3PartyID Nested3PartyID
+                    public QuickFix.Fields.Nested3PartyID Nested3PartyID
                     { 
                         get 
                         {
@@ -4764,7 +4764,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested3PartySubID Nested3PartySubID
+                        public QuickFix.Fields.Nested3PartySubID Nested3PartySubID
                         { 
                             get 
                             {
@@ -4846,7 +4846,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {
@@ -4926,7 +4926,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -5006,7 +5006,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -5148,7 +5148,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -6621,7 +6621,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -6701,7 +6701,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -6782,7 +6782,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -8441,7 +8441,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -8521,7 +8521,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegStipulationType LegStipulationType
+                    public QuickFix.Fields.LegStipulationType LegStipulationType
                     { 
                         get 
                         {
@@ -8601,7 +8601,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegAllocAccount LegAllocAccount
+                    public QuickFix.Fields.LegAllocAccount LegAllocAccount
                     { 
                         get 
                         {
@@ -8803,7 +8803,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested2PartyID Nested2PartyID
+                        public QuickFix.Fields.Nested2PartyID Nested2PartyID
                         { 
                             get 
                             {
@@ -8943,7 +8943,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
+                            public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
                             { 
                                 get 
                                 {
@@ -9025,7 +9025,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -9165,7 +9165,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX44/NetworkStatusRequest.cs
+++ b/QuickFIXn/Message/FIX44/NetworkStatusRequest.cs
@@ -132,7 +132,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RefCompID RefCompID
+                public QuickFix.Fields.RefCompID RefCompID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX44/NetworkStatusResponse.cs
+++ b/QuickFIXn/Message/FIX44/NetworkStatusResponse.cs
@@ -192,7 +192,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RefCompID RefCompID
+                public QuickFix.Fields.RefCompID RefCompID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX44/NewOrderCross.cs
+++ b/QuickFIXn/Message/FIX44/NewOrderCross.cs
@@ -3457,7 +3457,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Side Side
+                public QuickFix.Fields.Side Side
                 { 
                     get 
                     {
@@ -4713,7 +4713,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -4853,7 +4853,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.PartySubID PartySubID
+                        public QuickFix.Fields.PartySubID PartySubID
                         { 
                             get 
                             {
@@ -4934,7 +4934,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.AllocAccount AllocAccount
+                    public QuickFix.Fields.AllocAccount AllocAccount
                     { 
                         get 
                         {
@@ -5136,7 +5136,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartyID NestedPartyID
+                        public QuickFix.Fields.NestedPartyID NestedPartyID
                         { 
                             get 
                             {
@@ -5276,7 +5276,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
                             { 
                                 get 
                                 {
@@ -5359,7 +5359,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -5439,7 +5439,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -5581,7 +5581,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -7054,7 +7054,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -7134,7 +7134,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -7215,7 +7215,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -8533,7 +8533,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -8614,7 +8614,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {
@@ -8694,7 +8694,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX44/NewOrderList.cs
+++ b/QuickFIXn/Message/FIX44/NewOrderList.cs
@@ -630,7 +630,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ClOrdID ClOrdID
+                public QuickFix.Fields.ClOrdID ClOrdID
                 { 
                     get 
                     {
@@ -5203,7 +5203,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -5343,7 +5343,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.PartySubID PartySubID
+                        public QuickFix.Fields.PartySubID PartySubID
                         { 
                             get 
                             {
@@ -5424,7 +5424,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.AllocAccount AllocAccount
+                    public QuickFix.Fields.AllocAccount AllocAccount
                     { 
                         get 
                         {
@@ -5626,7 +5626,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartyID NestedPartyID
+                        public QuickFix.Fields.NestedPartyID NestedPartyID
                         { 
                             get 
                             {
@@ -5766,7 +5766,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
                             { 
                                 get 
                                 {
@@ -5848,7 +5848,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.TradingSessionID TradingSessionID
+                    public QuickFix.Fields.TradingSessionID TradingSessionID
                     { 
                         get 
                         {
@@ -5928,7 +5928,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -6008,7 +6008,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -6150,7 +6150,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                     { 
                         get 
                         {
@@ -7623,7 +7623,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                        public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                         { 
                             get 
                             {
@@ -7703,7 +7703,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                        public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                         { 
                             get 
                             {
@@ -7784,7 +7784,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StipulationType StipulationType
+                    public QuickFix.Fields.StipulationType StipulationType
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX44/NewOrderMultileg.cs
+++ b/QuickFIXn/Message/FIX44/NewOrderMultileg.cs
@@ -4106,7 +4106,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -4246,7 +4246,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -4327,7 +4327,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AllocAccount AllocAccount
+                public QuickFix.Fields.AllocAccount AllocAccount
                 { 
                     get 
                     {
@@ -4529,7 +4529,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.Nested3PartyID Nested3PartyID
+                    public QuickFix.Fields.Nested3PartyID Nested3PartyID
                     { 
                         get 
                         {
@@ -4669,7 +4669,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested3PartySubID Nested3PartySubID
+                        public QuickFix.Fields.Nested3PartySubID Nested3PartySubID
                         { 
                             get 
                             {
@@ -4751,7 +4751,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {
@@ -4831,7 +4831,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -4911,7 +4911,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -5053,7 +5053,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -6526,7 +6526,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -6606,7 +6606,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -6687,7 +6687,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -8346,7 +8346,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -8426,7 +8426,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegStipulationType LegStipulationType
+                    public QuickFix.Fields.LegStipulationType LegStipulationType
                     { 
                         get 
                         {
@@ -8506,7 +8506,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegAllocAccount LegAllocAccount
+                    public QuickFix.Fields.LegAllocAccount LegAllocAccount
                     { 
                         get 
                         {
@@ -8708,7 +8708,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested2PartyID Nested2PartyID
+                        public QuickFix.Fields.Nested2PartyID Nested2PartyID
                         { 
                             get 
                             {
@@ -8848,7 +8848,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
+                            public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
                             { 
                                 get 
                                 {
@@ -8930,7 +8930,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -9070,7 +9070,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX44/NewOrderSingle.cs
+++ b/QuickFIXn/Message/FIX44/NewOrderSingle.cs
@@ -4881,7 +4881,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -5021,7 +5021,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -5102,7 +5102,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AllocAccount AllocAccount
+                public QuickFix.Fields.AllocAccount AllocAccount
                 { 
                     get 
                     {
@@ -5304,7 +5304,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -5444,7 +5444,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -5526,7 +5526,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {
@@ -5606,7 +5606,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -5686,7 +5686,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -5828,7 +5828,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -7301,7 +7301,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -7381,7 +7381,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -7462,7 +7462,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX44/News.cs
+++ b/QuickFIXn/Message/FIX44/News.cs
@@ -440,7 +440,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RoutingType RoutingType
+                public QuickFix.Fields.RoutingType RoutingType
                 { 
                     get 
                     {
@@ -520,7 +520,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -1869,7 +1869,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -1949,7 +1949,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -2092,7 +2092,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -3410,7 +3410,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -3491,7 +3491,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -4964,7 +4964,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -5044,7 +5044,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -5125,7 +5125,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Text Text
+                public QuickFix.Fields.Text Text
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX44/OrderCancelReject.cs
+++ b/QuickFIXn/Message/FIX44/OrderCancelReject.cs
@@ -680,7 +680,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EncodedText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX44/OrderCancelReplaceRequest.cs
+++ b/QuickFIXn/Message/FIX44/OrderCancelReplaceRequest.cs
@@ -4852,7 +4852,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -4992,7 +4992,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -5073,7 +5073,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AllocAccount AllocAccount
+                public QuickFix.Fields.AllocAccount AllocAccount
                 { 
                     get 
                     {
@@ -5275,7 +5275,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -5415,7 +5415,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -5497,7 +5497,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {
@@ -5577,7 +5577,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -5657,7 +5657,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -5799,7 +5799,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -7272,7 +7272,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -7352,7 +7352,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX44/OrderCancelRequest.cs
+++ b/QuickFIXn/Message/FIX44/OrderCancelRequest.cs
@@ -2370,7 +2370,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -2510,7 +2510,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -2591,7 +2591,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -2671,7 +2671,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -2813,7 +2813,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -4286,7 +4286,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -4366,7 +4366,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX44/OrderMassCancelReport.cs
+++ b/QuickFIXn/Message/FIX44/OrderMassCancelReport.cs
@@ -3327,7 +3327,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.OrigClOrdID OrigClOrdID
+                public QuickFix.Fields.OrigClOrdID OrigClOrdID
                 { 
                     get 
                     {
@@ -3438,7 +3438,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3518,7 +3518,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -3660,7 +3660,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                 { 
                     get 
                     {
@@ -3740,7 +3740,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX44/OrderMassCancelRequest.cs
+++ b/QuickFIXn/Message/FIX44/OrderMassCancelRequest.cs
@@ -3141,7 +3141,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3221,7 +3221,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -3363,7 +3363,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                 { 
                     get 
                     {
@@ -3443,7 +3443,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX44/OrderMassStatusRequest.cs
+++ b/QuickFIXn/Message/FIX44/OrderMassStatusRequest.cs
@@ -3077,7 +3077,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -3217,7 +3217,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -3298,7 +3298,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3378,7 +3378,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -3520,7 +3520,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                 { 
                     get 
                     {
@@ -3600,7 +3600,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX44/OrderStatusRequest.cs
+++ b/QuickFIXn/Message/FIX44/OrderStatusRequest.cs
@@ -1963,7 +1963,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -2103,7 +2103,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -2184,7 +2184,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -2264,7 +2264,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -2406,7 +2406,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -3879,7 +3879,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -3959,7 +3959,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX44/PositionMaintenanceReport.cs
+++ b/QuickFIXn/Message/FIX44/PositionMaintenanceReport.cs
@@ -2194,7 +2194,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -2334,7 +2334,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -2415,7 +2415,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -2495,7 +2495,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -2637,7 +2637,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -3955,7 +3955,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -4036,7 +4036,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -5509,7 +5509,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -5589,7 +5589,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -5670,7 +5670,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {
@@ -5750,7 +5750,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosType PosType
+                public QuickFix.Fields.PosType PosType
                 { 
                     get 
                     {
@@ -5921,7 +5921,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -6061,7 +6061,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -6143,7 +6143,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosAmtType PosAmtType
+                public QuickFix.Fields.PosAmtType PosAmtType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX44/PositionMaintenanceRequest.cs
+++ b/QuickFIXn/Message/FIX44/PositionMaintenanceRequest.cs
@@ -2159,7 +2159,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -2299,7 +2299,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -2380,7 +2380,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -2460,7 +2460,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -2602,7 +2602,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -3920,7 +3920,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -4001,7 +4001,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -5474,7 +5474,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -5554,7 +5554,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -5635,7 +5635,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {
@@ -5715,7 +5715,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosType PosType
+                public QuickFix.Fields.PosType PosType
                 { 
                     get 
                     {
@@ -5886,7 +5886,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -6026,7 +6026,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX44/PositionReport.cs
+++ b/QuickFIXn/Message/FIX44/PositionReport.cs
@@ -2221,7 +2221,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -2361,7 +2361,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -2442,7 +2442,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -2522,7 +2522,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -2664,7 +2664,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -3982,7 +3982,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -4063,7 +4063,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -5598,7 +5598,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -5678,7 +5678,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -5759,7 +5759,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosType PosType
+                public QuickFix.Fields.PosType PosType
                 { 
                     get 
                     {
@@ -5930,7 +5930,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -6070,7 +6070,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -6152,7 +6152,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosAmtType PosAmtType
+                public QuickFix.Fields.PosAmtType PosAmtType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX44/Quote.cs
+++ b/QuickFIXn/Message/FIX44/Quote.cs
@@ -3914,7 +3914,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.QuoteQualifier QuoteQualifier
+                public QuickFix.Fields.QuoteQualifier QuoteQualifier
                 { 
                     get 
                     {
@@ -3963,7 +3963,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -4103,7 +4103,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -4184,7 +4184,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -4264,7 +4264,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -4406,7 +4406,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -5879,7 +5879,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -5959,7 +5959,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -6040,7 +6040,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -6120,7 +6120,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -7872,7 +7872,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -7952,7 +7952,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegStipulationType LegStipulationType
+                    public QuickFix.Fields.LegStipulationType LegStipulationType
                     { 
                         get 
                         {
@@ -8032,7 +8032,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -8172,7 +8172,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX44/QuoteCancel.cs
+++ b/QuickFIXn/Message/FIX44/QuoteCancel.cs
@@ -380,7 +380,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -520,7 +520,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -601,7 +601,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -2291,7 +2291,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -2371,7 +2371,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -2513,7 +2513,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                     { 
                         get 
                         {
@@ -3986,7 +3986,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                        public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                         { 
                             get 
                             {
@@ -4066,7 +4066,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                        public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                         { 
                             get 
                             {
@@ -4147,7 +4147,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSymbol LegSymbol
+                    public QuickFix.Fields.LegSymbol LegSymbol
                     { 
                         get 
                         {
@@ -5465,7 +5465,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                        public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX44/QuoteRequest.cs
+++ b/QuickFIXn/Message/FIX44/QuoteRequest.cs
@@ -285,7 +285,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -3401,7 +3401,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -3481,7 +3481,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -3623,7 +3623,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                     { 
                         get 
                         {
@@ -5096,7 +5096,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                        public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                         { 
                             get 
                             {
@@ -5176,7 +5176,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                        public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                         { 
                             get 
                             {
@@ -5257,7 +5257,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StipulationType StipulationType
+                    public QuickFix.Fields.StipulationType StipulationType
                     { 
                         get 
                         {
@@ -5337,7 +5337,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSymbol LegSymbol
+                    public QuickFix.Fields.LegSymbol LegSymbol
                     { 
                         get 
                         {
@@ -6996,7 +6996,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                        public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                         { 
                             get 
                             {
@@ -7076,7 +7076,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegStipulationType LegStipulationType
+                        public QuickFix.Fields.LegStipulationType LegStipulationType
                         { 
                             get 
                             {
@@ -7156,7 +7156,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartyID NestedPartyID
+                        public QuickFix.Fields.NestedPartyID NestedPartyID
                         { 
                             get 
                             {
@@ -7296,7 +7296,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
                             { 
                                 get 
                                 {
@@ -7378,7 +7378,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.QuoteQualifier QuoteQualifier
+                    public QuickFix.Fields.QuoteQualifier QuoteQualifier
                     { 
                         get 
                         {
@@ -7427,7 +7427,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -7567,7 +7567,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.PartySubID PartySubID
+                        public QuickFix.Fields.PartySubID PartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX44/QuoteRequestReject.cs
+++ b/QuickFIXn/Message/FIX44/QuoteRequestReject.cs
@@ -969,7 +969,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -3341,7 +3341,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -3421,7 +3421,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -3563,7 +3563,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                     { 
                         get 
                         {
@@ -5036,7 +5036,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                        public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                         { 
                             get 
                             {
@@ -5116,7 +5116,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                        public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                         { 
                             get 
                             {
@@ -5197,7 +5197,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StipulationType StipulationType
+                    public QuickFix.Fields.StipulationType StipulationType
                     { 
                         get 
                         {
@@ -5277,7 +5277,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSymbol LegSymbol
+                    public QuickFix.Fields.LegSymbol LegSymbol
                     { 
                         get 
                         {
@@ -6936,7 +6936,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                        public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                         { 
                             get 
                             {
@@ -7016,7 +7016,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegStipulationType LegStipulationType
+                        public QuickFix.Fields.LegStipulationType LegStipulationType
                         { 
                             get 
                             {
@@ -7096,7 +7096,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartyID NestedPartyID
+                        public QuickFix.Fields.NestedPartyID NestedPartyID
                         { 
                             get 
                             {
@@ -7236,7 +7236,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
                             { 
                                 get 
                                 {
@@ -7319,7 +7319,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.QuoteQualifier QuoteQualifier
+                public QuickFix.Fields.QuoteQualifier QuoteQualifier
                 { 
                     get 
                     {
@@ -7368,7 +7368,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -7508,7 +7508,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX44/QuoteResponse.cs
+++ b/QuickFIXn/Message/FIX44/QuoteResponse.cs
@@ -3978,7 +3978,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.QuoteQualifier QuoteQualifier
+                public QuickFix.Fields.QuoteQualifier QuoteQualifier
                 { 
                     get 
                     {
@@ -4027,7 +4027,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -4167,7 +4167,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -4248,7 +4248,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -4328,7 +4328,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -4470,7 +4470,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -5943,7 +5943,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -6023,7 +6023,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -6104,7 +6104,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -6184,7 +6184,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -7936,7 +7936,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -8016,7 +8016,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegStipulationType LegStipulationType
+                    public QuickFix.Fields.LegStipulationType LegStipulationType
                     { 
                         get 
                         {
@@ -8096,7 +8096,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -8236,7 +8236,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX44/QuoteStatusReport.cs
+++ b/QuickFIXn/Message/FIX44/QuoteStatusReport.cs
@@ -3976,7 +3976,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -4116,7 +4116,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -4197,7 +4197,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -4277,7 +4277,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -4419,7 +4419,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -5892,7 +5892,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -5972,7 +5972,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -6053,7 +6053,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -6133,7 +6133,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -7637,7 +7637,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -7717,7 +7717,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegStipulationType LegStipulationType
+                    public QuickFix.Fields.LegStipulationType LegStipulationType
                     { 
                         get 
                         {
@@ -7797,7 +7797,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -7937,7 +7937,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -8019,7 +8019,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.QuoteQualifier QuoteQualifier
+                public QuickFix.Fields.QuoteQualifier QuoteQualifier
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX44/QuoteStatusRequest.cs
+++ b/QuickFIXn/Message/FIX44/QuoteStatusRequest.cs
@@ -1990,7 +1990,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -2070,7 +2070,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -2212,7 +2212,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -3685,7 +3685,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -3765,7 +3765,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -3846,7 +3846,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -5164,7 +5164,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -5245,7 +5245,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -5385,7 +5385,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX44/RFQRequest.cs
+++ b/QuickFIXn/Message/FIX44/RFQRequest.cs
@@ -130,7 +130,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -1696,7 +1696,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -1776,7 +1776,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -1918,7 +1918,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                     { 
                         get 
                         {
@@ -3391,7 +3391,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                        public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                         { 
                             get 
                             {
@@ -3471,7 +3471,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                        public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                         { 
                             get 
                             {
@@ -3552,7 +3552,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSymbol LegSymbol
+                    public QuickFix.Fields.LegSymbol LegSymbol
                     { 
                         get 
                         {
@@ -4870,7 +4870,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                        public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX44/RegistrationInstructions.cs
+++ b/QuickFIXn/Message/FIX44/RegistrationInstructions.cs
@@ -413,7 +413,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -553,7 +553,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -634,7 +634,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RegistDtls RegistDtls
+                public QuickFix.Fields.RegistDtls RegistDtls
                 { 
                     get 
                     {
@@ -898,7 +898,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -1038,7 +1038,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -1120,7 +1120,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.DistribPaymentMethod DistribPaymentMethod
+                public QuickFix.Fields.DistribPaymentMethod DistribPaymentMethod
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX44/RegistrationInstructionsResponse.cs
+++ b/QuickFIXn/Message/FIX44/RegistrationInstructionsResponse.cs
@@ -353,7 +353,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -493,7 +493,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX44/Reject.cs
+++ b/QuickFIXn/Message/FIX44/Reject.cs
@@ -238,7 +238,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EncodedText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX44/RequestForPositions.cs
+++ b/QuickFIXn/Message/FIX44/RequestForPositions.cs
@@ -2031,7 +2031,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -2171,7 +2171,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -2252,7 +2252,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -2332,7 +2332,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -2474,7 +2474,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -3792,7 +3792,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -3873,7 +3873,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -5346,7 +5346,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -5426,7 +5426,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -5507,7 +5507,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX44/RequestForPositionsAck.cs
+++ b/QuickFIXn/Message/FIX44/RequestForPositionsAck.cs
@@ -1936,7 +1936,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -2076,7 +2076,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -2157,7 +2157,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -2237,7 +2237,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -2379,7 +2379,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -3697,7 +3697,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -3778,7 +3778,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -5251,7 +5251,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -5331,7 +5331,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX44/ResendRequest.cs
+++ b/QuickFIXn/Message/FIX44/ResendRequest.cs
@@ -85,7 +85,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EndSeqNo);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX44/SecurityDefinition.cs
+++ b/QuickFIXn/Message/FIX44/SecurityDefinition.cs
@@ -1901,7 +1901,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -1981,7 +1981,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -2123,7 +2123,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrAttribType InstrAttribType
+                public QuickFix.Fields.InstrAttribType InstrAttribType
                 { 
                     get 
                     {
@@ -2203,7 +2203,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -3676,7 +3676,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -3756,7 +3756,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -3837,7 +3837,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -5155,7 +5155,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX44/SecurityDefinitionRequest.cs
+++ b/QuickFIXn/Message/FIX44/SecurityDefinitionRequest.cs
@@ -1837,7 +1837,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -1917,7 +1917,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -2059,7 +2059,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrAttribType InstrAttribType
+                public QuickFix.Fields.InstrAttribType InstrAttribType
                 { 
                     get 
                     {
@@ -2139,7 +2139,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -3612,7 +3612,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -3692,7 +3692,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -3773,7 +3773,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -5091,7 +5091,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX44/SecurityList.cs
+++ b/QuickFIXn/Message/FIX44/SecurityList.cs
@@ -227,7 +227,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -2754,7 +2754,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -2834,7 +2834,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -2976,7 +2976,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrAttribType InstrAttribType
+                    public QuickFix.Fields.InstrAttribType InstrAttribType
                     { 
                         get 
                         {
@@ -3056,7 +3056,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                     { 
                         get 
                         {
@@ -4529,7 +4529,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                        public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                         { 
                             get 
                             {
@@ -4609,7 +4609,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                        public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                         { 
                             get 
                             {
@@ -4690,7 +4690,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StipulationType StipulationType
+                    public QuickFix.Fields.StipulationType StipulationType
                     { 
                         get 
                         {
@@ -4770,7 +4770,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSymbol LegSymbol
+                    public QuickFix.Fields.LegSymbol LegSymbol
                     { 
                         get 
                         {
@@ -6336,7 +6336,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                        public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                         { 
                             get 
                             {
@@ -6416,7 +6416,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegStipulationType LegStipulationType
+                        public QuickFix.Fields.LegStipulationType LegStipulationType
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX44/SecurityListRequest.cs
+++ b/QuickFIXn/Message/FIX44/SecurityListRequest.cs
@@ -2085,7 +2085,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -2165,7 +2165,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -2307,7 +2307,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrAttribType InstrAttribType
+                public QuickFix.Fields.InstrAttribType InstrAttribType
                 { 
                     get 
                     {
@@ -2387,7 +2387,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -3860,7 +3860,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -3940,7 +3940,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -4021,7 +4021,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -5339,7 +5339,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX44/SecurityStatus.cs
+++ b/QuickFIXn/Message/FIX44/SecurityStatus.cs
@@ -2176,7 +2176,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -2256,7 +2256,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -2398,7 +2398,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrAttribType InstrAttribType
+                public QuickFix.Fields.InstrAttribType InstrAttribType
                 { 
                     get 
                     {
@@ -2478,7 +2478,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -3951,7 +3951,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -4031,7 +4031,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -4112,7 +4112,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -5430,7 +5430,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX44/SecurityStatusRequest.cs
+++ b/QuickFIXn/Message/FIX44/SecurityStatusRequest.cs
@@ -1684,7 +1684,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -1764,7 +1764,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -1906,7 +1906,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrAttribType InstrAttribType
+                public QuickFix.Fields.InstrAttribType InstrAttribType
                 { 
                     get 
                     {
@@ -1986,7 +1986,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -3459,7 +3459,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -3539,7 +3539,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -3620,7 +3620,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -4938,7 +4938,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX44/SecurityTypeRequest.cs
+++ b/QuickFIXn/Message/FIX44/SecurityTypeRequest.cs
@@ -300,7 +300,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.SecuritySubType);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX44/SecurityTypes.cs
+++ b/QuickFIXn/Message/FIX44/SecurityTypes.cs
@@ -413,7 +413,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityType SecurityType
+                public QuickFix.Fields.SecurityType SecurityType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX44/SequenceReset.cs
+++ b/QuickFIXn/Message/FIX44/SequenceReset.cs
@@ -83,7 +83,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.NewSeqNo);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX44/SettlementInstructionRequest.cs
+++ b/QuickFIXn/Message/FIX44/SettlementInstructionRequest.cs
@@ -504,7 +504,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -644,7 +644,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX44/SettlementInstructions.cs
+++ b/QuickFIXn/Message/FIX44/SettlementInstructions.cs
@@ -382,7 +382,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SettlInstID SettlInstID
+                public QuickFix.Fields.SettlInstID SettlInstID
                 { 
                     get 
                     {
@@ -1173,7 +1173,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -1313,7 +1313,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.PartySubID PartySubID
+                        public QuickFix.Fields.PartySubID PartySubID
                         { 
                             get 
                             {
@@ -1394,7 +1394,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SettlInstSource SettlInstSource
+                    public QuickFix.Fields.SettlInstSource SettlInstSource
                     { 
                         get 
                         {
@@ -1503,7 +1503,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SettlPartyID SettlPartyID
+                        public QuickFix.Fields.SettlPartyID SettlPartyID
                         { 
                             get 
                             {
@@ -1643,7 +1643,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.SettlPartySubID SettlPartySubID
+                            public QuickFix.Fields.SettlPartySubID SettlPartySubID
                             { 
                                 get 
                                 {

--- a/QuickFIXn/Message/FIX44/TestRequest.cs
+++ b/QuickFIXn/Message/FIX44/TestRequest.cs
@@ -52,7 +52,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.TestReqID);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX44/TradeCaptureReport.cs
+++ b/QuickFIXn/Message/FIX44/TradeCaptureReport.cs
@@ -3862,7 +3862,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3942,7 +3942,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -4084,7 +4084,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -5557,7 +5557,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -5637,7 +5637,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -5718,7 +5718,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosAmtType PosAmtType
+                public QuickFix.Fields.PosAmtType PosAmtType
                 { 
                     get 
                     {
@@ -5798,7 +5798,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -7457,7 +7457,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -7537,7 +7537,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegStipulationType LegStipulationType
+                    public QuickFix.Fields.LegStipulationType LegStipulationType
                     { 
                         get 
                         {
@@ -7617,7 +7617,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -7757,7 +7757,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -7839,7 +7839,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
+                public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
                 { 
                     get 
                     {
@@ -7950,7 +7950,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Side Side
+                public QuickFix.Fields.Side Side
                 { 
                     get 
                     {
@@ -9888,7 +9888,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -10028,7 +10028,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.PartySubID PartySubID
+                        public QuickFix.Fields.PartySubID PartySubID
                         { 
                             get 
                             {
@@ -10109,7 +10109,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ClearingInstruction ClearingInstruction
+                    public QuickFix.Fields.ClearingInstruction ClearingInstruction
                     { 
                         get 
                         {
@@ -10158,7 +10158,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ContAmtType ContAmtType
+                    public QuickFix.Fields.ContAmtType ContAmtType
                     { 
                         get 
                         {
@@ -10269,7 +10269,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StipulationType StipulationType
+                    public QuickFix.Fields.StipulationType StipulationType
                     { 
                         get 
                         {
@@ -10349,7 +10349,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
+                    public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
                     { 
                         get 
                         {
@@ -10491,7 +10491,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.AllocAccount AllocAccount
+                    public QuickFix.Fields.AllocAccount AllocAccount
                     { 
                         get 
                         {
@@ -10693,7 +10693,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested2PartyID Nested2PartyID
+                        public QuickFix.Fields.Nested2PartyID Nested2PartyID
                         { 
                             get 
                             {
@@ -10833,7 +10833,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
+                            public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
                             { 
                                 get 
                                 {

--- a/QuickFIXn/Message/FIX44/TradeCaptureReportAck.cs
+++ b/QuickFIXn/Message/FIX44/TradeCaptureReportAck.cs
@@ -2490,7 +2490,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -2570,7 +2570,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -2712,7 +2712,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
+                public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
                 { 
                     get 
                     {
@@ -2823,7 +2823,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -4482,7 +4482,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -4562,7 +4562,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegStipulationType LegStipulationType
+                    public QuickFix.Fields.LegStipulationType LegStipulationType
                     { 
                         get 
                         {
@@ -4642,7 +4642,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -4782,7 +4782,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -4864,7 +4864,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AllocAccount AllocAccount
+                public QuickFix.Fields.AllocAccount AllocAccount
                 { 
                     get 
                     {
@@ -5066,7 +5066,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.Nested2PartyID Nested2PartyID
+                    public QuickFix.Fields.Nested2PartyID Nested2PartyID
                     { 
                         get 
                         {
@@ -5206,7 +5206,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
+                        public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX44/TradeCaptureReportRequest.cs
+++ b/QuickFIXn/Message/FIX44/TradeCaptureReportRequest.cs
@@ -2767,7 +2767,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -2907,7 +2907,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -2988,7 +2988,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3068,7 +3068,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -3210,7 +3210,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrAttribType InstrAttribType
+                public QuickFix.Fields.InstrAttribType InstrAttribType
                 { 
                     get 
                     {
@@ -3290,7 +3290,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -4763,7 +4763,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -4843,7 +4843,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -4924,7 +4924,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -6242,7 +6242,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -6323,7 +6323,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradeDate TradeDate
+                public QuickFix.Fields.TradeDate TradeDate
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX44/TradeCaptureReportRequestAck.cs
+++ b/QuickFIXn/Message/FIX44/TradeCaptureReportRequestAck.cs
@@ -1810,7 +1810,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -1890,7 +1890,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -2032,7 +2032,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -3505,7 +3505,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -3585,7 +3585,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -3666,7 +3666,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -4984,7 +4984,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX44/TradingSessionStatus.cs
+++ b/QuickFIXn/Message/FIX44/TradingSessionStatus.cs
@@ -550,7 +550,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EncodedText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX44/TradingSessionStatusRequest.cs
+++ b/QuickFIXn/Message/FIX44/TradingSessionStatusRequest.cs
@@ -209,7 +209,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.SubscriptionRequestType);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX44/UserRequest.cs
+++ b/QuickFIXn/Message/FIX44/UserRequest.cs
@@ -242,7 +242,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.RawData);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX44/UserResponse.cs
+++ b/QuickFIXn/Message/FIX44/UserResponse.cs
@@ -147,7 +147,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.UserStatusText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX50/AdjustedPositionReport.cs
+++ b/QuickFIXn/Message/FIX50/AdjustedPositionReport.cs
@@ -1992,7 +1992,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -2132,7 +2132,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -2213,7 +2213,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosType PosType
+                public QuickFix.Fields.PosType PosType
                 { 
                     get 
                     {
@@ -2415,7 +2415,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -2555,7 +2555,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -2637,7 +2637,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -2717,7 +2717,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -2859,7 +2859,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -2999,7 +2999,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50/Advertisement.cs
+++ b/QuickFIXn/Message/FIX50/Advertisement.cs
@@ -2306,7 +2306,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -2386,7 +2386,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -2528,7 +2528,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -2668,7 +2668,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -2749,7 +2749,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -4129,7 +4129,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -4210,7 +4210,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -6024,7 +6024,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -6104,7 +6104,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -6184,7 +6184,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -6324,7 +6324,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50/AllocationInstruction.cs
+++ b/QuickFIXn/Message/FIX50/AllocationInstruction.cs
@@ -4635,7 +4635,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ClOrdID ClOrdID
+                public QuickFix.Fields.ClOrdID ClOrdID
                 { 
                     get 
                     {
@@ -4930,7 +4930,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.Nested2PartyID Nested2PartyID
+                    public QuickFix.Fields.Nested2PartyID Nested2PartyID
                     { 
                         get 
                         {
@@ -5070,7 +5070,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
+                        public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
                         { 
                             get 
                             {
@@ -5152,7 +5152,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LastQty LastQty
+                public QuickFix.Fields.LastQty LastQty
                 { 
                     get 
                     {
@@ -5418,7 +5418,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -5498,7 +5498,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -5640,7 +5640,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -5780,7 +5780,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -5861,7 +5861,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrAttribType InstrAttribType
+                public QuickFix.Fields.InstrAttribType InstrAttribType
                 { 
                     get 
                     {
@@ -5941,7 +5941,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -7755,7 +7755,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -7835,7 +7835,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -7915,7 +7915,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -8055,7 +8055,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -8137,7 +8137,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -9517,7 +9517,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -9598,7 +9598,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -9738,7 +9738,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -9819,7 +9819,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -9899,7 +9899,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AllocAccount AllocAccount
+                public QuickFix.Fields.AllocAccount AllocAccount
                 { 
                     get 
                     {
@@ -11186,7 +11186,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -11326,7 +11326,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -11407,7 +11407,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
+                    public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
                     { 
                         get 
                         {
@@ -11549,7 +11549,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ClearingInstruction ClearingInstruction
+                    public QuickFix.Fields.ClearingInstruction ClearingInstruction
                     { 
                         get 
                         {
@@ -11598,7 +11598,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SettlInstSource SettlInstSource
+                    public QuickFix.Fields.SettlInstSource SettlInstSource
                     { 
                         get 
                         {
@@ -11707,7 +11707,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SettlPartyID SettlPartyID
+                        public QuickFix.Fields.SettlPartyID SettlPartyID
                         { 
                             get 
                             {
@@ -11847,7 +11847,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.SettlPartySubID SettlPartySubID
+                            public QuickFix.Fields.SettlPartySubID SettlPartySubID
                             { 
                                 get 
                                 {
@@ -11930,7 +11930,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosAmtType PosAmtType
+                public QuickFix.Fields.PosAmtType PosAmtType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50/AllocationInstructionAck.cs
+++ b/QuickFIXn/Message/FIX50/AllocationInstructionAck.cs
@@ -535,7 +535,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -675,7 +675,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -756,7 +756,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AllocAccount AllocAccount
+                public QuickFix.Fields.AllocAccount AllocAccount
                 { 
                     get 
                     {
@@ -1206,7 +1206,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -1346,7 +1346,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50/AllocationInstructionAlert.cs
+++ b/QuickFIXn/Message/FIX50/AllocationInstructionAlert.cs
@@ -4635,7 +4635,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ClOrdID ClOrdID
+                public QuickFix.Fields.ClOrdID ClOrdID
                 { 
                     get 
                     {
@@ -4930,7 +4930,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.Nested2PartyID Nested2PartyID
+                    public QuickFix.Fields.Nested2PartyID Nested2PartyID
                     { 
                         get 
                         {
@@ -5070,7 +5070,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
+                        public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
                         { 
                             get 
                             {
@@ -5152,7 +5152,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LastQty LastQty
+                public QuickFix.Fields.LastQty LastQty
                 { 
                     get 
                     {
@@ -5418,7 +5418,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -5498,7 +5498,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -5640,7 +5640,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -5780,7 +5780,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -5861,7 +5861,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrAttribType InstrAttribType
+                public QuickFix.Fields.InstrAttribType InstrAttribType
                 { 
                     get 
                     {
@@ -5941,7 +5941,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -7755,7 +7755,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -7835,7 +7835,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -7915,7 +7915,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -8055,7 +8055,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -8137,7 +8137,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -9517,7 +9517,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -9598,7 +9598,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -9738,7 +9738,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -9819,7 +9819,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -9899,7 +9899,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosAmtType PosAmtType
+                public QuickFix.Fields.PosAmtType PosAmtType
                 { 
                     get 
                     {
@@ -10010,7 +10010,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AllocAccount AllocAccount
+                public QuickFix.Fields.AllocAccount AllocAccount
                 { 
                     get 
                     {
@@ -11297,7 +11297,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -11437,7 +11437,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -11518,7 +11518,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
+                    public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
                     { 
                         get 
                         {
@@ -11660,7 +11660,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ClearingInstruction ClearingInstruction
+                    public QuickFix.Fields.ClearingInstruction ClearingInstruction
                     { 
                         get 
                         {
@@ -11709,7 +11709,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SettlInstSource SettlInstSource
+                    public QuickFix.Fields.SettlInstSource SettlInstSource
                     { 
                         get 
                         {
@@ -11818,7 +11818,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SettlPartyID SettlPartyID
+                        public QuickFix.Fields.SettlPartyID SettlPartyID
                         { 
                             get 
                             {
@@ -11958,7 +11958,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.SettlPartySubID SettlPartySubID
+                            public QuickFix.Fields.SettlPartySubID SettlPartySubID
                             { 
                                 get 
                                 {

--- a/QuickFIXn/Message/FIX50/AllocationReport.cs
+++ b/QuickFIXn/Message/FIX50/AllocationReport.cs
@@ -4794,7 +4794,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ClOrdID ClOrdID
+                public QuickFix.Fields.ClOrdID ClOrdID
                 { 
                     get 
                     {
@@ -5089,7 +5089,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.Nested2PartyID Nested2PartyID
+                    public QuickFix.Fields.Nested2PartyID Nested2PartyID
                     { 
                         get 
                         {
@@ -5229,7 +5229,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
+                        public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
                         { 
                             get 
                             {
@@ -5311,7 +5311,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LastQty LastQty
+                public QuickFix.Fields.LastQty LastQty
                 { 
                     get 
                     {
@@ -5577,7 +5577,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -5657,7 +5657,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -5799,7 +5799,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -5939,7 +5939,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -6020,7 +6020,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrAttribType InstrAttribType
+                public QuickFix.Fields.InstrAttribType InstrAttribType
                 { 
                     get 
                     {
@@ -6100,7 +6100,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -7914,7 +7914,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -7994,7 +7994,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -8074,7 +8074,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -8214,7 +8214,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -8296,7 +8296,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -9676,7 +9676,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -9757,7 +9757,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -9897,7 +9897,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -9978,7 +9978,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -10058,7 +10058,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AllocAccount AllocAccount
+                public QuickFix.Fields.AllocAccount AllocAccount
                 { 
                     get 
                     {
@@ -11345,7 +11345,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -11485,7 +11485,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -11566,7 +11566,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
+                    public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
                     { 
                         get 
                         {
@@ -11708,7 +11708,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ClearingInstruction ClearingInstruction
+                    public QuickFix.Fields.ClearingInstruction ClearingInstruction
                     { 
                         get 
                         {
@@ -11757,7 +11757,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SettlInstSource SettlInstSource
+                    public QuickFix.Fields.SettlInstSource SettlInstSource
                     { 
                         get 
                         {
@@ -11866,7 +11866,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SettlPartyID SettlPartyID
+                        public QuickFix.Fields.SettlPartyID SettlPartyID
                         { 
                             get 
                             {
@@ -12006,7 +12006,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.SettlPartySubID SettlPartySubID
+                            public QuickFix.Fields.SettlPartySubID SettlPartySubID
                             { 
                                 get 
                                 {
@@ -12089,7 +12089,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosAmtType PosAmtType
+                public QuickFix.Fields.PosAmtType PosAmtType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50/AllocationReportAck.cs
+++ b/QuickFIXn/Message/FIX50/AllocationReportAck.cs
@@ -690,7 +690,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -830,7 +830,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -911,7 +911,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AllocAccount AllocAccount
+                public QuickFix.Fields.AllocAccount AllocAccount
                 { 
                     get 
                     {
@@ -1361,7 +1361,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -1501,7 +1501,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50/AssignmentReport.cs
+++ b/QuickFIXn/Message/FIX50/AssignmentReport.cs
@@ -2550,7 +2550,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -2690,7 +2690,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -2771,7 +2771,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -2851,7 +2851,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -2993,7 +2993,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -3133,7 +3133,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -3214,7 +3214,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -4594,7 +4594,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -4675,7 +4675,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -6489,7 +6489,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -6569,7 +6569,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -6649,7 +6649,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -6789,7 +6789,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -6871,7 +6871,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosType PosType
+                public QuickFix.Fields.PosType PosType
                 { 
                     get 
                     {
@@ -7073,7 +7073,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -7213,7 +7213,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -7295,7 +7295,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosAmtType PosAmtType
+                public QuickFix.Fields.PosAmtType PosAmtType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50/BidRequest.cs
+++ b/QuickFIXn/Message/FIX50/BidRequest.cs
@@ -946,7 +946,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.BidDescriptorType BidDescriptorType
+                public QuickFix.Fields.BidDescriptorType BidDescriptorType
                 { 
                     get 
                     {
@@ -1305,7 +1305,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ListID ListID
+                public QuickFix.Fields.ListID ListID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50/BidResponse.cs
+++ b/QuickFIXn/Message/FIX50/BidResponse.cs
@@ -124,7 +124,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Commission Commission
+                public QuickFix.Fields.Commission Commission
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50/BusinessMessageReject.cs
+++ b/QuickFIXn/Message/FIX50/BusinessMessageReject.cs
@@ -240,7 +240,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EncodedText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX50/CollateralAssignment.cs
+++ b/QuickFIXn/Message/FIX50/CollateralAssignment.cs
@@ -3732,7 +3732,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -3872,7 +3872,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -3953,7 +3953,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ExecID ExecID
+                public QuickFix.Fields.ExecID ExecID
                 { 
                     get 
                     {
@@ -4002,7 +4002,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradeReportID TradeReportID
+                public QuickFix.Fields.TradeReportID TradeReportID
                 { 
                     get 
                     {
@@ -4082,7 +4082,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -4162,7 +4162,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -4304,7 +4304,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -4444,7 +4444,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -4525,7 +4525,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -5905,7 +5905,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -5986,7 +5986,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -7831,7 +7831,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -7911,7 +7911,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -7991,7 +7991,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -8131,7 +8131,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -8213,7 +8213,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
+                public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
                 { 
                     get 
                     {
@@ -8417,7 +8417,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
+                public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
                 { 
                     get 
                     {
@@ -8559,7 +8559,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -8639,7 +8639,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SettlInstSource SettlInstSource
+                public QuickFix.Fields.SettlInstSource SettlInstSource
                 { 
                     get 
                     {
@@ -8748,7 +8748,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SettlPartyID SettlPartyID
+                    public QuickFix.Fields.SettlPartyID SettlPartyID
                     { 
                         get 
                         {
@@ -8888,7 +8888,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SettlPartySubID SettlPartySubID
+                        public QuickFix.Fields.SettlPartySubID SettlPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50/CollateralInquiry.cs
+++ b/QuickFIXn/Message/FIX50/CollateralInquiry.cs
@@ -3627,7 +3627,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.CollInquiryQualifier CollInquiryQualifier
+                public QuickFix.Fields.CollInquiryQualifier CollInquiryQualifier
                 { 
                     get 
                     {
@@ -3676,7 +3676,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -3816,7 +3816,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -3897,7 +3897,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ExecID ExecID
+                public QuickFix.Fields.ExecID ExecID
                 { 
                     get 
                     {
@@ -3946,7 +3946,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradeReportID TradeReportID
+                public QuickFix.Fields.TradeReportID TradeReportID
                 { 
                     get 
                     {
@@ -4026,7 +4026,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -4106,7 +4106,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -4248,7 +4248,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -4388,7 +4388,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -4469,7 +4469,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -5849,7 +5849,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -5930,7 +5930,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -7744,7 +7744,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -7824,7 +7824,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -7904,7 +7904,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -8044,7 +8044,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -8126,7 +8126,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
+                public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
                 { 
                     get 
                     {
@@ -8330,7 +8330,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -8410,7 +8410,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SettlInstSource SettlInstSource
+                public QuickFix.Fields.SettlInstSource SettlInstSource
                 { 
                     get 
                     {
@@ -8519,7 +8519,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SettlPartyID SettlPartyID
+                    public QuickFix.Fields.SettlPartyID SettlPartyID
                     { 
                         get 
                         {
@@ -8659,7 +8659,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SettlPartySubID SettlPartySubID
+                        public QuickFix.Fields.SettlPartySubID SettlPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50/CollateralInquiryAck.cs
+++ b/QuickFIXn/Message/FIX50/CollateralInquiryAck.cs
@@ -2922,7 +2922,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.CollInquiryQualifier CollInquiryQualifier
+                public QuickFix.Fields.CollInquiryQualifier CollInquiryQualifier
                 { 
                     get 
                     {
@@ -2971,7 +2971,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -3111,7 +3111,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -3192,7 +3192,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ExecID ExecID
+                public QuickFix.Fields.ExecID ExecID
                 { 
                     get 
                     {
@@ -3241,7 +3241,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradeReportID TradeReportID
+                public QuickFix.Fields.TradeReportID TradeReportID
                 { 
                     get 
                     {
@@ -3321,7 +3321,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3401,7 +3401,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -3543,7 +3543,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -3683,7 +3683,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -3764,7 +3764,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -5144,7 +5144,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -5225,7 +5225,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -7039,7 +7039,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -7119,7 +7119,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -7199,7 +7199,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -7339,7 +7339,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50/CollateralReport.cs
+++ b/QuickFIXn/Message/FIX50/CollateralReport.cs
@@ -3759,7 +3759,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -3899,7 +3899,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -3980,7 +3980,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ExecID ExecID
+                public QuickFix.Fields.ExecID ExecID
                 { 
                     get 
                     {
@@ -4029,7 +4029,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradeReportID TradeReportID
+                public QuickFix.Fields.TradeReportID TradeReportID
                 { 
                     get 
                     {
@@ -4109,7 +4109,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -4189,7 +4189,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -4331,7 +4331,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -4471,7 +4471,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -4552,7 +4552,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -5932,7 +5932,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -6013,7 +6013,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -7827,7 +7827,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -7907,7 +7907,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -7987,7 +7987,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -8127,7 +8127,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -8209,7 +8209,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
+                public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
                 { 
                     get 
                     {
@@ -8413,7 +8413,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
+                public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
                 { 
                     get 
                     {
@@ -8555,7 +8555,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -8635,7 +8635,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SettlInstSource SettlInstSource
+                public QuickFix.Fields.SettlInstSource SettlInstSource
                 { 
                     get 
                     {
@@ -8744,7 +8744,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SettlPartyID SettlPartyID
+                    public QuickFix.Fields.SettlPartyID SettlPartyID
                     { 
                         get 
                         {
@@ -8884,7 +8884,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SettlPartySubID SettlPartySubID
+                        public QuickFix.Fields.SettlPartySubID SettlPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50/CollateralRequest.cs
+++ b/QuickFIXn/Message/FIX50/CollateralRequest.cs
@@ -3482,7 +3482,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -3622,7 +3622,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -3703,7 +3703,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ExecID ExecID
+                public QuickFix.Fields.ExecID ExecID
                 { 
                     get 
                     {
@@ -3752,7 +3752,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradeReportID TradeReportID
+                public QuickFix.Fields.TradeReportID TradeReportID
                 { 
                     get 
                     {
@@ -3832,7 +3832,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3912,7 +3912,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -4054,7 +4054,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -4194,7 +4194,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -4275,7 +4275,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -5655,7 +5655,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -5736,7 +5736,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -7581,7 +7581,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -7661,7 +7661,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -7741,7 +7741,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -7881,7 +7881,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -7963,7 +7963,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
+                public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
                 { 
                     get 
                     {
@@ -8167,7 +8167,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
+                public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
                 { 
                     get 
                     {
@@ -8309,7 +8309,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50/CollateralResponse.cs
+++ b/QuickFIXn/Message/FIX50/CollateralResponse.cs
@@ -3544,7 +3544,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -3684,7 +3684,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -3765,7 +3765,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ExecID ExecID
+                public QuickFix.Fields.ExecID ExecID
                 { 
                     get 
                     {
@@ -3814,7 +3814,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradeReportID TradeReportID
+                public QuickFix.Fields.TradeReportID TradeReportID
                 { 
                     get 
                     {
@@ -3894,7 +3894,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3974,7 +3974,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -4116,7 +4116,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -4256,7 +4256,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -4337,7 +4337,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -5717,7 +5717,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -5798,7 +5798,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -7643,7 +7643,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -7723,7 +7723,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -7803,7 +7803,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -7943,7 +7943,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -8025,7 +8025,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
+                public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
                 { 
                     get 
                     {
@@ -8229,7 +8229,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
+                public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
                 { 
                     get 
                     {
@@ -8371,7 +8371,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50/Confirmation.cs
+++ b/QuickFIXn/Message/FIX50/Confirmation.cs
@@ -4616,7 +4616,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -4756,7 +4756,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -4837,7 +4837,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ClOrdID ClOrdID
+                public QuickFix.Fields.ClOrdID ClOrdID
                 { 
                     get 
                     {
@@ -5132,7 +5132,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.Nested2PartyID Nested2PartyID
+                    public QuickFix.Fields.Nested2PartyID Nested2PartyID
                     { 
                         get 
                         {
@@ -5272,7 +5272,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
+                        public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
                         { 
                             get 
                             {
@@ -5354,7 +5354,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
+                public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
                 { 
                     get 
                     {
@@ -5558,7 +5558,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -5638,7 +5638,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -5780,7 +5780,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -5920,7 +5920,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -6001,7 +6001,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrAttribType InstrAttribType
+                public QuickFix.Fields.InstrAttribType InstrAttribType
                 { 
                     get 
                     {
@@ -6081,7 +6081,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -7895,7 +7895,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -7975,7 +7975,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -8055,7 +8055,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -8195,7 +8195,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -8277,7 +8277,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -9657,7 +9657,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -9738,7 +9738,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.OrderCapacity OrderCapacity
+                public QuickFix.Fields.OrderCapacity OrderCapacity
                 { 
                     get 
                     {
@@ -9849,7 +9849,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SettlInstSource SettlInstSource
+                public QuickFix.Fields.SettlInstSource SettlInstSource
                 { 
                     get 
                     {
@@ -9958,7 +9958,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SettlPartyID SettlPartyID
+                    public QuickFix.Fields.SettlPartyID SettlPartyID
                     { 
                         get 
                         {
@@ -10098,7 +10098,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SettlPartySubID SettlPartySubID
+                        public QuickFix.Fields.SettlPartySubID SettlPartySubID
                         { 
                             get 
                             {
@@ -10180,7 +10180,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -10260,7 +10260,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
+                public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50/ConfirmationAck.cs
+++ b/QuickFIXn/Message/FIX50/ConfirmationAck.cs
@@ -306,7 +306,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EncodedText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX50/ConfirmationRequest.cs
+++ b/QuickFIXn/Message/FIX50/ConfirmationRequest.cs
@@ -444,7 +444,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ClOrdID ClOrdID
+                public QuickFix.Fields.ClOrdID ClOrdID
                 { 
                     get 
                     {
@@ -739,7 +739,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.Nested2PartyID Nested2PartyID
+                    public QuickFix.Fields.Nested2PartyID Nested2PartyID
                     { 
                         get 
                         {
@@ -879,7 +879,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
+                        public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50/ContraryIntentionReport.cs
+++ b/QuickFIXn/Message/FIX50/ContraryIntentionReport.cs
@@ -2054,7 +2054,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -2194,7 +2194,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -2275,7 +2275,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ExpType ExpType
+                public QuickFix.Fields.ExpType ExpType
                 { 
                     get 
                     {
@@ -2355,7 +2355,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -2435,7 +2435,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -2577,7 +2577,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -2717,7 +2717,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -2798,7 +2798,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -4612,7 +4612,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -4692,7 +4692,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -4772,7 +4772,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -4912,7 +4912,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50/CrossOrderCancelReplaceRequest.cs
+++ b/QuickFIXn/Message/FIX50/CrossOrderCancelReplaceRequest.cs
@@ -4976,7 +4976,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Side Side
+                public QuickFix.Fields.Side Side
                 { 
                     get 
                     {
@@ -6294,7 +6294,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -6434,7 +6434,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.PartySubID PartySubID
+                        public QuickFix.Fields.PartySubID PartySubID
                         { 
                             get 
                             {
@@ -6515,7 +6515,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.AllocAccount AllocAccount
+                    public QuickFix.Fields.AllocAccount AllocAccount
                     { 
                         get 
                         {
@@ -6717,7 +6717,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartyID NestedPartyID
+                        public QuickFix.Fields.NestedPartyID NestedPartyID
                         { 
                             get 
                             {
@@ -6857,7 +6857,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
                             { 
                                 get 
                                 {
@@ -6940,7 +6940,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -7020,7 +7020,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -7162,7 +7162,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -7302,7 +7302,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -7383,7 +7383,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -9197,7 +9197,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -9277,7 +9277,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -9357,7 +9357,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -9497,7 +9497,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -9579,7 +9579,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -10959,7 +10959,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -11040,7 +11040,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {
@@ -11120,7 +11120,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -11200,7 +11200,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StrategyParameterName StrategyParameterName
+                public QuickFix.Fields.StrategyParameterName StrategyParameterName
                 { 
                     get 
                     {
@@ -11311,7 +11311,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RootPartyID RootPartyID
+                public QuickFix.Fields.RootPartyID RootPartyID
                 { 
                     get 
                     {
@@ -11451,7 +11451,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.RootPartySubID RootPartySubID
+                    public QuickFix.Fields.RootPartySubID RootPartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50/CrossOrderCancelRequest.cs
+++ b/QuickFIXn/Message/FIX50/CrossOrderCancelRequest.cs
@@ -2060,7 +2060,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Side Side
+                public QuickFix.Fields.Side Side
                 { 
                     get 
                     {
@@ -2634,7 +2634,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -2774,7 +2774,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.PartySubID PartySubID
+                        public QuickFix.Fields.PartySubID PartySubID
                         { 
                             get 
                             {
@@ -2856,7 +2856,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -2936,7 +2936,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -3078,7 +3078,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -3218,7 +3218,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -3299,7 +3299,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -5113,7 +5113,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -5193,7 +5193,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -5273,7 +5273,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -5413,7 +5413,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -5495,7 +5495,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -6875,7 +6875,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -6956,7 +6956,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RootPartyID RootPartyID
+                public QuickFix.Fields.RootPartyID RootPartyID
                 { 
                     get 
                     {
@@ -7096,7 +7096,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.RootPartySubID RootPartySubID
+                    public QuickFix.Fields.RootPartySubID RootPartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50/DerivativeSecurityList.cs
+++ b/QuickFIXn/Message/FIX50/DerivativeSecurityList.cs
@@ -2025,7 +2025,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                 { 
                     get 
                     {
@@ -2105,7 +2105,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                 { 
                     get 
                     {
@@ -2185,7 +2185,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                 { 
                     get 
                     {
@@ -2325,7 +2325,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                    public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                     { 
                         get 
                         {
@@ -2406,7 +2406,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -4437,7 +4437,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -4517,7 +4517,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -4659,7 +4659,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                     { 
                         get 
                         {
@@ -4799,7 +4799,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                        public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                         { 
                             get 
                             {
@@ -4880,7 +4880,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrAttribType InstrAttribType
+                    public QuickFix.Fields.InstrAttribType InstrAttribType
                     { 
                         get 
                         {
@@ -4960,7 +4960,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSymbol LegSymbol
+                    public QuickFix.Fields.LegSymbol LegSymbol
                     { 
                         get 
                         {
@@ -6340,7 +6340,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                        public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50/DerivativeSecurityListRequest.cs
+++ b/QuickFIXn/Message/FIX50/DerivativeSecurityListRequest.cs
@@ -2147,7 +2147,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                 { 
                     get 
                     {
@@ -2227,7 +2227,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                 { 
                     get 
                     {
@@ -2307,7 +2307,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                 { 
                     get 
                     {
@@ -2447,7 +2447,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                    public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50/DontKnowTrade.cs
+++ b/QuickFIXn/Message/FIX50/DontKnowTrade.cs
@@ -2244,7 +2244,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -2324,7 +2324,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -2466,7 +2466,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -2606,7 +2606,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -2687,7 +2687,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -4501,7 +4501,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -4581,7 +4581,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -4661,7 +4661,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -4801,7 +4801,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -4883,7 +4883,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -6263,7 +6263,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50/Email.cs
+++ b/QuickFIXn/Message/FIX50/Email.cs
@@ -506,7 +506,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RoutingType RoutingType
+                public QuickFix.Fields.RoutingType RoutingType
                 { 
                     get 
                     {
@@ -586,7 +586,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -2276,7 +2276,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -2356,7 +2356,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -2498,7 +2498,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                     { 
                         get 
                         {
@@ -2638,7 +2638,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                        public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                         { 
                             get 
                             {
@@ -2720,7 +2720,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -4534,7 +4534,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -4614,7 +4614,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -4694,7 +4694,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -4834,7 +4834,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -4916,7 +4916,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -6296,7 +6296,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -6377,7 +6377,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Text Text
+                public QuickFix.Fields.Text Text
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50/ExecutionAcknowledgement.cs
+++ b/QuickFIXn/Message/FIX50/ExecutionAcknowledgement.cs
@@ -2430,7 +2430,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -2510,7 +2510,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -2652,7 +2652,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -2792,7 +2792,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -2873,7 +2873,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -4687,7 +4687,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -4767,7 +4767,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -4847,7 +4847,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -4987,7 +4987,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -5069,7 +5069,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -6449,7 +6449,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50/ExecutionReport.cs
+++ b/QuickFIXn/Message/FIX50/ExecutionReport.cs
@@ -8605,7 +8605,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -8745,7 +8745,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -8826,7 +8826,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ContraBroker ContraBroker
+                public QuickFix.Fields.ContraBroker ContraBroker
                 { 
                     get 
                     {
@@ -8999,7 +8999,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -9079,7 +9079,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -9221,7 +9221,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -9361,7 +9361,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -9442,7 +9442,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -11256,7 +11256,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -11336,7 +11336,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -11416,7 +11416,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -11556,7 +11556,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -11638,7 +11638,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -11718,7 +11718,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ContAmtType ContAmtType
+                public QuickFix.Fields.ContAmtType ContAmtType
                 { 
                     get 
                     {
@@ -11829,7 +11829,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -13705,7 +13705,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -13785,7 +13785,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegStipulationType LegStipulationType
+                    public QuickFix.Fields.LegStipulationType LegStipulationType
                     { 
                         get 
                         {
@@ -13865,7 +13865,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -14005,7 +14005,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -14087,7 +14087,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
+                public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
                 { 
                     get 
                     {
@@ -14229,7 +14229,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StrategyParameterName StrategyParameterName
+                public QuickFix.Fields.StrategyParameterName StrategyParameterName
                 { 
                     get 
                     {
@@ -14340,7 +14340,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
+                public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50/IOI.cs
+++ b/QuickFIXn/Message/FIX50/IOI.cs
@@ -3298,7 +3298,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3378,7 +3378,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -3520,7 +3520,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -3660,7 +3660,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -3741,7 +3741,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -5555,7 +5555,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -5635,7 +5635,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -5715,7 +5715,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -5855,7 +5855,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -5937,7 +5937,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -6017,7 +6017,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -7459,7 +7459,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -7539,7 +7539,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegStipulationType LegStipulationType
+                    public QuickFix.Fields.LegStipulationType LegStipulationType
                     { 
                         get 
                         {
@@ -7620,7 +7620,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.IOIQualifier IOIQualifier
+                public QuickFix.Fields.IOIQualifier IOIQualifier
                 { 
                     get 
                     {
@@ -7669,7 +7669,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RoutingType RoutingType
+                public QuickFix.Fields.RoutingType RoutingType
                 { 
                     get 
                     {
@@ -7749,7 +7749,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -7889,7 +7889,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50/ListCancelRequest.cs
+++ b/QuickFIXn/Message/FIX50/ListCancelRequest.cs
@@ -287,7 +287,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -427,7 +427,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50/ListExecute.cs
+++ b/QuickFIXn/Message/FIX50/ListExecute.cs
@@ -240,7 +240,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EncodedText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX50/ListStatus.cs
+++ b/QuickFIXn/Message/FIX50/ListStatus.cs
@@ -419,7 +419,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ClOrdID ClOrdID
+                public QuickFix.Fields.ClOrdID ClOrdID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50/ListStatusRequest.cs
+++ b/QuickFIXn/Message/FIX50/ListStatusRequest.cs
@@ -145,7 +145,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EncodedText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX50/ListStrikePrice.cs
+++ b/QuickFIXn/Message/FIX50/ListStrikePrice.cs
@@ -194,7 +194,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -1884,7 +1884,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -1964,7 +1964,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -2106,7 +2106,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                     { 
                         get 
                         {
@@ -2246,7 +2246,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                        public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                         { 
                             get 
                             {
@@ -2328,7 +2328,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -4421,7 +4421,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -4501,7 +4501,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -4581,7 +4581,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -4721,7 +4721,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50/MarketDataIncrementalRefresh.cs
+++ b/QuickFIXn/Message/FIX50/MarketDataIncrementalRefresh.cs
@@ -279,7 +279,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MDUpdateAction MDUpdateAction
+                public QuickFix.Fields.MDUpdateAction MDUpdateAction
                 { 
                     get 
                     {
@@ -3767,7 +3767,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -3847,7 +3847,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -3989,7 +3989,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                     { 
                         get 
                         {
@@ -4129,7 +4129,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                        public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                         { 
                             get 
                             {
@@ -4210,7 +4210,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                     { 
                         get 
                         {
@@ -6024,7 +6024,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                        public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                         { 
                             get 
                             {
@@ -6104,7 +6104,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                        public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                         { 
                             get 
                             {
@@ -6184,7 +6184,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                        public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                         { 
                             get 
                             {
@@ -6324,7 +6324,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                             { 
                                 get 
                                 {
@@ -6406,7 +6406,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSymbol LegSymbol
+                    public QuickFix.Fields.LegSymbol LegSymbol
                     { 
                         get 
                         {
@@ -7786,7 +7786,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                        public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                         { 
                             get 
                             {
@@ -7867,7 +7867,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -8007,7 +8007,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.PartySubID PartySubID
+                        public QuickFix.Fields.PartySubID PartySubID
                         { 
                             get 
                             {
@@ -8089,7 +8089,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RoutingType RoutingType
+                public QuickFix.Fields.RoutingType RoutingType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50/MarketDataRequest.cs
+++ b/QuickFIXn/Message/FIX50/MarketDataRequest.cs
@@ -475,7 +475,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MDEntryType MDEntryType
+                public QuickFix.Fields.MDEntryType MDEntryType
                 { 
                     get 
                     {
@@ -524,7 +524,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -2431,7 +2431,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -2511,7 +2511,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -2653,7 +2653,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                     { 
                         get 
                         {
@@ -2793,7 +2793,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                        public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                         { 
                             get 
                             {
@@ -2874,7 +2874,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                     { 
                         get 
                         {
@@ -4688,7 +4688,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                        public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                         { 
                             get 
                             {
@@ -4768,7 +4768,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                        public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                         { 
                             get 
                             {
@@ -4848,7 +4848,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                        public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                         { 
                             get 
                             {
@@ -4988,7 +4988,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                             { 
                                 get 
                                 {
@@ -5070,7 +5070,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSymbol LegSymbol
+                    public QuickFix.Fields.LegSymbol LegSymbol
                     { 
                         get 
                         {
@@ -6450,7 +6450,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                        public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                         { 
                             get 
                             {
@@ -6532,7 +6532,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50/MarketDataRequestReject.cs
+++ b/QuickFIXn/Message/FIX50/MarketDataRequestReject.cs
@@ -223,7 +223,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AltMDSourceID AltMDSourceID
+                public QuickFix.Fields.AltMDSourceID AltMDSourceID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50/MarketDataSnapshotFullRefresh.cs
+++ b/QuickFIXn/Message/FIX50/MarketDataSnapshotFullRefresh.cs
@@ -2170,7 +2170,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -2250,7 +2250,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -2392,7 +2392,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -2532,7 +2532,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -2613,7 +2613,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -4427,7 +4427,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -4507,7 +4507,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -4587,7 +4587,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -4727,7 +4727,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -4809,7 +4809,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -6189,7 +6189,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -6270,7 +6270,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MDEntryType MDEntryType
+                public QuickFix.Fields.MDEntryType MDEntryType
                 { 
                     get 
                     {
@@ -7836,7 +7836,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -7976,7 +7976,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.PartySubID PartySubID
+                        public QuickFix.Fields.PartySubID PartySubID
                         { 
                             get 
                             {
@@ -8058,7 +8058,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RoutingType RoutingType
+                public QuickFix.Fields.RoutingType RoutingType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50/MassQuote.cs
+++ b/QuickFIXn/Message/FIX50/MassQuote.cs
@@ -378,7 +378,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -518,7 +518,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -599,7 +599,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.QuoteSetID QuoteSetID
+                public QuickFix.Fields.QuoteSetID QuoteSetID
                 { 
                     get 
                     {
@@ -2568,7 +2568,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -2648,7 +2648,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -2728,7 +2728,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -2868,7 +2868,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -2949,7 +2949,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.QuoteEntryID QuoteEntryID
+                    public QuickFix.Fields.QuoteEntryID QuoteEntryID
                     { 
                         get 
                         {
@@ -5414,7 +5414,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                        public QuickFix.Fields.SecurityAltID SecurityAltID
                         { 
                             get 
                             {
@@ -5494,7 +5494,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.EventType EventType
+                        public QuickFix.Fields.EventType EventType
                         { 
                             get 
                             {
@@ -5636,7 +5636,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                        public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                         { 
                             get 
                             {
@@ -5776,7 +5776,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                             { 
                                 get 
                                 {
@@ -5857,7 +5857,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegSymbol LegSymbol
+                        public QuickFix.Fields.LegSymbol LegSymbol
                         { 
                             get 
                             {
@@ -7237,7 +7237,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                             { 
                                 get 
                                 {

--- a/QuickFIXn/Message/FIX50/MassQuoteAcknowledgement.cs
+++ b/QuickFIXn/Message/FIX50/MassQuoteAcknowledgement.cs
@@ -471,7 +471,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -611,7 +611,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -692,7 +692,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.QuoteSetID QuoteSetID
+                public QuickFix.Fields.QuoteSetID QuoteSetID
                 { 
                     get 
                     {
@@ -2630,7 +2630,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -2710,7 +2710,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -2790,7 +2790,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -2930,7 +2930,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -3011,7 +3011,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.QuoteEntryID QuoteEntryID
+                    public QuickFix.Fields.QuoteEntryID QuoteEntryID
                     { 
                         get 
                         {
@@ -5507,7 +5507,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                        public QuickFix.Fields.SecurityAltID SecurityAltID
                         { 
                             get 
                             {
@@ -5587,7 +5587,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.EventType EventType
+                        public QuickFix.Fields.EventType EventType
                         { 
                             get 
                             {
@@ -5729,7 +5729,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                        public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                         { 
                             get 
                             {
@@ -5869,7 +5869,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                             { 
                                 get 
                                 {
@@ -5950,7 +5950,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegSymbol LegSymbol
+                        public QuickFix.Fields.LegSymbol LegSymbol
                         { 
                             get 
                             {
@@ -7330,7 +7330,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                             { 
                                 get 
                                 {

--- a/QuickFIXn/Message/FIX50/MultilegOrderCancelReplace.cs
+++ b/QuickFIXn/Message/FIX50/MultilegOrderCancelReplace.cs
@@ -5625,7 +5625,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -5765,7 +5765,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -5846,7 +5846,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AllocAccount AllocAccount
+                public QuickFix.Fields.AllocAccount AllocAccount
                 { 
                     get 
                     {
@@ -6048,7 +6048,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.Nested3PartyID Nested3PartyID
+                    public QuickFix.Fields.Nested3PartyID Nested3PartyID
                     { 
                         get 
                         {
@@ -6188,7 +6188,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested3PartySubID Nested3PartySubID
+                        public QuickFix.Fields.Nested3PartySubID Nested3PartySubID
                         { 
                             get 
                             {
@@ -6270,7 +6270,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {
@@ -6350,7 +6350,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -6430,7 +6430,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -6572,7 +6572,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -6712,7 +6712,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -6793,7 +6793,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -8607,7 +8607,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -8687,7 +8687,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -8767,7 +8767,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -8907,7 +8907,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -8989,7 +8989,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -10772,7 +10772,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -10852,7 +10852,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegStipulationType LegStipulationType
+                    public QuickFix.Fields.LegStipulationType LegStipulationType
                     { 
                         get 
                         {
@@ -10932,7 +10932,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegAllocAccount LegAllocAccount
+                    public QuickFix.Fields.LegAllocAccount LegAllocAccount
                     { 
                         get 
                         {
@@ -11134,7 +11134,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested2PartyID Nested2PartyID
+                        public QuickFix.Fields.Nested2PartyID Nested2PartyID
                         { 
                             get 
                             {
@@ -11274,7 +11274,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
+                            public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
                             { 
                                 get 
                                 {
@@ -11356,7 +11356,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -11496,7 +11496,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -11578,7 +11578,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StrategyParameterName StrategyParameterName
+                public QuickFix.Fields.StrategyParameterName StrategyParameterName
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50/NetworkCounterpartySystemStatusRequest.cs
+++ b/QuickFIXn/Message/FIX50/NetworkCounterpartySystemStatusRequest.cs
@@ -132,7 +132,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RefCompID RefCompID
+                public QuickFix.Fields.RefCompID RefCompID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50/NetworkCounterpartySystemStatusResponse.cs
+++ b/QuickFIXn/Message/FIX50/NetworkCounterpartySystemStatusResponse.cs
@@ -194,7 +194,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RefCompID RefCompID
+                public QuickFix.Fields.RefCompID RefCompID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50/NewOrderCross.cs
+++ b/QuickFIXn/Message/FIX50/NewOrderCross.cs
@@ -4881,7 +4881,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Side Side
+                public QuickFix.Fields.Side Side
                 { 
                     get 
                     {
@@ -6199,7 +6199,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -6339,7 +6339,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.PartySubID PartySubID
+                        public QuickFix.Fields.PartySubID PartySubID
                         { 
                             get 
                             {
@@ -6420,7 +6420,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.AllocAccount AllocAccount
+                    public QuickFix.Fields.AllocAccount AllocAccount
                     { 
                         get 
                         {
@@ -6622,7 +6622,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartyID NestedPartyID
+                        public QuickFix.Fields.NestedPartyID NestedPartyID
                         { 
                             get 
                             {
@@ -6762,7 +6762,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
                             { 
                                 get 
                                 {
@@ -6845,7 +6845,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -6925,7 +6925,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -7067,7 +7067,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -7207,7 +7207,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -7288,7 +7288,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -9102,7 +9102,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -9182,7 +9182,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -9262,7 +9262,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -9402,7 +9402,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -9484,7 +9484,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -10864,7 +10864,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -10945,7 +10945,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {
@@ -11025,7 +11025,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -11105,7 +11105,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StrategyParameterName StrategyParameterName
+                public QuickFix.Fields.StrategyParameterName StrategyParameterName
                 { 
                     get 
                     {
@@ -11216,7 +11216,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RootPartyID RootPartyID
+                public QuickFix.Fields.RootPartyID RootPartyID
                 { 
                     get 
                     {
@@ -11356,7 +11356,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.RootPartySubID RootPartySubID
+                    public QuickFix.Fields.RootPartySubID RootPartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50/NewOrderList.cs
+++ b/QuickFIXn/Message/FIX50/NewOrderList.cs
@@ -661,7 +661,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ClOrdID ClOrdID
+                public QuickFix.Fields.ClOrdID ClOrdID
                 { 
                     get 
                     {
@@ -6691,7 +6691,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -6831,7 +6831,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.PartySubID PartySubID
+                        public QuickFix.Fields.PartySubID PartySubID
                         { 
                             get 
                             {
@@ -6912,7 +6912,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.AllocAccount AllocAccount
+                    public QuickFix.Fields.AllocAccount AllocAccount
                     { 
                         get 
                         {
@@ -7114,7 +7114,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartyID NestedPartyID
+                        public QuickFix.Fields.NestedPartyID NestedPartyID
                         { 
                             get 
                             {
@@ -7254,7 +7254,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
                             { 
                                 get 
                                 {
@@ -7336,7 +7336,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.TradingSessionID TradingSessionID
+                    public QuickFix.Fields.TradingSessionID TradingSessionID
                     { 
                         get 
                         {
@@ -7416,7 +7416,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -7496,7 +7496,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -7638,7 +7638,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                     { 
                         get 
                         {
@@ -7778,7 +7778,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                        public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                         { 
                             get 
                             {
@@ -7859,7 +7859,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                     { 
                         get 
                         {
@@ -9673,7 +9673,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                        public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                         { 
                             get 
                             {
@@ -9753,7 +9753,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                        public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                         { 
                             get 
                             {
@@ -9833,7 +9833,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                        public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                         { 
                             get 
                             {
@@ -9973,7 +9973,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                             { 
                                 get 
                                 {
@@ -10055,7 +10055,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StipulationType StipulationType
+                    public QuickFix.Fields.StipulationType StipulationType
                     { 
                         get 
                         {
@@ -10135,7 +10135,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StrategyParameterName StrategyParameterName
+                    public QuickFix.Fields.StrategyParameterName StrategyParameterName
                     { 
                         get 
                         {
@@ -10247,7 +10247,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RootPartyID RootPartyID
+                public QuickFix.Fields.RootPartyID RootPartyID
                 { 
                     get 
                     {
@@ -10387,7 +10387,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.RootPartySubID RootPartySubID
+                    public QuickFix.Fields.RootPartySubID RootPartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50/NewOrderMultileg.cs
+++ b/QuickFIXn/Message/FIX50/NewOrderMultileg.cs
@@ -5592,7 +5592,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -5732,7 +5732,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -5813,7 +5813,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AllocAccount AllocAccount
+                public QuickFix.Fields.AllocAccount AllocAccount
                 { 
                     get 
                     {
@@ -6015,7 +6015,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.Nested3PartyID Nested3PartyID
+                    public QuickFix.Fields.Nested3PartyID Nested3PartyID
                     { 
                         get 
                         {
@@ -6155,7 +6155,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested3PartySubID Nested3PartySubID
+                        public QuickFix.Fields.Nested3PartySubID Nested3PartySubID
                         { 
                             get 
                             {
@@ -6237,7 +6237,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {
@@ -6317,7 +6317,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -6397,7 +6397,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -6539,7 +6539,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -6679,7 +6679,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -6760,7 +6760,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -8574,7 +8574,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -8654,7 +8654,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -8734,7 +8734,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -8874,7 +8874,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -8956,7 +8956,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -10739,7 +10739,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -10819,7 +10819,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegStipulationType LegStipulationType
+                    public QuickFix.Fields.LegStipulationType LegStipulationType
                     { 
                         get 
                         {
@@ -10899,7 +10899,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegAllocAccount LegAllocAccount
+                    public QuickFix.Fields.LegAllocAccount LegAllocAccount
                     { 
                         get 
                         {
@@ -11101,7 +11101,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested2PartyID Nested2PartyID
+                        public QuickFix.Fields.Nested2PartyID Nested2PartyID
                         { 
                             get 
                             {
@@ -11241,7 +11241,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
+                            public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
                             { 
                                 get 
                                 {
@@ -11323,7 +11323,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -11463,7 +11463,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -11545,7 +11545,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StrategyParameterName StrategyParameterName
+                public QuickFix.Fields.StrategyParameterName StrategyParameterName
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50/NewOrderSingle.cs
+++ b/QuickFIXn/Message/FIX50/NewOrderSingle.cs
@@ -6522,7 +6522,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -6662,7 +6662,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -6743,7 +6743,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AllocAccount AllocAccount
+                public QuickFix.Fields.AllocAccount AllocAccount
                 { 
                     get 
                     {
@@ -6945,7 +6945,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -7085,7 +7085,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -7167,7 +7167,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {
@@ -7247,7 +7247,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -7327,7 +7327,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -7469,7 +7469,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -7609,7 +7609,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -7690,7 +7690,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -9504,7 +9504,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -9584,7 +9584,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -9664,7 +9664,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -9804,7 +9804,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -9886,7 +9886,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -9966,7 +9966,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StrategyParameterName StrategyParameterName
+                public QuickFix.Fields.StrategyParameterName StrategyParameterName
                 { 
                     get 
                     {
@@ -10077,7 +10077,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
+                public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50/News.cs
+++ b/QuickFIXn/Message/FIX50/News.cs
@@ -440,7 +440,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RoutingType RoutingType
+                public QuickFix.Fields.RoutingType RoutingType
                 { 
                     get 
                     {
@@ -520,7 +520,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -2210,7 +2210,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -2290,7 +2290,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -2432,7 +2432,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                     { 
                         get 
                         {
@@ -2572,7 +2572,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                        public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                         { 
                             get 
                             {
@@ -2654,7 +2654,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -4034,7 +4034,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -4115,7 +4115,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -5929,7 +5929,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -6009,7 +6009,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -6089,7 +6089,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -6229,7 +6229,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -6311,7 +6311,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Text Text
+                public QuickFix.Fields.Text Text
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50/OrderCancelReject.cs
+++ b/QuickFIXn/Message/FIX50/OrderCancelReject.cs
@@ -680,7 +680,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EncodedText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX50/OrderCancelReplaceRequest.cs
+++ b/QuickFIXn/Message/FIX50/OrderCancelReplaceRequest.cs
@@ -6431,7 +6431,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -6571,7 +6571,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -6652,7 +6652,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AllocAccount AllocAccount
+                public QuickFix.Fields.AllocAccount AllocAccount
                 { 
                     get 
                     {
@@ -6854,7 +6854,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -6994,7 +6994,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -7076,7 +7076,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {
@@ -7156,7 +7156,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -7236,7 +7236,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -7378,7 +7378,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -7518,7 +7518,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -7599,7 +7599,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -9413,7 +9413,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -9493,7 +9493,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -9573,7 +9573,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -9713,7 +9713,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -9795,7 +9795,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StrategyParameterName StrategyParameterName
+                public QuickFix.Fields.StrategyParameterName StrategyParameterName
                 { 
                     get 
                     {
@@ -9906,7 +9906,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
+                public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50/OrderCancelRequest.cs
+++ b/QuickFIXn/Message/FIX50/OrderCancelRequest.cs
@@ -2709,7 +2709,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -2849,7 +2849,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -2930,7 +2930,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3010,7 +3010,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -3152,7 +3152,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -3292,7 +3292,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -3373,7 +3373,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -5187,7 +5187,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -5267,7 +5267,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -5347,7 +5347,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -5487,7 +5487,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50/OrderMassCancelReport.cs
+++ b/QuickFIXn/Message/FIX50/OrderMassCancelReport.cs
@@ -4040,7 +4040,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.OrigClOrdID OrigClOrdID
+                public QuickFix.Fields.OrigClOrdID OrigClOrdID
                 { 
                     get 
                     {
@@ -4151,7 +4151,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -4231,7 +4231,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -4373,7 +4373,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -4513,7 +4513,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -4594,7 +4594,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                 { 
                     get 
                     {
@@ -4674,7 +4674,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                 { 
                     get 
                     {
@@ -4754,7 +4754,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                 { 
                     get 
                     {
@@ -4894,7 +4894,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                    public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                     { 
                         get 
                         {
@@ -4975,7 +4975,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -5115,7 +5115,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50/OrderMassCancelRequest.cs
+++ b/QuickFIXn/Message/FIX50/OrderMassCancelRequest.cs
@@ -3854,7 +3854,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3934,7 +3934,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -4076,7 +4076,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -4216,7 +4216,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -4297,7 +4297,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                 { 
                     get 
                     {
@@ -4377,7 +4377,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                 { 
                     get 
                     {
@@ -4457,7 +4457,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                 { 
                     get 
                     {
@@ -4597,7 +4597,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                    public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                     { 
                         get 
                         {
@@ -4678,7 +4678,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -4818,7 +4818,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50/OrderMassStatusRequest.cs
+++ b/QuickFIXn/Message/FIX50/OrderMassStatusRequest.cs
@@ -3759,7 +3759,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -3899,7 +3899,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -3980,7 +3980,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -4060,7 +4060,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -4202,7 +4202,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -4342,7 +4342,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -4423,7 +4423,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                 { 
                     get 
                     {
@@ -4503,7 +4503,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                 { 
                     get 
                     {
@@ -4583,7 +4583,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                 { 
                     get 
                     {
@@ -4723,7 +4723,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                    public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50/OrderStatusRequest.cs
+++ b/QuickFIXn/Message/FIX50/OrderStatusRequest.cs
@@ -2302,7 +2302,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -2442,7 +2442,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -2523,7 +2523,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -2603,7 +2603,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -2745,7 +2745,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -2885,7 +2885,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -2966,7 +2966,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -4780,7 +4780,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -4860,7 +4860,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -4940,7 +4940,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -5080,7 +5080,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50/PositionMaintenanceReport.cs
+++ b/QuickFIXn/Message/FIX50/PositionMaintenanceReport.cs
@@ -2649,7 +2649,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -2789,7 +2789,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -2870,7 +2870,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -2950,7 +2950,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -3092,7 +3092,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -3232,7 +3232,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -3313,7 +3313,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -4693,7 +4693,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -4774,7 +4774,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -6588,7 +6588,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -6668,7 +6668,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -6748,7 +6748,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -6888,7 +6888,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -6970,7 +6970,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {
@@ -7050,7 +7050,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosType PosType
+                public QuickFix.Fields.PosType PosType
                 { 
                     get 
                     {
@@ -7252,7 +7252,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -7392,7 +7392,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -7474,7 +7474,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosAmtType PosAmtType
+                public QuickFix.Fields.PosAmtType PosAmtType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50/PositionMaintenanceRequest.cs
+++ b/QuickFIXn/Message/FIX50/PositionMaintenanceRequest.cs
@@ -2552,7 +2552,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -2692,7 +2692,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -2773,7 +2773,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -2853,7 +2853,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -2995,7 +2995,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -3135,7 +3135,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -3216,7 +3216,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -4596,7 +4596,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -4677,7 +4677,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -6491,7 +6491,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -6571,7 +6571,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -6651,7 +6651,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -6791,7 +6791,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -6873,7 +6873,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {
@@ -6953,7 +6953,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosType PosType
+                public QuickFix.Fields.PosType PosType
                 { 
                     get 
                     {
@@ -7155,7 +7155,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -7295,7 +7295,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -7377,7 +7377,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosAmtType PosAmtType
+                public QuickFix.Fields.PosAmtType PosAmtType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50/PositionReport.cs
+++ b/QuickFIXn/Message/FIX50/PositionReport.cs
@@ -2674,7 +2674,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -2814,7 +2814,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -2895,7 +2895,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -2975,7 +2975,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -3117,7 +3117,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -3257,7 +3257,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -3338,7 +3338,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -4718,7 +4718,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -4799,7 +4799,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -6737,7 +6737,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -6817,7 +6817,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -6897,7 +6897,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -7037,7 +7037,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -7118,7 +7118,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingPayAmount UnderlyingPayAmount
+                    public QuickFix.Fields.UnderlyingPayAmount UnderlyingPayAmount
                     { 
                         get 
                         {
@@ -7261,7 +7261,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosType PosType
+                public QuickFix.Fields.PosType PosType
                 { 
                     get 
                     {
@@ -7463,7 +7463,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -7603,7 +7603,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -7685,7 +7685,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosAmtType PosAmtType
+                public QuickFix.Fields.PosAmtType PosAmtType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50/Quote.cs
+++ b/QuickFIXn/Message/FIX50/Quote.cs
@@ -4346,7 +4346,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.QuoteQualifier QuoteQualifier
+                public QuickFix.Fields.QuoteQualifier QuoteQualifier
                 { 
                     get 
                     {
@@ -4395,7 +4395,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -4535,7 +4535,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -4616,7 +4616,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -4696,7 +4696,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -4838,7 +4838,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -4978,7 +4978,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -5059,7 +5059,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -6873,7 +6873,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -6953,7 +6953,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -7033,7 +7033,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -7173,7 +7173,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -7255,7 +7255,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -7335,7 +7335,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -9273,7 +9273,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -9353,7 +9353,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegStipulationType LegStipulationType
+                    public QuickFix.Fields.LegStipulationType LegStipulationType
                     { 
                         get 
                         {
@@ -9433,7 +9433,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -9573,7 +9573,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50/QuoteCancel.cs
+++ b/QuickFIXn/Message/FIX50/QuoteCancel.cs
@@ -378,7 +378,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -518,7 +518,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -599,7 +599,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -2630,7 +2630,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -2710,7 +2710,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -2852,7 +2852,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                     { 
                         get 
                         {
@@ -2992,7 +2992,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                        public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                         { 
                             get 
                             {
@@ -3073,7 +3073,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                     { 
                         get 
                         {
@@ -4887,7 +4887,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                        public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                         { 
                             get 
                             {
@@ -4967,7 +4967,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                        public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                         { 
                             get 
                             {
@@ -5047,7 +5047,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                        public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                         { 
                             get 
                             {
@@ -5187,7 +5187,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                             { 
                                 get 
                                 {
@@ -5269,7 +5269,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSymbol LegSymbol
+                    public QuickFix.Fields.LegSymbol LegSymbol
                     { 
                         get 
                         {
@@ -6649,7 +6649,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                        public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50/QuoteRequest.cs
+++ b/QuickFIXn/Message/FIX50/QuoteRequest.cs
@@ -285,7 +285,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -3742,7 +3742,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -3822,7 +3822,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -3964,7 +3964,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                     { 
                         get 
                         {
@@ -4104,7 +4104,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                        public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                         { 
                             get 
                             {
@@ -4185,7 +4185,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                     { 
                         get 
                         {
@@ -5999,7 +5999,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                        public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                         { 
                             get 
                             {
@@ -6079,7 +6079,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                        public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                         { 
                             get 
                             {
@@ -6159,7 +6159,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                        public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                         { 
                             get 
                             {
@@ -6299,7 +6299,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                             { 
                                 get 
                                 {
@@ -6381,7 +6381,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StipulationType StipulationType
+                    public QuickFix.Fields.StipulationType StipulationType
                     { 
                         get 
                         {
@@ -6461,7 +6461,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSymbol LegSymbol
+                    public QuickFix.Fields.LegSymbol LegSymbol
                     { 
                         get 
                         {
@@ -8306,7 +8306,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                        public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                         { 
                             get 
                             {
@@ -8386,7 +8386,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegStipulationType LegStipulationType
+                        public QuickFix.Fields.LegStipulationType LegStipulationType
                         { 
                             get 
                             {
@@ -8466,7 +8466,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartyID NestedPartyID
+                        public QuickFix.Fields.NestedPartyID NestedPartyID
                         { 
                             get 
                             {
@@ -8606,7 +8606,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
                             { 
                                 get 
                                 {
@@ -8688,7 +8688,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.QuoteQualifier QuoteQualifier
+                    public QuickFix.Fields.QuoteQualifier QuoteQualifier
                     { 
                         get 
                         {
@@ -8737,7 +8737,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -8877,7 +8877,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.PartySubID PartySubID
+                        public QuickFix.Fields.PartySubID PartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50/QuoteRequestReject.cs
+++ b/QuickFIXn/Message/FIX50/QuoteRequestReject.cs
@@ -256,7 +256,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -3682,7 +3682,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -3762,7 +3762,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -3904,7 +3904,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                     { 
                         get 
                         {
@@ -4044,7 +4044,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                        public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                         { 
                             get 
                             {
@@ -4125,7 +4125,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                     { 
                         get 
                         {
@@ -5939,7 +5939,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                        public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                         { 
                             get 
                             {
@@ -6019,7 +6019,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                        public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                         { 
                             get 
                             {
@@ -6099,7 +6099,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                        public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                         { 
                             get 
                             {
@@ -6239,7 +6239,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                             { 
                                 get 
                                 {
@@ -6321,7 +6321,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StipulationType StipulationType
+                    public QuickFix.Fields.StipulationType StipulationType
                     { 
                         get 
                         {
@@ -6401,7 +6401,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSymbol LegSymbol
+                    public QuickFix.Fields.LegSymbol LegSymbol
                     { 
                         get 
                         {
@@ -8246,7 +8246,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                        public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                         { 
                             get 
                             {
@@ -8326,7 +8326,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegStipulationType LegStipulationType
+                        public QuickFix.Fields.LegStipulationType LegStipulationType
                         { 
                             get 
                             {
@@ -8406,7 +8406,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartyID NestedPartyID
+                        public QuickFix.Fields.NestedPartyID NestedPartyID
                         { 
                             get 
                             {
@@ -8546,7 +8546,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
                             { 
                                 get 
                                 {
@@ -8628,7 +8628,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.QuoteQualifier QuoteQualifier
+                    public QuickFix.Fields.QuoteQualifier QuoteQualifier
                     { 
                         get 
                         {
@@ -8677,7 +8677,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -8817,7 +8817,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.PartySubID PartySubID
+                        public QuickFix.Fields.PartySubID PartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50/QuoteResponse.cs
+++ b/QuickFIXn/Message/FIX50/QuoteResponse.cs
@@ -4348,7 +4348,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.QuoteQualifier QuoteQualifier
+                public QuickFix.Fields.QuoteQualifier QuoteQualifier
                 { 
                     get 
                     {
@@ -4397,7 +4397,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -4537,7 +4537,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -4618,7 +4618,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -4698,7 +4698,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -4840,7 +4840,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -4980,7 +4980,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -5061,7 +5061,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -6875,7 +6875,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -6955,7 +6955,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -7035,7 +7035,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -7175,7 +7175,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -7257,7 +7257,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -7337,7 +7337,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -9275,7 +9275,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -9355,7 +9355,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegStipulationType LegStipulationType
+                    public QuickFix.Fields.LegStipulationType LegStipulationType
                     { 
                         get 
                         {
@@ -9435,7 +9435,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -9575,7 +9575,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50/QuoteStatusReport.cs
+++ b/QuickFIXn/Message/FIX50/QuoteStatusReport.cs
@@ -4346,7 +4346,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -4486,7 +4486,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -4567,7 +4567,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -4647,7 +4647,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -4789,7 +4789,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -4929,7 +4929,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -5010,7 +5010,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -6824,7 +6824,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -6904,7 +6904,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -6984,7 +6984,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -7124,7 +7124,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -7206,7 +7206,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -7286,7 +7286,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -8883,7 +8883,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -8963,7 +8963,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegStipulationType LegStipulationType
+                    public QuickFix.Fields.LegStipulationType LegStipulationType
                     { 
                         get 
                         {
@@ -9043,7 +9043,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -9183,7 +9183,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -9265,7 +9265,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.QuoteQualifier QuoteQualifier
+                public QuickFix.Fields.QuoteQualifier QuoteQualifier
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50/QuoteStatusRequest.cs
+++ b/QuickFIXn/Message/FIX50/QuoteStatusRequest.cs
@@ -2325,7 +2325,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -2405,7 +2405,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -2547,7 +2547,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -2687,7 +2687,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -2768,7 +2768,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -4582,7 +4582,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -4662,7 +4662,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -4742,7 +4742,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -4882,7 +4882,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -4964,7 +4964,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -6344,7 +6344,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -6425,7 +6425,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -6565,7 +6565,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50/RFQRequest.cs
+++ b/QuickFIXn/Message/FIX50/RFQRequest.cs
@@ -130,7 +130,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -2037,7 +2037,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -2117,7 +2117,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -2259,7 +2259,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                     { 
                         get 
                         {
@@ -2399,7 +2399,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                        public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                         { 
                             get 
                             {
@@ -2480,7 +2480,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                     { 
                         get 
                         {
@@ -4294,7 +4294,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                        public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                         { 
                             get 
                             {
@@ -4374,7 +4374,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                        public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                         { 
                             get 
                             {
@@ -4454,7 +4454,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                        public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                         { 
                             get 
                             {
@@ -4594,7 +4594,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                             { 
                                 get 
                                 {
@@ -4676,7 +4676,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSymbol LegSymbol
+                    public QuickFix.Fields.LegSymbol LegSymbol
                     { 
                         get 
                         {
@@ -6056,7 +6056,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                        public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50/RegistrationInstructions.cs
+++ b/QuickFIXn/Message/FIX50/RegistrationInstructions.cs
@@ -413,7 +413,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -553,7 +553,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -634,7 +634,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RegistDtls RegistDtls
+                public QuickFix.Fields.RegistDtls RegistDtls
                 { 
                     get 
                     {
@@ -898,7 +898,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -1038,7 +1038,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -1120,7 +1120,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.DistribPaymentMethod DistribPaymentMethod
+                public QuickFix.Fields.DistribPaymentMethod DistribPaymentMethod
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50/RegistrationInstructionsResponse.cs
+++ b/QuickFIXn/Message/FIX50/RegistrationInstructionsResponse.cs
@@ -353,7 +353,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -493,7 +493,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50/RequestForPositions.cs
+++ b/QuickFIXn/Message/FIX50/RequestForPositions.cs
@@ -2399,7 +2399,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -2539,7 +2539,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -2620,7 +2620,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -2700,7 +2700,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -2842,7 +2842,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -2982,7 +2982,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -3063,7 +3063,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -4443,7 +4443,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -4524,7 +4524,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -6338,7 +6338,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -6418,7 +6418,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -6498,7 +6498,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -6638,7 +6638,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -6720,7 +6720,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50/RequestForPositionsAck.cs
+++ b/QuickFIXn/Message/FIX50/RequestForPositionsAck.cs
@@ -2490,7 +2490,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -2630,7 +2630,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -2711,7 +2711,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -2791,7 +2791,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -2933,7 +2933,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -3073,7 +3073,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -3154,7 +3154,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -4534,7 +4534,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -4615,7 +4615,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -6429,7 +6429,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -6509,7 +6509,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -6589,7 +6589,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -6729,7 +6729,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50/SecurityDefinition.cs
+++ b/QuickFIXn/Message/FIX50/SecurityDefinition.cs
@@ -2294,7 +2294,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -2374,7 +2374,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -2516,7 +2516,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -2656,7 +2656,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -2737,7 +2737,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrAttribType InstrAttribType
+                public QuickFix.Fields.InstrAttribType InstrAttribType
                 { 
                     get 
                     {
@@ -2817,7 +2817,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -4631,7 +4631,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -4711,7 +4711,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -4791,7 +4791,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -4931,7 +4931,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -5013,7 +5013,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -6393,7 +6393,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -6474,7 +6474,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegOptionRatio LegOptionRatio
+                public QuickFix.Fields.LegOptionRatio LegOptionRatio
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50/SecurityDefinitionRequest.cs
+++ b/QuickFIXn/Message/FIX50/SecurityDefinitionRequest.cs
@@ -2178,7 +2178,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -2258,7 +2258,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -2400,7 +2400,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -2540,7 +2540,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -2621,7 +2621,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrAttribType InstrAttribType
+                public QuickFix.Fields.InstrAttribType InstrAttribType
                 { 
                     get 
                     {
@@ -2701,7 +2701,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -4515,7 +4515,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -4595,7 +4595,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -4675,7 +4675,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -4815,7 +4815,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -4897,7 +4897,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -6277,7 +6277,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -6358,7 +6358,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegOptionRatio LegOptionRatio
+                public QuickFix.Fields.LegOptionRatio LegOptionRatio
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50/SecurityDefinitionUpdateReport.cs
+++ b/QuickFIXn/Message/FIX50/SecurityDefinitionUpdateReport.cs
@@ -4030,7 +4030,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -4110,7 +4110,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -4252,7 +4252,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -4392,7 +4392,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -4473,7 +4473,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                 { 
                     get 
                     {
@@ -4553,7 +4553,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                 { 
                     get 
                     {
@@ -4633,7 +4633,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                 { 
                     get 
                     {
@@ -4773,7 +4773,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                    public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                     { 
                         get 
                         {
@@ -4854,7 +4854,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -6234,7 +6234,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50/SecurityList.cs
+++ b/QuickFIXn/Message/FIX50/SecurityList.cs
@@ -279,7 +279,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -3147,7 +3147,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -3227,7 +3227,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -3369,7 +3369,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                     { 
                         get 
                         {
@@ -3509,7 +3509,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                        public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                         { 
                             get 
                             {
@@ -3590,7 +3590,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrAttribType InstrAttribType
+                    public QuickFix.Fields.InstrAttribType InstrAttribType
                     { 
                         get 
                         {
@@ -3670,7 +3670,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                     { 
                         get 
                         {
@@ -5484,7 +5484,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                        public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                         { 
                             get 
                             {
@@ -5564,7 +5564,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                        public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                         { 
                             get 
                             {
@@ -5644,7 +5644,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                        public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                         { 
                             get 
                             {
@@ -5784,7 +5784,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                             { 
                                 get 
                                 {
@@ -5866,7 +5866,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StipulationType StipulationType
+                    public QuickFix.Fields.StipulationType StipulationType
                     { 
                         get 
                         {
@@ -5946,7 +5946,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSymbol LegSymbol
+                    public QuickFix.Fields.LegSymbol LegSymbol
                     { 
                         get 
                         {
@@ -7574,7 +7574,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                        public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                         { 
                             get 
                             {
@@ -7654,7 +7654,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegStipulationType LegStipulationType
+                        public QuickFix.Fields.LegStipulationType LegStipulationType
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50/SecurityListRequest.cs
+++ b/QuickFIXn/Message/FIX50/SecurityListRequest.cs
@@ -2426,7 +2426,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -2506,7 +2506,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -2648,7 +2648,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -2788,7 +2788,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -2869,7 +2869,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrAttribType InstrAttribType
+                public QuickFix.Fields.InstrAttribType InstrAttribType
                 { 
                     get 
                     {
@@ -2949,7 +2949,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -4763,7 +4763,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -4843,7 +4843,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -4923,7 +4923,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -5063,7 +5063,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -5145,7 +5145,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -6525,7 +6525,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50/SecurityListUpdateReport.cs
+++ b/QuickFIXn/Message/FIX50/SecurityListUpdateReport.cs
@@ -341,7 +341,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -4976,7 +4976,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -5056,7 +5056,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -5198,7 +5198,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                     { 
                         get 
                         {
@@ -5338,7 +5338,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                        public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                         { 
                             get 
                             {
@@ -5419,7 +5419,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrAttribType InstrAttribType
+                    public QuickFix.Fields.InstrAttribType InstrAttribType
                     { 
                         get 
                         {
@@ -5499,7 +5499,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSymbol LegSymbol
+                    public QuickFix.Fields.LegSymbol LegSymbol
                     { 
                         get 
                         {
@@ -7127,7 +7127,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                        public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                         { 
                             get 
                             {
@@ -7207,7 +7207,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegStipulationType LegStipulationType
+                        public QuickFix.Fields.LegStipulationType LegStipulationType
                         { 
                             get 
                             {
@@ -7288,7 +7288,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -7368,7 +7368,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -7448,7 +7448,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -7588,7 +7588,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -7669,7 +7669,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StipulationType StipulationType
+                    public QuickFix.Fields.StipulationType StipulationType
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50/SecurityStatus.cs
+++ b/QuickFIXn/Message/FIX50/SecurityStatus.cs
@@ -2542,7 +2542,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -2622,7 +2622,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -2764,7 +2764,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -2904,7 +2904,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -2985,7 +2985,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrAttribType InstrAttribType
+                public QuickFix.Fields.InstrAttribType InstrAttribType
                 { 
                     get 
                     {
@@ -3065,7 +3065,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -4879,7 +4879,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -4959,7 +4959,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -5039,7 +5039,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -5179,7 +5179,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -5261,7 +5261,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -6641,7 +6641,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50/SecurityStatusRequest.cs
+++ b/QuickFIXn/Message/FIX50/SecurityStatusRequest.cs
@@ -2023,7 +2023,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -2103,7 +2103,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -2245,7 +2245,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -2385,7 +2385,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -2466,7 +2466,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrAttribType InstrAttribType
+                public QuickFix.Fields.InstrAttribType InstrAttribType
                 { 
                     get 
                     {
@@ -2546,7 +2546,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -4360,7 +4360,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -4440,7 +4440,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -4520,7 +4520,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -4660,7 +4660,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -4742,7 +4742,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -6122,7 +6122,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50/SecurityTypeRequest.cs
+++ b/QuickFIXn/Message/FIX50/SecurityTypeRequest.cs
@@ -300,7 +300,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.SecuritySubType);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX50/SecurityTypes.cs
+++ b/QuickFIXn/Message/FIX50/SecurityTypes.cs
@@ -413,7 +413,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityType SecurityType
+                public QuickFix.Fields.SecurityType SecurityType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50/SettlementInstructionRequest.cs
+++ b/QuickFIXn/Message/FIX50/SettlementInstructionRequest.cs
@@ -535,7 +535,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -675,7 +675,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50/SettlementInstructions.cs
+++ b/QuickFIXn/Message/FIX50/SettlementInstructions.cs
@@ -351,7 +351,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SettlInstID SettlInstID
+                public QuickFix.Fields.SettlInstID SettlInstID
                 { 
                     get 
                     {
@@ -1173,7 +1173,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -1313,7 +1313,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.PartySubID PartySubID
+                        public QuickFix.Fields.PartySubID PartySubID
                         { 
                             get 
                             {
@@ -1394,7 +1394,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SettlInstSource SettlInstSource
+                    public QuickFix.Fields.SettlInstSource SettlInstSource
                     { 
                         get 
                         {
@@ -1503,7 +1503,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SettlPartyID SettlPartyID
+                        public QuickFix.Fields.SettlPartyID SettlPartyID
                         { 
                             get 
                             {
@@ -1643,7 +1643,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.SettlPartySubID SettlPartySubID
+                            public QuickFix.Fields.SettlPartySubID SettlPartySubID
                             { 
                                 get 
                                 {

--- a/QuickFIXn/Message/FIX50/TradeCaptureReport.cs
+++ b/QuickFIXn/Message/FIX50/TradeCaptureReport.cs
@@ -4970,7 +4970,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -5050,7 +5050,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -5192,7 +5192,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -5332,7 +5332,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -5413,7 +5413,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -7227,7 +7227,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -7307,7 +7307,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -7387,7 +7387,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -7527,7 +7527,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -7609,7 +7609,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosAmtType PosAmtType
+                public QuickFix.Fields.PosAmtType PosAmtType
                 { 
                     get 
                     {
@@ -7720,7 +7720,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -9596,7 +9596,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -9676,7 +9676,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegStipulationType LegStipulationType
+                    public QuickFix.Fields.LegStipulationType LegStipulationType
                     { 
                         get 
                         {
@@ -9756,7 +9756,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -9896,7 +9896,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -9978,7 +9978,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
+                public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
                 { 
                     get 
                     {
@@ -10182,7 +10182,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Side Side
+                public QuickFix.Fields.Side Side
                 { 
                     get 
                     {
@@ -12430,7 +12430,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -12570,7 +12570,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.PartySubID PartySubID
+                        public QuickFix.Fields.PartySubID PartySubID
                         { 
                             get 
                             {
@@ -12651,7 +12651,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ClearingInstruction ClearingInstruction
+                    public QuickFix.Fields.ClearingInstruction ClearingInstruction
                     { 
                         get 
                         {
@@ -12700,7 +12700,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ContAmtType ContAmtType
+                    public QuickFix.Fields.ContAmtType ContAmtType
                     { 
                         get 
                         {
@@ -12811,7 +12811,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StipulationType StipulationType
+                    public QuickFix.Fields.StipulationType StipulationType
                     { 
                         get 
                         {
@@ -12891,7 +12891,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
+                    public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
                     { 
                         get 
                         {
@@ -13033,7 +13033,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.AllocAccount AllocAccount
+                    public QuickFix.Fields.AllocAccount AllocAccount
                     { 
                         get 
                         {
@@ -13359,7 +13359,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested2PartyID Nested2PartyID
+                        public QuickFix.Fields.Nested2PartyID Nested2PartyID
                         { 
                             get 
                             {
@@ -13499,7 +13499,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
+                            public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
                             { 
                                 get 
                                 {
@@ -13581,7 +13581,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SideTrdRegTimestamp SideTrdRegTimestamp
+                    public QuickFix.Fields.SideTrdRegTimestamp SideTrdRegTimestamp
                     { 
                         get 
                         {
@@ -13693,7 +13693,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RootPartyID RootPartyID
+                public QuickFix.Fields.RootPartyID RootPartyID
                 { 
                     get 
                     {
@@ -13833,7 +13833,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.RootPartySubID RootPartySubID
+                    public QuickFix.Fields.RootPartySubID RootPartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50/TradeCaptureReportAck.cs
+++ b/QuickFIXn/Message/FIX50/TradeCaptureReportAck.cs
@@ -4092,7 +4092,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -4172,7 +4172,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -4314,7 +4314,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -4454,7 +4454,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -4535,7 +4535,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
+                public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
                 { 
                     get 
                     {
@@ -4739,7 +4739,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -6615,7 +6615,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -6695,7 +6695,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegStipulationType LegStipulationType
+                    public QuickFix.Fields.LegStipulationType LegStipulationType
                     { 
                         get 
                         {
@@ -6775,7 +6775,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -6915,7 +6915,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -6997,7 +6997,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosAmtType PosAmtType
+                public QuickFix.Fields.PosAmtType PosAmtType
                 { 
                     get 
                     {
@@ -7108,7 +7108,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Side Side
+                public QuickFix.Fields.Side Side
                 { 
                     get 
                     {
@@ -9201,7 +9201,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -9341,7 +9341,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.PartySubID PartySubID
+                        public QuickFix.Fields.PartySubID PartySubID
                         { 
                             get 
                             {
@@ -9422,7 +9422,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ClearingInstruction ClearingInstruction
+                    public QuickFix.Fields.ClearingInstruction ClearingInstruction
                     { 
                         get 
                         {
@@ -9471,7 +9471,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ContAmtType ContAmtType
+                    public QuickFix.Fields.ContAmtType ContAmtType
                     { 
                         get 
                         {
@@ -9582,7 +9582,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StipulationType StipulationType
+                    public QuickFix.Fields.StipulationType StipulationType
                     { 
                         get 
                         {
@@ -9662,7 +9662,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
+                    public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
                     { 
                         get 
                         {
@@ -9804,7 +9804,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.AllocAccount AllocAccount
+                    public QuickFix.Fields.AllocAccount AllocAccount
                     { 
                         get 
                         {
@@ -10130,7 +10130,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested2PartyID Nested2PartyID
+                        public QuickFix.Fields.Nested2PartyID Nested2PartyID
                         { 
                             get 
                             {
@@ -10270,7 +10270,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
+                            public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
                             { 
                                 get 
                                 {
@@ -10352,7 +10352,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SideTrdRegTimestamp SideTrdRegTimestamp
+                    public QuickFix.Fields.SideTrdRegTimestamp SideTrdRegTimestamp
                     { 
                         get 
                         {
@@ -10464,7 +10464,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RootPartyID RootPartyID
+                public QuickFix.Fields.RootPartyID RootPartyID
                 { 
                     get 
                     {
@@ -10604,7 +10604,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.RootPartySubID RootPartySubID
+                    public QuickFix.Fields.RootPartySubID RootPartySubID
                     { 
                         get 
                         {
@@ -10685,7 +10685,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -12499,7 +12499,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -12579,7 +12579,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -12659,7 +12659,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -12799,7 +12799,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50/TradeCaptureReportRequest.cs
+++ b/QuickFIXn/Message/FIX50/TradeCaptureReportRequest.cs
@@ -3294,7 +3294,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -3434,7 +3434,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -3515,7 +3515,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3595,7 +3595,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -3737,7 +3737,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -3877,7 +3877,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -3958,7 +3958,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrAttribType InstrAttribType
+                public QuickFix.Fields.InstrAttribType InstrAttribType
                 { 
                     get 
                     {
@@ -4038,7 +4038,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -5852,7 +5852,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -5932,7 +5932,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -6012,7 +6012,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -6152,7 +6152,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -6234,7 +6234,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -7614,7 +7614,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -7695,7 +7695,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradeDate TradeDate
+                public QuickFix.Fields.TradeDate TradeDate
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50/TradeCaptureReportRequestAck.cs
+++ b/QuickFIXn/Message/FIX50/TradeCaptureReportRequestAck.cs
@@ -2306,7 +2306,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -2386,7 +2386,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -2528,7 +2528,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -2668,7 +2668,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -2749,7 +2749,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -4563,7 +4563,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -4643,7 +4643,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -4723,7 +4723,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -4863,7 +4863,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -4945,7 +4945,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -6325,7 +6325,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50/TradingSessionList.cs
+++ b/QuickFIXn/Message/FIX50/TradingSessionList.cs
@@ -93,7 +93,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50/TradingSessionListRequest.cs
+++ b/QuickFIXn/Message/FIX50/TradingSessionListRequest.cs
@@ -240,7 +240,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.SubscriptionRequestType);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX50/TradingSessionStatus.cs
+++ b/QuickFIXn/Message/FIX50/TradingSessionStatus.cs
@@ -2240,7 +2240,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -2320,7 +2320,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -2462,7 +2462,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -2602,7 +2602,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50/TradingSessionStatusRequest.cs
+++ b/QuickFIXn/Message/FIX50/TradingSessionStatusRequest.cs
@@ -240,7 +240,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.SecurityExchange);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX50/UserRequest.cs
+++ b/QuickFIXn/Message/FIX50/UserRequest.cs
@@ -242,7 +242,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.RawData);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX50/UserResponse.cs
+++ b/QuickFIXn/Message/FIX50/UserResponse.cs
@@ -147,7 +147,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.UserStatusText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX50SP1/AdjustedPositionReport.cs
+++ b/QuickFIXn/Message/FIX50SP1/AdjustedPositionReport.cs
@@ -349,7 +349,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -489,7 +489,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -570,7 +570,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosType PosType
+                public QuickFix.Fields.PosType PosType
                 { 
                     get 
                     {
@@ -772,7 +772,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -912,7 +912,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -994,7 +994,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -3304,7 +3304,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -3384,7 +3384,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -3557,7 +3557,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                     { 
                         get 
                         {
@@ -3697,7 +3697,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                        public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50SP1/Advertisement.cs
+++ b/QuickFIXn/Message/FIX50SP1/Advertisement.cs
@@ -2926,7 +2926,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3006,7 +3006,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -3179,7 +3179,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -3319,7 +3319,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -3400,7 +3400,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -5028,7 +5028,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -5109,7 +5109,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -7109,7 +7109,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -7189,7 +7189,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -7269,7 +7269,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -7409,7 +7409,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50SP1/AllocationInstruction.cs
+++ b/QuickFIXn/Message/FIX50SP1/AllocationInstruction.cs
@@ -5255,7 +5255,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ClOrdID ClOrdID
+                public QuickFix.Fields.ClOrdID ClOrdID
                 { 
                     get 
                     {
@@ -5550,7 +5550,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.Nested2PartyID Nested2PartyID
+                    public QuickFix.Fields.Nested2PartyID Nested2PartyID
                     { 
                         get 
                         {
@@ -5690,7 +5690,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
+                        public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
                         { 
                             get 
                             {
@@ -5772,7 +5772,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LastQty LastQty
+                public QuickFix.Fields.LastQty LastQty
                 { 
                     get 
                     {
@@ -6038,7 +6038,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -6118,7 +6118,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -6291,7 +6291,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -6431,7 +6431,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -6512,7 +6512,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrAttribType InstrAttribType
+                public QuickFix.Fields.InstrAttribType InstrAttribType
                 { 
                     get 
                     {
@@ -6592,7 +6592,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -8592,7 +8592,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -8672,7 +8672,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -8752,7 +8752,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -8892,7 +8892,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -8974,7 +8974,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -10602,7 +10602,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -10683,7 +10683,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -10823,7 +10823,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -10904,7 +10904,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -10984,7 +10984,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AllocAccount AllocAccount
+                public QuickFix.Fields.AllocAccount AllocAccount
                 { 
                     get 
                     {
@@ -12271,7 +12271,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -12411,7 +12411,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -12492,7 +12492,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
+                    public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
                     { 
                         get 
                         {
@@ -12634,7 +12634,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ClearingInstruction ClearingInstruction
+                    public QuickFix.Fields.ClearingInstruction ClearingInstruction
                     { 
                         get 
                         {
@@ -12683,7 +12683,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SettlInstSource SettlInstSource
+                    public QuickFix.Fields.SettlInstSource SettlInstSource
                     { 
                         get 
                         {
@@ -12792,7 +12792,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SettlPartyID SettlPartyID
+                        public QuickFix.Fields.SettlPartyID SettlPartyID
                         { 
                             get 
                             {
@@ -12932,7 +12932,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.SettlPartySubID SettlPartySubID
+                            public QuickFix.Fields.SettlPartySubID SettlPartySubID
                             { 
                                 get 
                                 {
@@ -13015,7 +13015,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosAmtType PosAmtType
+                public QuickFix.Fields.PosAmtType PosAmtType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP1/AllocationInstructionAck.cs
+++ b/QuickFIXn/Message/FIX50SP1/AllocationInstructionAck.cs
@@ -535,7 +535,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -675,7 +675,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -756,7 +756,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AllocAccount AllocAccount
+                public QuickFix.Fields.AllocAccount AllocAccount
                 { 
                     get 
                     {
@@ -1206,7 +1206,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -1346,7 +1346,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50SP1/AllocationInstructionAlert.cs
+++ b/QuickFIXn/Message/FIX50SP1/AllocationInstructionAlert.cs
@@ -5255,7 +5255,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ClOrdID ClOrdID
+                public QuickFix.Fields.ClOrdID ClOrdID
                 { 
                     get 
                     {
@@ -5550,7 +5550,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.Nested2PartyID Nested2PartyID
+                    public QuickFix.Fields.Nested2PartyID Nested2PartyID
                     { 
                         get 
                         {
@@ -5690,7 +5690,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
+                        public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
                         { 
                             get 
                             {
@@ -5772,7 +5772,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LastQty LastQty
+                public QuickFix.Fields.LastQty LastQty
                 { 
                     get 
                     {
@@ -6038,7 +6038,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -6118,7 +6118,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -6291,7 +6291,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -6431,7 +6431,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -6512,7 +6512,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrAttribType InstrAttribType
+                public QuickFix.Fields.InstrAttribType InstrAttribType
                 { 
                     get 
                     {
@@ -6592,7 +6592,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -8592,7 +8592,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -8672,7 +8672,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -8752,7 +8752,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -8892,7 +8892,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -8974,7 +8974,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -10602,7 +10602,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -10683,7 +10683,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -10823,7 +10823,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -10904,7 +10904,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -10984,7 +10984,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosAmtType PosAmtType
+                public QuickFix.Fields.PosAmtType PosAmtType
                 { 
                     get 
                     {
@@ -11095,7 +11095,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AllocAccount AllocAccount
+                public QuickFix.Fields.AllocAccount AllocAccount
                 { 
                     get 
                     {
@@ -12382,7 +12382,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -12522,7 +12522,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -12603,7 +12603,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
+                    public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
                     { 
                         get 
                         {
@@ -12745,7 +12745,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ClearingInstruction ClearingInstruction
+                    public QuickFix.Fields.ClearingInstruction ClearingInstruction
                     { 
                         get 
                         {
@@ -12794,7 +12794,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SettlInstSource SettlInstSource
+                    public QuickFix.Fields.SettlInstSource SettlInstSource
                     { 
                         get 
                         {
@@ -12903,7 +12903,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SettlPartyID SettlPartyID
+                        public QuickFix.Fields.SettlPartyID SettlPartyID
                         { 
                             get 
                             {
@@ -13043,7 +13043,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.SettlPartySubID SettlPartySubID
+                            public QuickFix.Fields.SettlPartySubID SettlPartySubID
                             { 
                                 get 
                                 {

--- a/QuickFIXn/Message/FIX50SP1/AllocationReport.cs
+++ b/QuickFIXn/Message/FIX50SP1/AllocationReport.cs
@@ -5414,7 +5414,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ClOrdID ClOrdID
+                public QuickFix.Fields.ClOrdID ClOrdID
                 { 
                     get 
                     {
@@ -5709,7 +5709,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.Nested2PartyID Nested2PartyID
+                    public QuickFix.Fields.Nested2PartyID Nested2PartyID
                     { 
                         get 
                         {
@@ -5849,7 +5849,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
+                        public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
                         { 
                             get 
                             {
@@ -5931,7 +5931,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LastQty LastQty
+                public QuickFix.Fields.LastQty LastQty
                 { 
                     get 
                     {
@@ -6197,7 +6197,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -6277,7 +6277,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -6450,7 +6450,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -6590,7 +6590,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -6671,7 +6671,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrAttribType InstrAttribType
+                public QuickFix.Fields.InstrAttribType InstrAttribType
                 { 
                     get 
                     {
@@ -6751,7 +6751,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -8751,7 +8751,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -8831,7 +8831,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -8911,7 +8911,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -9051,7 +9051,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -9133,7 +9133,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -10761,7 +10761,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -10842,7 +10842,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -10982,7 +10982,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -11063,7 +11063,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -11143,7 +11143,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AllocAccount AllocAccount
+                public QuickFix.Fields.AllocAccount AllocAccount
                 { 
                     get 
                     {
@@ -12430,7 +12430,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -12570,7 +12570,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -12651,7 +12651,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
+                    public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
                     { 
                         get 
                         {
@@ -12793,7 +12793,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ClearingInstruction ClearingInstruction
+                    public QuickFix.Fields.ClearingInstruction ClearingInstruction
                     { 
                         get 
                         {
@@ -12842,7 +12842,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SettlInstSource SettlInstSource
+                    public QuickFix.Fields.SettlInstSource SettlInstSource
                     { 
                         get 
                         {
@@ -12951,7 +12951,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SettlPartyID SettlPartyID
+                        public QuickFix.Fields.SettlPartyID SettlPartyID
                         { 
                             get 
                             {
@@ -13091,7 +13091,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.SettlPartySubID SettlPartySubID
+                            public QuickFix.Fields.SettlPartySubID SettlPartySubID
                             { 
                                 get 
                                 {
@@ -13174,7 +13174,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosAmtType PosAmtType
+                public QuickFix.Fields.PosAmtType PosAmtType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP1/AllocationReportAck.cs
+++ b/QuickFIXn/Message/FIX50SP1/AllocationReportAck.cs
@@ -690,7 +690,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -830,7 +830,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -911,7 +911,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AllocAccount AllocAccount
+                public QuickFix.Fields.AllocAccount AllocAccount
                 { 
                     get 
                     {
@@ -1361,7 +1361,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -1501,7 +1501,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50SP1/ApplicationMessageReport.cs
+++ b/QuickFIXn/Message/FIX50SP1/ApplicationMessageReport.cs
@@ -225,7 +225,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RefApplID RefApplID
+                public QuickFix.Fields.RefApplID RefApplID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP1/ApplicationMessageRequest.cs
+++ b/QuickFIXn/Message/FIX50SP1/ApplicationMessageRequest.cs
@@ -225,7 +225,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RefApplID RefApplID
+                public QuickFix.Fields.RefApplID RefApplID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP1/ApplicationMessageRequestAck.cs
+++ b/QuickFIXn/Message/FIX50SP1/ApplicationMessageRequestAck.cs
@@ -316,7 +316,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RefApplID RefApplID
+                public QuickFix.Fields.RefApplID RefApplID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP1/AssignmentReport.cs
+++ b/QuickFIXn/Message/FIX50SP1/AssignmentReport.cs
@@ -3294,7 +3294,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -3434,7 +3434,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -3515,7 +3515,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3595,7 +3595,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -3768,7 +3768,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -3908,7 +3908,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -3989,7 +3989,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -5617,7 +5617,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -5698,7 +5698,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -7698,7 +7698,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -7778,7 +7778,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -7858,7 +7858,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -7998,7 +7998,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -8080,7 +8080,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosType PosType
+                public QuickFix.Fields.PosType PosType
                 { 
                     get 
                     {
@@ -8282,7 +8282,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -8422,7 +8422,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -8504,7 +8504,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosAmtType PosAmtType
+                public QuickFix.Fields.PosAmtType PosAmtType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP1/BidRequest.cs
+++ b/QuickFIXn/Message/FIX50SP1/BidRequest.cs
@@ -946,7 +946,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.BidDescriptorType BidDescriptorType
+                public QuickFix.Fields.BidDescriptorType BidDescriptorType
                 { 
                     get 
                     {
@@ -1305,7 +1305,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ListID ListID
+                public QuickFix.Fields.ListID ListID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP1/BidResponse.cs
+++ b/QuickFIXn/Message/FIX50SP1/BidResponse.cs
@@ -124,7 +124,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Commission Commission
+                public QuickFix.Fields.Commission Commission
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP1/BusinessMessageReject.cs
+++ b/QuickFIXn/Message/FIX50SP1/BusinessMessageReject.cs
@@ -333,7 +333,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.RefCstmApplVerID);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX50SP1/CollateralAssignment.cs
+++ b/QuickFIXn/Message/FIX50SP1/CollateralAssignment.cs
@@ -4352,7 +4352,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -4492,7 +4492,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -4573,7 +4573,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ExecID ExecID
+                public QuickFix.Fields.ExecID ExecID
                 { 
                     get 
                     {
@@ -4622,7 +4622,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradeReportID TradeReportID
+                public QuickFix.Fields.TradeReportID TradeReportID
                 { 
                     get 
                     {
@@ -4702,7 +4702,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -4782,7 +4782,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -4955,7 +4955,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -5095,7 +5095,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -5176,7 +5176,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -6804,7 +6804,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -6885,7 +6885,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -8916,7 +8916,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -8996,7 +8996,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -9076,7 +9076,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -9216,7 +9216,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -9298,7 +9298,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
+                public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
                 { 
                     get 
                     {
@@ -9502,7 +9502,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
+                public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
                 { 
                     get 
                     {
@@ -9644,7 +9644,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -9724,7 +9724,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SettlInstSource SettlInstSource
+                public QuickFix.Fields.SettlInstSource SettlInstSource
                 { 
                     get 
                     {
@@ -9833,7 +9833,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SettlPartyID SettlPartyID
+                    public QuickFix.Fields.SettlPartyID SettlPartyID
                     { 
                         get 
                         {
@@ -9973,7 +9973,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SettlPartySubID SettlPartySubID
+                        public QuickFix.Fields.SettlPartySubID SettlPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50SP1/CollateralInquiry.cs
+++ b/QuickFIXn/Message/FIX50SP1/CollateralInquiry.cs
@@ -4247,7 +4247,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.CollInquiryQualifier CollInquiryQualifier
+                public QuickFix.Fields.CollInquiryQualifier CollInquiryQualifier
                 { 
                     get 
                     {
@@ -4296,7 +4296,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -4436,7 +4436,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -4517,7 +4517,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ExecID ExecID
+                public QuickFix.Fields.ExecID ExecID
                 { 
                     get 
                     {
@@ -4566,7 +4566,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradeReportID TradeReportID
+                public QuickFix.Fields.TradeReportID TradeReportID
                 { 
                     get 
                     {
@@ -4646,7 +4646,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -4726,7 +4726,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -4899,7 +4899,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -5039,7 +5039,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -5120,7 +5120,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -6748,7 +6748,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -6829,7 +6829,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -8829,7 +8829,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -8909,7 +8909,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -8989,7 +8989,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -9129,7 +9129,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -9211,7 +9211,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
+                public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
                 { 
                     get 
                     {
@@ -9415,7 +9415,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -9495,7 +9495,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SettlInstSource SettlInstSource
+                public QuickFix.Fields.SettlInstSource SettlInstSource
                 { 
                     get 
                     {
@@ -9604,7 +9604,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SettlPartyID SettlPartyID
+                    public QuickFix.Fields.SettlPartyID SettlPartyID
                     { 
                         get 
                         {
@@ -9744,7 +9744,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SettlPartySubID SettlPartySubID
+                        public QuickFix.Fields.SettlPartySubID SettlPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50SP1/CollateralInquiryAck.cs
+++ b/QuickFIXn/Message/FIX50SP1/CollateralInquiryAck.cs
@@ -3542,7 +3542,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.CollInquiryQualifier CollInquiryQualifier
+                public QuickFix.Fields.CollInquiryQualifier CollInquiryQualifier
                 { 
                     get 
                     {
@@ -3591,7 +3591,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -3731,7 +3731,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -3812,7 +3812,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ExecID ExecID
+                public QuickFix.Fields.ExecID ExecID
                 { 
                     get 
                     {
@@ -3861,7 +3861,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradeReportID TradeReportID
+                public QuickFix.Fields.TradeReportID TradeReportID
                 { 
                     get 
                     {
@@ -3941,7 +3941,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -4021,7 +4021,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -4194,7 +4194,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -4334,7 +4334,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -4415,7 +4415,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -6043,7 +6043,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -6124,7 +6124,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -8124,7 +8124,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -8204,7 +8204,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -8284,7 +8284,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -8424,7 +8424,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50SP1/CollateralReport.cs
+++ b/QuickFIXn/Message/FIX50SP1/CollateralReport.cs
@@ -4379,7 +4379,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -4519,7 +4519,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -4600,7 +4600,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ExecID ExecID
+                public QuickFix.Fields.ExecID ExecID
                 { 
                     get 
                     {
@@ -4649,7 +4649,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradeReportID TradeReportID
+                public QuickFix.Fields.TradeReportID TradeReportID
                 { 
                     get 
                     {
@@ -4729,7 +4729,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -4809,7 +4809,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -4982,7 +4982,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -5122,7 +5122,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -5203,7 +5203,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -6831,7 +6831,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -6912,7 +6912,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -8912,7 +8912,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -8992,7 +8992,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -9072,7 +9072,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -9212,7 +9212,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -9294,7 +9294,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
+                public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
                 { 
                     get 
                     {
@@ -9498,7 +9498,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
+                public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
                 { 
                     get 
                     {
@@ -9640,7 +9640,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -9720,7 +9720,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SettlInstSource SettlInstSource
+                public QuickFix.Fields.SettlInstSource SettlInstSource
                 { 
                     get 
                     {
@@ -9829,7 +9829,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SettlPartyID SettlPartyID
+                    public QuickFix.Fields.SettlPartyID SettlPartyID
                     { 
                         get 
                         {
@@ -9969,7 +9969,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SettlPartySubID SettlPartySubID
+                        public QuickFix.Fields.SettlPartySubID SettlPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50SP1/CollateralRequest.cs
+++ b/QuickFIXn/Message/FIX50SP1/CollateralRequest.cs
@@ -4102,7 +4102,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -4242,7 +4242,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -4323,7 +4323,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ExecID ExecID
+                public QuickFix.Fields.ExecID ExecID
                 { 
                     get 
                     {
@@ -4372,7 +4372,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradeReportID TradeReportID
+                public QuickFix.Fields.TradeReportID TradeReportID
                 { 
                     get 
                     {
@@ -4452,7 +4452,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -4532,7 +4532,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -4705,7 +4705,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -4845,7 +4845,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -4926,7 +4926,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -6554,7 +6554,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -6635,7 +6635,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -8666,7 +8666,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -8746,7 +8746,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -8826,7 +8826,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -8966,7 +8966,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -9048,7 +9048,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
+                public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
                 { 
                     get 
                     {
@@ -9252,7 +9252,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
+                public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
                 { 
                     get 
                     {
@@ -9394,7 +9394,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP1/CollateralResponse.cs
+++ b/QuickFIXn/Message/FIX50SP1/CollateralResponse.cs
@@ -4164,7 +4164,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -4304,7 +4304,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -4385,7 +4385,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ExecID ExecID
+                public QuickFix.Fields.ExecID ExecID
                 { 
                     get 
                     {
@@ -4434,7 +4434,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradeReportID TradeReportID
+                public QuickFix.Fields.TradeReportID TradeReportID
                 { 
                     get 
                     {
@@ -4514,7 +4514,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -4594,7 +4594,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -4767,7 +4767,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -4907,7 +4907,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -4988,7 +4988,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -6616,7 +6616,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -6697,7 +6697,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -8728,7 +8728,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -8808,7 +8808,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -8888,7 +8888,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -9028,7 +9028,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -9110,7 +9110,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
+                public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
                 { 
                     get 
                     {
@@ -9314,7 +9314,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
+                public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
                 { 
                     get 
                     {
@@ -9456,7 +9456,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP1/Confirmation.cs
+++ b/QuickFIXn/Message/FIX50SP1/Confirmation.cs
@@ -5236,7 +5236,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -5376,7 +5376,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -5457,7 +5457,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ClOrdID ClOrdID
+                public QuickFix.Fields.ClOrdID ClOrdID
                 { 
                     get 
                     {
@@ -5752,7 +5752,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.Nested2PartyID Nested2PartyID
+                    public QuickFix.Fields.Nested2PartyID Nested2PartyID
                     { 
                         get 
                         {
@@ -5892,7 +5892,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
+                        public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
                         { 
                             get 
                             {
@@ -5974,7 +5974,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
+                public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
                 { 
                     get 
                     {
@@ -6178,7 +6178,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -6258,7 +6258,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -6431,7 +6431,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -6571,7 +6571,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -6652,7 +6652,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrAttribType InstrAttribType
+                public QuickFix.Fields.InstrAttribType InstrAttribType
                 { 
                     get 
                     {
@@ -6732,7 +6732,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -8732,7 +8732,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -8812,7 +8812,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -8892,7 +8892,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -9032,7 +9032,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -9114,7 +9114,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -10742,7 +10742,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -10823,7 +10823,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.OrderCapacity OrderCapacity
+                public QuickFix.Fields.OrderCapacity OrderCapacity
                 { 
                     get 
                     {
@@ -10934,7 +10934,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SettlInstSource SettlInstSource
+                public QuickFix.Fields.SettlInstSource SettlInstSource
                 { 
                     get 
                     {
@@ -11043,7 +11043,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SettlPartyID SettlPartyID
+                    public QuickFix.Fields.SettlPartyID SettlPartyID
                     { 
                         get 
                         {
@@ -11183,7 +11183,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SettlPartySubID SettlPartySubID
+                        public QuickFix.Fields.SettlPartySubID SettlPartySubID
                         { 
                             get 
                             {
@@ -11265,7 +11265,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -11345,7 +11345,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
+                public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP1/ConfirmationAck.cs
+++ b/QuickFIXn/Message/FIX50SP1/ConfirmationAck.cs
@@ -306,7 +306,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EncodedText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX50SP1/ConfirmationRequest.cs
+++ b/QuickFIXn/Message/FIX50SP1/ConfirmationRequest.cs
@@ -444,7 +444,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ClOrdID ClOrdID
+                public QuickFix.Fields.ClOrdID ClOrdID
                 { 
                     get 
                     {
@@ -739,7 +739,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.Nested2PartyID Nested2PartyID
+                    public QuickFix.Fields.Nested2PartyID Nested2PartyID
                     { 
                         get 
                         {
@@ -879,7 +879,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
+                        public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50SP1/ContraryIntentionReport.cs
+++ b/QuickFIXn/Message/FIX50SP1/ContraryIntentionReport.cs
@@ -2798,7 +2798,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -2938,7 +2938,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -3019,7 +3019,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ExpirationQtyType ExpirationQtyType
+                public QuickFix.Fields.ExpirationQtyType ExpirationQtyType
                 { 
                     get 
                     {
@@ -3099,7 +3099,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3179,7 +3179,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -3352,7 +3352,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -3492,7 +3492,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -3573,7 +3573,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -5573,7 +5573,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -5653,7 +5653,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -5733,7 +5733,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -5873,7 +5873,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50SP1/CrossOrderCancelReplaceRequest.cs
+++ b/QuickFIXn/Message/FIX50SP1/CrossOrderCancelReplaceRequest.cs
@@ -5596,7 +5596,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Side Side
+                public QuickFix.Fields.Side Side
                 { 
                     get 
                     {
@@ -6945,7 +6945,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -7085,7 +7085,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.PartySubID PartySubID
+                        public QuickFix.Fields.PartySubID PartySubID
                         { 
                             get 
                             {
@@ -7166,7 +7166,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.AllocAccount AllocAccount
+                    public QuickFix.Fields.AllocAccount AllocAccount
                     { 
                         get 
                         {
@@ -7368,7 +7368,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartyID NestedPartyID
+                        public QuickFix.Fields.NestedPartyID NestedPartyID
                         { 
                             get 
                             {
@@ -7508,7 +7508,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
                             { 
                                 get 
                                 {
@@ -7591,7 +7591,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -7671,7 +7671,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -7844,7 +7844,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -7984,7 +7984,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -8065,7 +8065,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -10065,7 +10065,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -10145,7 +10145,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -10225,7 +10225,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -10365,7 +10365,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -10447,7 +10447,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -12075,7 +12075,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -12156,7 +12156,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {
@@ -12236,7 +12236,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -12316,7 +12316,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StrategyParameterName StrategyParameterName
+                public QuickFix.Fields.StrategyParameterName StrategyParameterName
                 { 
                     get 
                     {
@@ -12427,7 +12427,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RootPartyID RootPartyID
+                public QuickFix.Fields.RootPartyID RootPartyID
                 { 
                     get 
                     {
@@ -12567,7 +12567,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.RootPartySubID RootPartySubID
+                    public QuickFix.Fields.RootPartySubID RootPartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP1/CrossOrderCancelRequest.cs
+++ b/QuickFIXn/Message/FIX50SP1/CrossOrderCancelRequest.cs
@@ -2680,7 +2680,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Side Side
+                public QuickFix.Fields.Side Side
                 { 
                     get 
                     {
@@ -3254,7 +3254,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -3394,7 +3394,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.PartySubID PartySubID
+                        public QuickFix.Fields.PartySubID PartySubID
                         { 
                             get 
                             {
@@ -3476,7 +3476,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3556,7 +3556,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -3729,7 +3729,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -3869,7 +3869,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -3950,7 +3950,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -5950,7 +5950,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -6030,7 +6030,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -6110,7 +6110,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -6250,7 +6250,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -6332,7 +6332,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -7960,7 +7960,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -8041,7 +8041,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RootPartyID RootPartyID
+                public QuickFix.Fields.RootPartyID RootPartyID
                 { 
                     get 
                     {
@@ -8181,7 +8181,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.RootPartySubID RootPartySubID
+                    public QuickFix.Fields.RootPartySubID RootPartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP1/DerivativeSecurityList.cs
+++ b/QuickFIXn/Message/FIX50SP1/DerivativeSecurityList.cs
@@ -4253,7 +4253,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                 { 
                     get 
                     {
@@ -4333,7 +4333,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                 { 
                     get 
                     {
@@ -4413,7 +4413,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                 { 
                     get 
                     {
@@ -4553,7 +4553,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                    public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                     { 
                         get 
                         {
@@ -4634,7 +4634,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -7347,7 +7347,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -7427,7 +7427,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -7600,7 +7600,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                     { 
                         get 
                         {
@@ -7740,7 +7740,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                        public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                         { 
                             get 
                             {
@@ -7821,7 +7821,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrAttribType InstrAttribType
+                    public QuickFix.Fields.InstrAttribType InstrAttribType
                     { 
                         get 
                         {
@@ -7901,7 +7901,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSymbol LegSymbol
+                    public QuickFix.Fields.LegSymbol LegSymbol
                     { 
                         get 
                         {
@@ -9529,7 +9529,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                        public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                         { 
                             get 
                             {
@@ -9611,7 +9611,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.DerivativeSecurityAltID DerivativeSecurityAltID
+                public QuickFix.Fields.DerivativeSecurityAltID DerivativeSecurityAltID
                 { 
                     get 
                     {
@@ -9691,7 +9691,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.DerivativeEventType DerivativeEventType
+                public QuickFix.Fields.DerivativeEventType DerivativeEventType
                 { 
                     get 
                     {
@@ -9864,7 +9864,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.DerivativeInstrumentPartyID DerivativeInstrumentPartyID
+                public QuickFix.Fields.DerivativeInstrumentPartyID DerivativeInstrumentPartyID
                 { 
                     get 
                     {
@@ -10004,7 +10004,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.DerivativeInstrumentPartySubID DerivativeInstrumentPartySubID
+                    public QuickFix.Fields.DerivativeInstrumentPartySubID DerivativeInstrumentPartySubID
                     { 
                         get 
                         {
@@ -10085,7 +10085,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.DerivativeInstrAttribType DerivativeInstrAttribType
+                public QuickFix.Fields.DerivativeInstrAttribType DerivativeInstrAttribType
                 { 
                     get 
                     {
@@ -10165,7 +10165,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MarketID MarketID
+                public QuickFix.Fields.MarketID MarketID
                 { 
                     get 
                     {
@@ -10832,7 +10832,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StartTickPriceRange StartTickPriceRange
+                    public QuickFix.Fields.StartTickPriceRange StartTickPriceRange
                     { 
                         get 
                         {
@@ -10974,7 +10974,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LotType LotType
+                    public QuickFix.Fields.LotType LotType
                     { 
                         get 
                         {
@@ -11054,7 +11054,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.TradingSessionID TradingSessionID
+                    public QuickFix.Fields.TradingSessionID TradingSessionID
                     { 
                         get 
                         {
@@ -11287,7 +11287,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.OrdType OrdType
+                        public QuickFix.Fields.OrdType OrdType
                         { 
                             get 
                             {
@@ -11336,7 +11336,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.TimeInForce TimeInForce
+                        public QuickFix.Fields.TimeInForce TimeInForce
                         { 
                             get 
                             {
@@ -11385,7 +11385,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ExecInstValue ExecInstValue
+                        public QuickFix.Fields.ExecInstValue ExecInstValue
                         { 
                             get 
                             {
@@ -11434,7 +11434,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.MatchAlgorithm MatchAlgorithm
+                        public QuickFix.Fields.MatchAlgorithm MatchAlgorithm
                         { 
                             get 
                             {
@@ -11514,7 +11514,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.MDFeedType MDFeedType
+                        public QuickFix.Fields.MDFeedType MDFeedType
                         { 
                             get 
                             {
@@ -11626,7 +11626,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedInstrAttribType NestedInstrAttribType
+                    public QuickFix.Fields.NestedInstrAttribType NestedInstrAttribType
                     { 
                         get 
                         {
@@ -11706,7 +11706,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StrikeRuleID StrikeRuleID
+                    public QuickFix.Fields.StrikeRuleID StrikeRuleID
                     { 
                         get 
                         {
@@ -11908,7 +11908,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.MaturityRuleID MaturityRuleID
+                        public QuickFix.Fields.MaturityRuleID MaturityRuleID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50SP1/DerivativeSecurityListRequest.cs
+++ b/QuickFIXn/Message/FIX50SP1/DerivativeSecurityListRequest.cs
@@ -4255,7 +4255,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                 { 
                     get 
                     {
@@ -4335,7 +4335,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                 { 
                     get 
                     {
@@ -4415,7 +4415,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                 { 
                     get 
                     {
@@ -4555,7 +4555,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                    public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                     { 
                         get 
                         {
@@ -4636,7 +4636,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.DerivativeSecurityAltID DerivativeSecurityAltID
+                public QuickFix.Fields.DerivativeSecurityAltID DerivativeSecurityAltID
                 { 
                     get 
                     {
@@ -4716,7 +4716,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.DerivativeEventType DerivativeEventType
+                public QuickFix.Fields.DerivativeEventType DerivativeEventType
                 { 
                     get 
                     {
@@ -4889,7 +4889,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.DerivativeInstrumentPartyID DerivativeInstrumentPartyID
+                public QuickFix.Fields.DerivativeInstrumentPartyID DerivativeInstrumentPartyID
                 { 
                     get 
                     {
@@ -5029,7 +5029,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.DerivativeInstrumentPartySubID DerivativeInstrumentPartySubID
+                    public QuickFix.Fields.DerivativeInstrumentPartySubID DerivativeInstrumentPartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP1/DerivativeSecurityListUpdateReport.cs
+++ b/QuickFIXn/Message/FIX50SP1/DerivativeSecurityListUpdateReport.cs
@@ -4278,7 +4278,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                 { 
                     get 
                     {
@@ -4358,7 +4358,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                 { 
                     get 
                     {
@@ -4438,7 +4438,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                 { 
                     get 
                     {
@@ -4578,7 +4578,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                    public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                     { 
                         get 
                         {
@@ -4659,7 +4659,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.DerivativeSecurityAltID DerivativeSecurityAltID
+                public QuickFix.Fields.DerivativeSecurityAltID DerivativeSecurityAltID
                 { 
                     get 
                     {
@@ -4739,7 +4739,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.DerivativeEventType DerivativeEventType
+                public QuickFix.Fields.DerivativeEventType DerivativeEventType
                 { 
                     get 
                     {
@@ -4912,7 +4912,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.DerivativeInstrumentPartyID DerivativeInstrumentPartyID
+                public QuickFix.Fields.DerivativeInstrumentPartyID DerivativeInstrumentPartyID
                 { 
                     get 
                     {
@@ -5052,7 +5052,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.DerivativeInstrumentPartySubID DerivativeInstrumentPartySubID
+                    public QuickFix.Fields.DerivativeInstrumentPartySubID DerivativeInstrumentPartySubID
                     { 
                         get 
                         {
@@ -5133,7 +5133,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.DerivativeInstrAttribType DerivativeInstrAttribType
+                public QuickFix.Fields.DerivativeInstrAttribType DerivativeInstrAttribType
                 { 
                     get 
                     {
@@ -5213,7 +5213,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MarketID MarketID
+                public QuickFix.Fields.MarketID MarketID
                 { 
                     get 
                     {
@@ -5880,7 +5880,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StartTickPriceRange StartTickPriceRange
+                    public QuickFix.Fields.StartTickPriceRange StartTickPriceRange
                     { 
                         get 
                         {
@@ -6022,7 +6022,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LotType LotType
+                    public QuickFix.Fields.LotType LotType
                     { 
                         get 
                         {
@@ -6102,7 +6102,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.TradingSessionID TradingSessionID
+                    public QuickFix.Fields.TradingSessionID TradingSessionID
                     { 
                         get 
                         {
@@ -6335,7 +6335,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.OrdType OrdType
+                        public QuickFix.Fields.OrdType OrdType
                         { 
                             get 
                             {
@@ -6384,7 +6384,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.TimeInForce TimeInForce
+                        public QuickFix.Fields.TimeInForce TimeInForce
                         { 
                             get 
                             {
@@ -6433,7 +6433,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ExecInstValue ExecInstValue
+                        public QuickFix.Fields.ExecInstValue ExecInstValue
                         { 
                             get 
                             {
@@ -6482,7 +6482,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.MatchAlgorithm MatchAlgorithm
+                        public QuickFix.Fields.MatchAlgorithm MatchAlgorithm
                         { 
                             get 
                             {
@@ -6562,7 +6562,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.MDFeedType MDFeedType
+                        public QuickFix.Fields.MDFeedType MDFeedType
                         { 
                             get 
                             {
@@ -6674,7 +6674,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedInstrAttribType NestedInstrAttribType
+                    public QuickFix.Fields.NestedInstrAttribType NestedInstrAttribType
                     { 
                         get 
                         {
@@ -6754,7 +6754,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StrikeRuleID StrikeRuleID
+                    public QuickFix.Fields.StrikeRuleID StrikeRuleID
                     { 
                         get 
                         {
@@ -6956,7 +6956,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.MaturityRuleID MaturityRuleID
+                        public QuickFix.Fields.MaturityRuleID MaturityRuleID
                         { 
                             get 
                             {
@@ -7162,7 +7162,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ListUpdateAction ListUpdateAction
+                public QuickFix.Fields.ListUpdateAction ListUpdateAction
                 { 
                     get 
                     {
@@ -9906,7 +9906,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -9986,7 +9986,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -10159,7 +10159,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                     { 
                         get 
                         {
@@ -10299,7 +10299,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                        public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                         { 
                             get 
                             {
@@ -10380,7 +10380,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrAttribType InstrAttribType
+                    public QuickFix.Fields.InstrAttribType InstrAttribType
                     { 
                         get 
                         {
@@ -10460,7 +10460,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSymbol LegSymbol
+                    public QuickFix.Fields.LegSymbol LegSymbol
                     { 
                         get 
                         {
@@ -12088,7 +12088,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                        public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50SP1/DontKnowTrade.cs
+++ b/QuickFIXn/Message/FIX50SP1/DontKnowTrade.cs
@@ -2864,7 +2864,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -2944,7 +2944,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -3117,7 +3117,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -3257,7 +3257,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -3338,7 +3338,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -5338,7 +5338,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -5418,7 +5418,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -5498,7 +5498,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -5638,7 +5638,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -5720,7 +5720,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -7348,7 +7348,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP1/Email.cs
+++ b/QuickFIXn/Message/FIX50SP1/Email.cs
@@ -506,7 +506,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RoutingType RoutingType
+                public QuickFix.Fields.RoutingType RoutingType
                 { 
                     get 
                     {
@@ -586,7 +586,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -2896,7 +2896,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -2976,7 +2976,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -3149,7 +3149,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                     { 
                         get 
                         {
@@ -3289,7 +3289,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                        public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                         { 
                             get 
                             {
@@ -3371,7 +3371,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -5371,7 +5371,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -5451,7 +5451,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -5531,7 +5531,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -5671,7 +5671,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -5753,7 +5753,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -7381,7 +7381,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -7462,7 +7462,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Text Text
+                public QuickFix.Fields.Text Text
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP1/ExecutionAcknowledgement.cs
+++ b/QuickFIXn/Message/FIX50SP1/ExecutionAcknowledgement.cs
@@ -3050,7 +3050,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3130,7 +3130,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -3303,7 +3303,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -3443,7 +3443,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -3524,7 +3524,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -5524,7 +5524,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -5604,7 +5604,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -5684,7 +5684,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -5824,7 +5824,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -5906,7 +5906,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -7534,7 +7534,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP1/ExecutionReport.cs
+++ b/QuickFIXn/Message/FIX50SP1/ExecutionReport.cs
@@ -9690,7 +9690,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -9830,7 +9830,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -9911,7 +9911,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ContraBroker ContraBroker
+                public QuickFix.Fields.ContraBroker ContraBroker
                 { 
                     get 
                     {
@@ -10084,7 +10084,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -10164,7 +10164,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -10337,7 +10337,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -10477,7 +10477,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -10558,7 +10558,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -12558,7 +12558,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -12638,7 +12638,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -12718,7 +12718,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -12858,7 +12858,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -12940,7 +12940,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -13020,7 +13020,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ContAmtType ContAmtType
+                public QuickFix.Fields.ContAmtType ContAmtType
                 { 
                     get 
                     {
@@ -13131,7 +13131,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -15441,7 +15441,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -15521,7 +15521,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegStipulationType LegStipulationType
+                    public QuickFix.Fields.LegStipulationType LegStipulationType
                     { 
                         get 
                         {
@@ -15601,7 +15601,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.Nested3PartyID Nested3PartyID
+                    public QuickFix.Fields.Nested3PartyID Nested3PartyID
                     { 
                         get 
                         {
@@ -15741,7 +15741,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested3PartySubID Nested3PartySubID
+                        public QuickFix.Fields.Nested3PartySubID Nested3PartySubID
                         { 
                             get 
                             {
@@ -15822,7 +15822,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegAllocAccount LegAllocAccount
+                    public QuickFix.Fields.LegAllocAccount LegAllocAccount
                     { 
                         get 
                         {
@@ -16024,7 +16024,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested2PartyID Nested2PartyID
+                        public QuickFix.Fields.Nested2PartyID Nested2PartyID
                         { 
                             get 
                             {
@@ -16164,7 +16164,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
+                            public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
                             { 
                                 get 
                                 {
@@ -16247,7 +16247,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
+                public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
                 { 
                     get 
                     {
@@ -16389,7 +16389,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StrategyParameterName StrategyParameterName
+                public QuickFix.Fields.StrategyParameterName StrategyParameterName
                 { 
                     get 
                     {
@@ -16500,7 +16500,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
+                public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
                 { 
                     get 
                     {
@@ -16704,7 +16704,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AllocAccount AllocAccount
+                public QuickFix.Fields.AllocAccount AllocAccount
                 { 
                     get 
                     {
@@ -16906,7 +16906,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -17046,7 +17046,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -17128,7 +17128,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.FillExecID FillExecID
+                public QuickFix.Fields.FillExecID FillExecID
                 { 
                     get 
                     {
@@ -17268,7 +17268,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.Nested4PartyID Nested4PartyID
+                    public QuickFix.Fields.Nested4PartyID Nested4PartyID
                     { 
                         get 
                         {
@@ -17408,7 +17408,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested4PartySubID Nested4PartySubID
+                        public QuickFix.Fields.Nested4PartySubID Nested4PartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50SP1/IOI.cs
+++ b/QuickFIXn/Message/FIX50SP1/IOI.cs
@@ -4042,7 +4042,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -4122,7 +4122,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -4295,7 +4295,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -4435,7 +4435,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -4516,7 +4516,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -6516,7 +6516,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -6596,7 +6596,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -6676,7 +6676,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -6816,7 +6816,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -6898,7 +6898,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -6978,7 +6978,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -8668,7 +8668,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -8748,7 +8748,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegStipulationType LegStipulationType
+                    public QuickFix.Fields.LegStipulationType LegStipulationType
                     { 
                         get 
                         {
@@ -8829,7 +8829,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.IOIQualifier IOIQualifier
+                public QuickFix.Fields.IOIQualifier IOIQualifier
                 { 
                     get 
                     {
@@ -8878,7 +8878,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RoutingType RoutingType
+                public QuickFix.Fields.RoutingType RoutingType
                 { 
                     get 
                     {
@@ -8958,7 +8958,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -9098,7 +9098,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP1/ListCancelRequest.cs
+++ b/QuickFIXn/Message/FIX50SP1/ListCancelRequest.cs
@@ -287,7 +287,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -427,7 +427,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP1/ListExecute.cs
+++ b/QuickFIXn/Message/FIX50SP1/ListExecute.cs
@@ -240,7 +240,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EncodedText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX50SP1/ListStatus.cs
+++ b/QuickFIXn/Message/FIX50SP1/ListStatus.cs
@@ -481,7 +481,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ClOrdID ClOrdID
+                public QuickFix.Fields.ClOrdID ClOrdID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP1/ListStatusRequest.cs
+++ b/QuickFIXn/Message/FIX50SP1/ListStatusRequest.cs
@@ -145,7 +145,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EncodedText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX50SP1/ListStrikePrice.cs
+++ b/QuickFIXn/Message/FIX50SP1/ListStrikePrice.cs
@@ -163,7 +163,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -2783,7 +2783,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -2863,7 +2863,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -3036,7 +3036,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                     { 
                         get 
                         {
@@ -3176,7 +3176,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                        public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                         { 
                             get 
                             {
@@ -3257,7 +3257,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                     { 
                         get 
                         {
@@ -5257,7 +5257,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                        public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                         { 
                             get 
                             {
@@ -5337,7 +5337,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                        public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                         { 
                             get 
                             {
@@ -5417,7 +5417,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                        public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                         { 
                             get 
                             {
@@ -5557,7 +5557,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                             { 
                                 get 
                                 {

--- a/QuickFIXn/Message/FIX50SP1/MarketDataIncrementalRefresh.cs
+++ b/QuickFIXn/Message/FIX50SP1/MarketDataIncrementalRefresh.cs
@@ -403,7 +403,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MDUpdateAction MDUpdateAction
+                public QuickFix.Fields.MDUpdateAction MDUpdateAction
                 { 
                     get 
                     {
@@ -5348,7 +5348,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -5428,7 +5428,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -5601,7 +5601,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                     { 
                         get 
                         {
@@ -5741,7 +5741,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                        public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                         { 
                             get 
                             {
@@ -5822,7 +5822,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                     { 
                         get 
                         {
@@ -7822,7 +7822,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                        public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                         { 
                             get 
                             {
@@ -7902,7 +7902,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                        public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                         { 
                             get 
                             {
@@ -7982,7 +7982,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                        public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                         { 
                             get 
                             {
@@ -8122,7 +8122,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                             { 
                                 get 
                                 {
@@ -8204,7 +8204,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSymbol LegSymbol
+                    public QuickFix.Fields.LegSymbol LegSymbol
                     { 
                         get 
                         {
@@ -9832,7 +9832,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                        public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                         { 
                             get 
                             {
@@ -9913,7 +9913,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -10053,7 +10053,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.PartySubID PartySubID
+                        public QuickFix.Fields.PartySubID PartySubID
                         { 
                             get 
                             {
@@ -10134,7 +10134,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.MDSecSizeType MDSecSizeType
+                    public QuickFix.Fields.MDSecSizeType MDSecSizeType
                     { 
                         get 
                         {
@@ -10214,7 +10214,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StatsType StatsType
+                    public QuickFix.Fields.StatsType StatsType
                     { 
                         get 
                         {
@@ -10264,7 +10264,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RoutingType RoutingType
+                public QuickFix.Fields.RoutingType RoutingType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP1/MarketDataRequest.cs
+++ b/QuickFIXn/Message/FIX50SP1/MarketDataRequest.cs
@@ -506,7 +506,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MDEntryType MDEntryType
+                public QuickFix.Fields.MDEntryType MDEntryType
                 { 
                     get 
                     {
@@ -555,7 +555,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -3082,7 +3082,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -3162,7 +3162,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -3335,7 +3335,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                     { 
                         get 
                         {
@@ -3475,7 +3475,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                        public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                         { 
                             get 
                             {
@@ -3556,7 +3556,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                     { 
                         get 
                         {
@@ -5556,7 +5556,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                        public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                         { 
                             get 
                             {
@@ -5636,7 +5636,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                        public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                         { 
                             get 
                             {
@@ -5716,7 +5716,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                        public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                         { 
                             get 
                             {
@@ -5856,7 +5856,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                             { 
                                 get 
                                 {
@@ -5938,7 +5938,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSymbol LegSymbol
+                    public QuickFix.Fields.LegSymbol LegSymbol
                     { 
                         get 
                         {
@@ -7566,7 +7566,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                        public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                         { 
                             get 
                             {
@@ -7648,7 +7648,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {
@@ -7728,7 +7728,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -7868,7 +7868,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP1/MarketDataRequestReject.cs
+++ b/QuickFIXn/Message/FIX50SP1/MarketDataRequestReject.cs
@@ -254,7 +254,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AltMDSourceID AltMDSourceID
+                public QuickFix.Fields.AltMDSourceID AltMDSourceID
                 { 
                     get 
                     {
@@ -303,7 +303,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -443,7 +443,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP1/MarketDataSnapshotFullRefresh.cs
+++ b/QuickFIXn/Message/FIX50SP1/MarketDataSnapshotFullRefresh.cs
@@ -3038,7 +3038,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3118,7 +3118,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -3291,7 +3291,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -3431,7 +3431,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -3512,7 +3512,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -5512,7 +5512,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -5592,7 +5592,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -5672,7 +5672,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -5812,7 +5812,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -5894,7 +5894,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -7522,7 +7522,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -7603,7 +7603,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MDEntryType MDEntryType
+                public QuickFix.Fields.MDEntryType MDEntryType
                 { 
                     get 
                     {
@@ -9758,7 +9758,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -9898,7 +9898,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.PartySubID PartySubID
+                        public QuickFix.Fields.PartySubID PartySubID
                         { 
                             get 
                             {
@@ -9979,7 +9979,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.MDSecSizeType MDSecSizeType
+                    public QuickFix.Fields.MDSecSizeType MDSecSizeType
                     { 
                         get 
                         {
@@ -10060,7 +10060,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RoutingType RoutingType
+                public QuickFix.Fields.RoutingType RoutingType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP1/MarketDefinition.cs
+++ b/QuickFIXn/Message/FIX50SP1/MarketDefinition.cs
@@ -1155,7 +1155,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StartTickPriceRange StartTickPriceRange
+                public QuickFix.Fields.StartTickPriceRange StartTickPriceRange
                 { 
                     get 
                     {
@@ -1297,7 +1297,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LotType LotType
+                public QuickFix.Fields.LotType LotType
                 { 
                     get 
                     {
@@ -1377,7 +1377,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.OrdType OrdType
+                public QuickFix.Fields.OrdType OrdType
                 { 
                     get 
                     {
@@ -1426,7 +1426,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TimeInForce TimeInForce
+                public QuickFix.Fields.TimeInForce TimeInForce
                 { 
                     get 
                     {
@@ -1475,7 +1475,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ExecInstValue ExecInstValue
+                public QuickFix.Fields.ExecInstValue ExecInstValue
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP1/MarketDefinitionRequest.cs
+++ b/QuickFIXn/Message/FIX50SP1/MarketDefinitionRequest.cs
@@ -178,7 +178,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.ParentMktSegmID);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX50SP1/MarketDefinitionUpdateReport.cs
+++ b/QuickFIXn/Message/FIX50SP1/MarketDefinitionUpdateReport.cs
@@ -1186,7 +1186,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StartTickPriceRange StartTickPriceRange
+                public QuickFix.Fields.StartTickPriceRange StartTickPriceRange
                 { 
                     get 
                     {
@@ -1328,7 +1328,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LotType LotType
+                public QuickFix.Fields.LotType LotType
                 { 
                     get 
                     {
@@ -1408,7 +1408,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.OrdType OrdType
+                public QuickFix.Fields.OrdType OrdType
                 { 
                     get 
                     {
@@ -1457,7 +1457,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TimeInForce TimeInForce
+                public QuickFix.Fields.TimeInForce TimeInForce
                 { 
                     get 
                     {
@@ -1506,7 +1506,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ExecInstValue ExecInstValue
+                public QuickFix.Fields.ExecInstValue ExecInstValue
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP1/MassQuote.cs
+++ b/QuickFIXn/Message/FIX50SP1/MassQuote.cs
@@ -378,7 +378,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -518,7 +518,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -599,7 +599,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.QuoteSetID QuoteSetID
+                public QuickFix.Fields.QuoteSetID QuoteSetID
                 { 
                     get 
                     {
@@ -2754,7 +2754,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -2834,7 +2834,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -2914,7 +2914,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -3054,7 +3054,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -3135,7 +3135,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.QuoteEntryID QuoteEntryID
+                    public QuickFix.Fields.QuoteEntryID QuoteEntryID
                     { 
                         get 
                         {
@@ -6220,7 +6220,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                        public QuickFix.Fields.SecurityAltID SecurityAltID
                         { 
                             get 
                             {
@@ -6300,7 +6300,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.EventType EventType
+                        public QuickFix.Fields.EventType EventType
                         { 
                             get 
                             {
@@ -6473,7 +6473,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                        public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                         { 
                             get 
                             {
@@ -6613,7 +6613,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                             { 
                                 get 
                                 {
@@ -6694,7 +6694,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegSymbol LegSymbol
+                        public QuickFix.Fields.LegSymbol LegSymbol
                         { 
                             get 
                             {
@@ -8322,7 +8322,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                             { 
                                 get 
                                 {

--- a/QuickFIXn/Message/FIX50SP1/MassQuoteAcknowledgement.cs
+++ b/QuickFIXn/Message/FIX50SP1/MassQuoteAcknowledgement.cs
@@ -502,7 +502,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -642,7 +642,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -723,7 +723,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.QuoteSetID QuoteSetID
+                public QuickFix.Fields.QuoteSetID QuoteSetID
                 { 
                     get 
                     {
@@ -2940,7 +2940,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -3020,7 +3020,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -3100,7 +3100,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -3240,7 +3240,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -3321,7 +3321,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.QuoteEntryID QuoteEntryID
+                    public QuickFix.Fields.QuoteEntryID QuoteEntryID
                     { 
                         get 
                         {
@@ -6468,7 +6468,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                        public QuickFix.Fields.SecurityAltID SecurityAltID
                         { 
                             get 
                             {
@@ -6548,7 +6548,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.EventType EventType
+                        public QuickFix.Fields.EventType EventType
                         { 
                             get 
                             {
@@ -6721,7 +6721,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                        public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                         { 
                             get 
                             {
@@ -6861,7 +6861,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                             { 
                                 get 
                                 {
@@ -6942,7 +6942,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegSymbol LegSymbol
+                        public QuickFix.Fields.LegSymbol LegSymbol
                         { 
                             get 
                             {
@@ -8570,7 +8570,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                             { 
                                 get 
                                 {

--- a/QuickFIXn/Message/FIX50SP1/MultilegOrderCancelReplace.cs
+++ b/QuickFIXn/Message/FIX50SP1/MultilegOrderCancelReplace.cs
@@ -6334,7 +6334,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -6474,7 +6474,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -6555,7 +6555,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AllocAccount AllocAccount
+                public QuickFix.Fields.AllocAccount AllocAccount
                 { 
                     get 
                     {
@@ -6757,7 +6757,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.Nested3PartyID Nested3PartyID
+                    public QuickFix.Fields.Nested3PartyID Nested3PartyID
                     { 
                         get 
                         {
@@ -6897,7 +6897,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested3PartySubID Nested3PartySubID
+                        public QuickFix.Fields.Nested3PartySubID Nested3PartySubID
                         { 
                             get 
                             {
@@ -6979,7 +6979,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {
@@ -7059,7 +7059,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -7139,7 +7139,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -7312,7 +7312,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -7452,7 +7452,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -7533,7 +7533,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -9533,7 +9533,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -9613,7 +9613,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -9693,7 +9693,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -9833,7 +9833,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -9915,7 +9915,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -12070,7 +12070,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -12150,7 +12150,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegStipulationType LegStipulationType
+                    public QuickFix.Fields.LegStipulationType LegStipulationType
                     { 
                         get 
                         {
@@ -12230,7 +12230,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegAllocAccount LegAllocAccount
+                    public QuickFix.Fields.LegAllocAccount LegAllocAccount
                     { 
                         get 
                         {
@@ -12432,7 +12432,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested2PartyID Nested2PartyID
+                        public QuickFix.Fields.Nested2PartyID Nested2PartyID
                         { 
                             get 
                             {
@@ -12572,7 +12572,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
+                            public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
                             { 
                                 get 
                                 {
@@ -12654,7 +12654,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -12794,7 +12794,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -12876,7 +12876,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StrategyParameterName StrategyParameterName
+                public QuickFix.Fields.StrategyParameterName StrategyParameterName
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP1/NetworkCounterpartySystemStatusRequest.cs
+++ b/QuickFIXn/Message/FIX50SP1/NetworkCounterpartySystemStatusRequest.cs
@@ -132,7 +132,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RefCompID RefCompID
+                public QuickFix.Fields.RefCompID RefCompID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP1/NetworkCounterpartySystemStatusResponse.cs
+++ b/QuickFIXn/Message/FIX50SP1/NetworkCounterpartySystemStatusResponse.cs
@@ -194,7 +194,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RefCompID RefCompID
+                public QuickFix.Fields.RefCompID RefCompID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP1/NewOrderCross.cs
+++ b/QuickFIXn/Message/FIX50SP1/NewOrderCross.cs
@@ -5501,7 +5501,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Side Side
+                public QuickFix.Fields.Side Side
                 { 
                     get 
                     {
@@ -6850,7 +6850,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -6990,7 +6990,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.PartySubID PartySubID
+                        public QuickFix.Fields.PartySubID PartySubID
                         { 
                             get 
                             {
@@ -7071,7 +7071,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.AllocAccount AllocAccount
+                    public QuickFix.Fields.AllocAccount AllocAccount
                     { 
                         get 
                         {
@@ -7273,7 +7273,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartyID NestedPartyID
+                        public QuickFix.Fields.NestedPartyID NestedPartyID
                         { 
                             get 
                             {
@@ -7413,7 +7413,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
                             { 
                                 get 
                                 {
@@ -7496,7 +7496,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -7576,7 +7576,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -7749,7 +7749,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -7889,7 +7889,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -7970,7 +7970,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -9970,7 +9970,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -10050,7 +10050,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -10130,7 +10130,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -10270,7 +10270,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -10352,7 +10352,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -11980,7 +11980,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -12061,7 +12061,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {
@@ -12141,7 +12141,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -12221,7 +12221,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StrategyParameterName StrategyParameterName
+                public QuickFix.Fields.StrategyParameterName StrategyParameterName
                 { 
                     get 
                     {
@@ -12332,7 +12332,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RootPartyID RootPartyID
+                public QuickFix.Fields.RootPartyID RootPartyID
                 { 
                     get 
                     {
@@ -12472,7 +12472,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.RootPartySubID RootPartySubID
+                    public QuickFix.Fields.RootPartySubID RootPartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP1/NewOrderList.cs
+++ b/QuickFIXn/Message/FIX50SP1/NewOrderList.cs
@@ -692,7 +692,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ClOrdID ClOrdID
+                public QuickFix.Fields.ClOrdID ClOrdID
                 { 
                     get 
                     {
@@ -7342,7 +7342,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -7482,7 +7482,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.PartySubID PartySubID
+                        public QuickFix.Fields.PartySubID PartySubID
                         { 
                             get 
                             {
@@ -7563,7 +7563,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.AllocAccount AllocAccount
+                    public QuickFix.Fields.AllocAccount AllocAccount
                     { 
                         get 
                         {
@@ -7765,7 +7765,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartyID NestedPartyID
+                        public QuickFix.Fields.NestedPartyID NestedPartyID
                         { 
                             get 
                             {
@@ -7905,7 +7905,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
                             { 
                                 get 
                                 {
@@ -7987,7 +7987,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.TradingSessionID TradingSessionID
+                    public QuickFix.Fields.TradingSessionID TradingSessionID
                     { 
                         get 
                         {
@@ -8067,7 +8067,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -8147,7 +8147,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -8320,7 +8320,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                     { 
                         get 
                         {
@@ -8460,7 +8460,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                        public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                         { 
                             get 
                             {
@@ -8541,7 +8541,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                     { 
                         get 
                         {
@@ -10541,7 +10541,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                        public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                         { 
                             get 
                             {
@@ -10621,7 +10621,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                        public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                         { 
                             get 
                             {
@@ -10701,7 +10701,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                        public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                         { 
                             get 
                             {
@@ -10841,7 +10841,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                             { 
                                 get 
                                 {
@@ -10923,7 +10923,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StipulationType StipulationType
+                    public QuickFix.Fields.StipulationType StipulationType
                     { 
                         get 
                         {
@@ -11003,7 +11003,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StrategyParameterName StrategyParameterName
+                    public QuickFix.Fields.StrategyParameterName StrategyParameterName
                     { 
                         get 
                         {
@@ -11115,7 +11115,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RootPartyID RootPartyID
+                public QuickFix.Fields.RootPartyID RootPartyID
                 { 
                     get 
                     {
@@ -11255,7 +11255,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.RootPartySubID RootPartySubID
+                    public QuickFix.Fields.RootPartySubID RootPartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP1/NewOrderMultileg.cs
+++ b/QuickFIXn/Message/FIX50SP1/NewOrderMultileg.cs
@@ -6305,7 +6305,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -6445,7 +6445,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -6526,7 +6526,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AllocAccount AllocAccount
+                public QuickFix.Fields.AllocAccount AllocAccount
                 { 
                     get 
                     {
@@ -6728,7 +6728,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.Nested3PartyID Nested3PartyID
+                    public QuickFix.Fields.Nested3PartyID Nested3PartyID
                     { 
                         get 
                         {
@@ -6868,7 +6868,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested3PartySubID Nested3PartySubID
+                        public QuickFix.Fields.Nested3PartySubID Nested3PartySubID
                         { 
                             get 
                             {
@@ -6950,7 +6950,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {
@@ -7030,7 +7030,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -7110,7 +7110,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -7283,7 +7283,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -7423,7 +7423,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -7504,7 +7504,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -9504,7 +9504,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -9584,7 +9584,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -9664,7 +9664,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -9804,7 +9804,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -9886,7 +9886,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -12041,7 +12041,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -12121,7 +12121,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegStipulationType LegStipulationType
+                    public QuickFix.Fields.LegStipulationType LegStipulationType
                     { 
                         get 
                         {
@@ -12201,7 +12201,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegAllocAccount LegAllocAccount
+                    public QuickFix.Fields.LegAllocAccount LegAllocAccount
                     { 
                         get 
                         {
@@ -12403,7 +12403,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested2PartyID Nested2PartyID
+                        public QuickFix.Fields.Nested2PartyID Nested2PartyID
                         { 
                             get 
                             {
@@ -12543,7 +12543,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
+                            public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
                             { 
                                 get 
                                 {
@@ -12625,7 +12625,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -12765,7 +12765,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -12847,7 +12847,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StrategyParameterName StrategyParameterName
+                public QuickFix.Fields.StrategyParameterName StrategyParameterName
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP1/NewOrderSingle.cs
+++ b/QuickFIXn/Message/FIX50SP1/NewOrderSingle.cs
@@ -7142,7 +7142,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -7282,7 +7282,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -7363,7 +7363,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AllocAccount AllocAccount
+                public QuickFix.Fields.AllocAccount AllocAccount
                 { 
                     get 
                     {
@@ -7565,7 +7565,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -7705,7 +7705,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -7787,7 +7787,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {
@@ -7867,7 +7867,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -7947,7 +7947,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -8120,7 +8120,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -8260,7 +8260,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -8341,7 +8341,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -10341,7 +10341,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -10421,7 +10421,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -10501,7 +10501,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -10641,7 +10641,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -10723,7 +10723,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -10803,7 +10803,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StrategyParameterName StrategyParameterName
+                public QuickFix.Fields.StrategyParameterName StrategyParameterName
                 { 
                     get 
                     {
@@ -10914,7 +10914,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
+                public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP1/News.cs
+++ b/QuickFIXn/Message/FIX50SP1/News.cs
@@ -564,7 +564,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RoutingType RoutingType
+                public QuickFix.Fields.RoutingType RoutingType
                 { 
                     get 
                     {
@@ -644,7 +644,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -2954,7 +2954,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -3034,7 +3034,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -3207,7 +3207,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                     { 
                         get 
                         {
@@ -3347,7 +3347,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                        public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                         { 
                             get 
                             {
@@ -3429,7 +3429,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -5057,7 +5057,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -5138,7 +5138,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -7138,7 +7138,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -7218,7 +7218,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -7298,7 +7298,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -7438,7 +7438,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -7520,7 +7520,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Text Text
+                public QuickFix.Fields.Text Text
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP1/OrderCancelReject.cs
+++ b/QuickFIXn/Message/FIX50SP1/OrderCancelReject.cs
@@ -678,7 +678,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EncodedText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX50SP1/OrderCancelReplaceRequest.cs
+++ b/QuickFIXn/Message/FIX50SP1/OrderCancelReplaceRequest.cs
@@ -7049,7 +7049,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -7189,7 +7189,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -7270,7 +7270,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AllocAccount AllocAccount
+                public QuickFix.Fields.AllocAccount AllocAccount
                 { 
                     get 
                     {
@@ -7472,7 +7472,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -7612,7 +7612,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -7694,7 +7694,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {
@@ -7774,7 +7774,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -7854,7 +7854,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -8027,7 +8027,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -8167,7 +8167,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -8248,7 +8248,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -10248,7 +10248,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -10328,7 +10328,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -10408,7 +10408,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -10548,7 +10548,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -10630,7 +10630,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StrategyParameterName StrategyParameterName
+                public QuickFix.Fields.StrategyParameterName StrategyParameterName
                 { 
                     get 
                     {
@@ -10741,7 +10741,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
+                public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP1/OrderCancelRequest.cs
+++ b/QuickFIXn/Message/FIX50SP1/OrderCancelRequest.cs
@@ -3327,7 +3327,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -3467,7 +3467,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -3548,7 +3548,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3628,7 +3628,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -3801,7 +3801,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -3941,7 +3941,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -4022,7 +4022,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -6022,7 +6022,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -6102,7 +6102,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -6182,7 +6182,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -6322,7 +6322,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50SP1/OrderMassActionReport.cs
+++ b/QuickFIXn/Message/FIX50SP1/OrderMassActionReport.cs
@@ -4941,7 +4941,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.OrigClOrdID OrigClOrdID
+                public QuickFix.Fields.OrigClOrdID OrigClOrdID
                 { 
                     get 
                     {
@@ -5052,7 +5052,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -5192,7 +5192,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -5273,7 +5273,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -5353,7 +5353,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -5526,7 +5526,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -5666,7 +5666,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -5747,7 +5747,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                 { 
                     get 
                     {
@@ -5827,7 +5827,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                 { 
                     get 
                     {
@@ -5907,7 +5907,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                 { 
                     get 
                     {
@@ -6047,7 +6047,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                    public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                     { 
                         get 
                         {
@@ -6128,7 +6128,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.NotAffOrigClOrdID NotAffOrigClOrdID
+                public QuickFix.Fields.NotAffOrigClOrdID NotAffOrigClOrdID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP1/OrderMassActionRequest.cs
+++ b/QuickFIXn/Message/FIX50SP1/OrderMassActionRequest.cs
@@ -4755,7 +4755,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -4895,7 +4895,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -4976,7 +4976,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -5056,7 +5056,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -5229,7 +5229,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -5369,7 +5369,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -5450,7 +5450,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                 { 
                     get 
                     {
@@ -5530,7 +5530,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                 { 
                     get 
                     {
@@ -5610,7 +5610,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                 { 
                     get 
                     {
@@ -5750,7 +5750,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                    public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP1/OrderMassCancelReport.cs
+++ b/QuickFIXn/Message/FIX50SP1/OrderMassCancelReport.cs
@@ -4972,7 +4972,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.OrigClOrdID OrigClOrdID
+                public QuickFix.Fields.OrigClOrdID OrigClOrdID
                 { 
                     get 
                     {
@@ -5083,7 +5083,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -5163,7 +5163,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -5336,7 +5336,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -5476,7 +5476,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -5557,7 +5557,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                 { 
                     get 
                     {
@@ -5637,7 +5637,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                 { 
                     get 
                     {
@@ -5717,7 +5717,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                 { 
                     get 
                     {
@@ -5857,7 +5857,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                    public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                     { 
                         get 
                         {
@@ -5938,7 +5938,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -6078,7 +6078,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -6159,7 +6159,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.NotAffOrigClOrdID NotAffOrigClOrdID
+                public QuickFix.Fields.NotAffOrigClOrdID NotAffOrigClOrdID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP1/OrderMassCancelRequest.cs
+++ b/QuickFIXn/Message/FIX50SP1/OrderMassCancelRequest.cs
@@ -4722,7 +4722,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -4802,7 +4802,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -4975,7 +4975,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -5115,7 +5115,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -5196,7 +5196,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                 { 
                     get 
                     {
@@ -5276,7 +5276,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                 { 
                     get 
                     {
@@ -5356,7 +5356,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                 { 
                     get 
                     {
@@ -5496,7 +5496,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                    public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                     { 
                         get 
                         {
@@ -5577,7 +5577,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -5717,7 +5717,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP1/OrderMassStatusRequest.cs
+++ b/QuickFIXn/Message/FIX50SP1/OrderMassStatusRequest.cs
@@ -4565,7 +4565,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -4705,7 +4705,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -4786,7 +4786,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -4866,7 +4866,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -5039,7 +5039,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -5179,7 +5179,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -5260,7 +5260,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                 { 
                     get 
                     {
@@ -5340,7 +5340,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                 { 
                     get 
                     {
@@ -5420,7 +5420,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                 { 
                     get 
                     {
@@ -5560,7 +5560,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                    public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP1/OrderStatusRequest.cs
+++ b/QuickFIXn/Message/FIX50SP1/OrderStatusRequest.cs
@@ -2920,7 +2920,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -3060,7 +3060,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -3141,7 +3141,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3221,7 +3221,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -3394,7 +3394,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -3534,7 +3534,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -3615,7 +3615,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -5615,7 +5615,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -5695,7 +5695,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -5775,7 +5775,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -5915,7 +5915,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50SP1/PositionMaintenanceReport.cs
+++ b/QuickFIXn/Message/FIX50SP1/PositionMaintenanceReport.cs
@@ -3269,7 +3269,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -3409,7 +3409,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -3490,7 +3490,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3570,7 +3570,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -3743,7 +3743,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -3883,7 +3883,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -3964,7 +3964,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -5592,7 +5592,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -5673,7 +5673,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -7673,7 +7673,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -7753,7 +7753,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -7833,7 +7833,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -7973,7 +7973,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -8055,7 +8055,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {
@@ -8135,7 +8135,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosType PosType
+                public QuickFix.Fields.PosType PosType
                 { 
                     get 
                     {
@@ -8337,7 +8337,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -8477,7 +8477,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -8559,7 +8559,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosAmtType PosAmtType
+                public QuickFix.Fields.PosAmtType PosAmtType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP1/PositionMaintenanceRequest.cs
+++ b/QuickFIXn/Message/FIX50SP1/PositionMaintenanceRequest.cs
@@ -3172,7 +3172,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -3312,7 +3312,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -3393,7 +3393,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3473,7 +3473,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -3646,7 +3646,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -3786,7 +3786,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -3867,7 +3867,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -5495,7 +5495,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -5576,7 +5576,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -7576,7 +7576,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -7656,7 +7656,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -7736,7 +7736,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -7876,7 +7876,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -7958,7 +7958,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {
@@ -8038,7 +8038,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosType PosType
+                public QuickFix.Fields.PosType PosType
                 { 
                     get 
                     {
@@ -8240,7 +8240,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -8380,7 +8380,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -8462,7 +8462,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosAmtType PosAmtType
+                public QuickFix.Fields.PosAmtType PosAmtType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP1/PositionReport.cs
+++ b/QuickFIXn/Message/FIX50SP1/PositionReport.cs
@@ -3418,7 +3418,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -3558,7 +3558,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -3639,7 +3639,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3719,7 +3719,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -3892,7 +3892,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -4032,7 +4032,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -4113,7 +4113,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -5741,7 +5741,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -5822,7 +5822,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -7946,7 +7946,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -8026,7 +8026,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -8106,7 +8106,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -8246,7 +8246,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -8327,7 +8327,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingPayAmount UnderlyingPayAmount
+                    public QuickFix.Fields.UnderlyingPayAmount UnderlyingPayAmount
                     { 
                         get 
                         {
@@ -8470,7 +8470,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosType PosType
+                public QuickFix.Fields.PosType PosType
                 { 
                     get 
                     {
@@ -8672,7 +8672,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -8812,7 +8812,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -8894,7 +8894,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosAmtType PosAmtType
+                public QuickFix.Fields.PosAmtType PosAmtType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP1/Quote.cs
+++ b/QuickFIXn/Message/FIX50SP1/Quote.cs
@@ -5059,7 +5059,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.QuoteQualifier QuoteQualifier
+                public QuickFix.Fields.QuoteQualifier QuoteQualifier
                 { 
                     get 
                     {
@@ -5108,7 +5108,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -5248,7 +5248,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -5329,7 +5329,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -5409,7 +5409,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -5582,7 +5582,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -5722,7 +5722,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -5803,7 +5803,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -7803,7 +7803,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -7883,7 +7883,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -7963,7 +7963,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -8103,7 +8103,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -8185,7 +8185,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -8265,7 +8265,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -10451,7 +10451,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -10531,7 +10531,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegStipulationType LegStipulationType
+                    public QuickFix.Fields.LegStipulationType LegStipulationType
                     { 
                         get 
                         {
@@ -10611,7 +10611,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -10751,7 +10751,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50SP1/QuoteCancel.cs
+++ b/QuickFIXn/Message/FIX50SP1/QuoteCancel.cs
@@ -409,7 +409,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -549,7 +549,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -630,7 +630,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -3281,7 +3281,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -3361,7 +3361,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -3534,7 +3534,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                     { 
                         get 
                         {
@@ -3674,7 +3674,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                        public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                         { 
                             get 
                             {
@@ -3755,7 +3755,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                     { 
                         get 
                         {
@@ -5755,7 +5755,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                        public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                         { 
                             get 
                             {
@@ -5835,7 +5835,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                        public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                         { 
                             get 
                             {
@@ -5915,7 +5915,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                        public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                         { 
                             get 
                             {
@@ -6055,7 +6055,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                             { 
                                 get 
                                 {
@@ -6137,7 +6137,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSymbol LegSymbol
+                    public QuickFix.Fields.LegSymbol LegSymbol
                     { 
                         get 
                         {
@@ -7765,7 +7765,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                        public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50SP1/QuoteRequest.cs
+++ b/QuickFIXn/Message/FIX50SP1/QuoteRequest.cs
@@ -409,7 +409,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -4517,7 +4517,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -4597,7 +4597,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -4770,7 +4770,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                     { 
                         get 
                         {
@@ -4910,7 +4910,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                        public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                         { 
                             get 
                             {
@@ -4991,7 +4991,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                     { 
                         get 
                         {
@@ -6991,7 +6991,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                        public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                         { 
                             get 
                             {
@@ -7071,7 +7071,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                        public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                         { 
                             get 
                             {
@@ -7151,7 +7151,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                        public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                         { 
                             get 
                             {
@@ -7291,7 +7291,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                             { 
                                 get 
                                 {
@@ -7373,7 +7373,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StipulationType StipulationType
+                    public QuickFix.Fields.StipulationType StipulationType
                     { 
                         get 
                         {
@@ -7453,7 +7453,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSymbol LegSymbol
+                    public QuickFix.Fields.LegSymbol LegSymbol
                     { 
                         get 
                         {
@@ -9484,7 +9484,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                        public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                         { 
                             get 
                             {
@@ -9564,7 +9564,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegStipulationType LegStipulationType
+                        public QuickFix.Fields.LegStipulationType LegStipulationType
                         { 
                             get 
                             {
@@ -9644,7 +9644,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartyID NestedPartyID
+                        public QuickFix.Fields.NestedPartyID NestedPartyID
                         { 
                             get 
                             {
@@ -9784,7 +9784,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
                             { 
                                 get 
                                 {
@@ -9866,7 +9866,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.QuoteQualifier QuoteQualifier
+                    public QuickFix.Fields.QuoteQualifier QuoteQualifier
                     { 
                         get 
                         {
@@ -9915,7 +9915,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -10055,7 +10055,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.PartySubID PartySubID
+                        public QuickFix.Fields.PartySubID PartySubID
                         { 
                             get 
                             {
@@ -10137,7 +10137,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RootPartyID RootPartyID
+                public QuickFix.Fields.RootPartyID RootPartyID
                 { 
                     get 
                     {
@@ -10277,7 +10277,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.RootPartySubID RootPartySubID
+                    public QuickFix.Fields.RootPartySubID RootPartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP1/QuoteRequestReject.cs
+++ b/QuickFIXn/Message/FIX50SP1/QuoteRequestReject.cs
@@ -380,7 +380,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -4426,7 +4426,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -4506,7 +4506,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -4679,7 +4679,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                     { 
                         get 
                         {
@@ -4819,7 +4819,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                        public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                         { 
                             get 
                             {
@@ -4900,7 +4900,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                     { 
                         get 
                         {
@@ -6900,7 +6900,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                        public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                         { 
                             get 
                             {
@@ -6980,7 +6980,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                        public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                         { 
                             get 
                             {
@@ -7060,7 +7060,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                        public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                         { 
                             get 
                             {
@@ -7200,7 +7200,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                             { 
                                 get 
                                 {
@@ -7282,7 +7282,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StipulationType StipulationType
+                    public QuickFix.Fields.StipulationType StipulationType
                     { 
                         get 
                         {
@@ -7362,7 +7362,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSymbol LegSymbol
+                    public QuickFix.Fields.LegSymbol LegSymbol
                     { 
                         get 
                         {
@@ -9393,7 +9393,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                        public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                         { 
                             get 
                             {
@@ -9473,7 +9473,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegStipulationType LegStipulationType
+                        public QuickFix.Fields.LegStipulationType LegStipulationType
                         { 
                             get 
                             {
@@ -9553,7 +9553,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartyID NestedPartyID
+                        public QuickFix.Fields.NestedPartyID NestedPartyID
                         { 
                             get 
                             {
@@ -9693,7 +9693,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
                             { 
                                 get 
                                 {
@@ -9775,7 +9775,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.QuoteQualifier QuoteQualifier
+                    public QuickFix.Fields.QuoteQualifier QuoteQualifier
                     { 
                         get 
                         {
@@ -9824,7 +9824,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -9964,7 +9964,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.PartySubID PartySubID
+                        public QuickFix.Fields.PartySubID PartySubID
                         { 
                             get 
                             {
@@ -10046,7 +10046,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RootPartyID RootPartyID
+                public QuickFix.Fields.RootPartyID RootPartyID
                 { 
                     get 
                     {
@@ -10186,7 +10186,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.RootPartySubID RootPartySubID
+                    public QuickFix.Fields.RootPartySubID RootPartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP1/QuoteResponse.cs
+++ b/QuickFIXn/Message/FIX50SP1/QuoteResponse.cs
@@ -5092,7 +5092,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.QuoteQualifier QuoteQualifier
+                public QuickFix.Fields.QuoteQualifier QuoteQualifier
                 { 
                     get 
                     {
@@ -5141,7 +5141,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -5281,7 +5281,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -5362,7 +5362,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -5442,7 +5442,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -5615,7 +5615,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -5755,7 +5755,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -5836,7 +5836,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -7836,7 +7836,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -7916,7 +7916,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -7996,7 +7996,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -8136,7 +8136,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -8218,7 +8218,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -8298,7 +8298,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -10484,7 +10484,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -10564,7 +10564,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegStipulationType LegStipulationType
+                    public QuickFix.Fields.LegStipulationType LegStipulationType
                     { 
                         get 
                         {
@@ -10644,7 +10644,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -10784,7 +10784,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50SP1/QuoteStatusReport.cs
+++ b/QuickFIXn/Message/FIX50SP1/QuoteStatusReport.cs
@@ -5084,7 +5084,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -5224,7 +5224,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -5305,7 +5305,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -5385,7 +5385,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -5558,7 +5558,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -5698,7 +5698,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -5779,7 +5779,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -7779,7 +7779,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -7859,7 +7859,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -7939,7 +7939,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -8079,7 +8079,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -8161,7 +8161,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -8241,7 +8241,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -10086,7 +10086,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -10166,7 +10166,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegStipulationType LegStipulationType
+                    public QuickFix.Fields.LegStipulationType LegStipulationType
                     { 
                         get 
                         {
@@ -10246,7 +10246,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -10386,7 +10386,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -10468,7 +10468,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.QuoteQualifier QuoteQualifier
+                public QuickFix.Fields.QuoteQualifier QuoteQualifier
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP1/QuoteStatusRequest.cs
+++ b/QuickFIXn/Message/FIX50SP1/QuoteStatusRequest.cs
@@ -2945,7 +2945,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3025,7 +3025,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -3198,7 +3198,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -3338,7 +3338,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -3419,7 +3419,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -5419,7 +5419,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -5499,7 +5499,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -5579,7 +5579,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -5719,7 +5719,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -5801,7 +5801,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -7429,7 +7429,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -7510,7 +7510,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -7650,7 +7650,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP1/RFQRequest.cs
+++ b/QuickFIXn/Message/FIX50SP1/RFQRequest.cs
@@ -192,7 +192,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -2719,7 +2719,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -2799,7 +2799,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -2972,7 +2972,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                     { 
                         get 
                         {
@@ -3112,7 +3112,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                        public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                         { 
                             get 
                             {
@@ -3193,7 +3193,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                     { 
                         get 
                         {
@@ -5193,7 +5193,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                        public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                         { 
                             get 
                             {
@@ -5273,7 +5273,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                        public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                         { 
                             get 
                             {
@@ -5353,7 +5353,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                        public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                         { 
                             get 
                             {
@@ -5493,7 +5493,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                             { 
                                 get 
                                 {
@@ -5575,7 +5575,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSymbol LegSymbol
+                    public QuickFix.Fields.LegSymbol LegSymbol
                     { 
                         get 
                         {
@@ -7203,7 +7203,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                        public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                         { 
                             get 
                             {
@@ -7285,7 +7285,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -7425,7 +7425,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP1/RegistrationInstructions.cs
+++ b/QuickFIXn/Message/FIX50SP1/RegistrationInstructions.cs
@@ -413,7 +413,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -553,7 +553,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -634,7 +634,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RegistDtls RegistDtls
+                public QuickFix.Fields.RegistDtls RegistDtls
                 { 
                     get 
                     {
@@ -898,7 +898,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -1038,7 +1038,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -1120,7 +1120,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.DistribPaymentMethod DistribPaymentMethod
+                public QuickFix.Fields.DistribPaymentMethod DistribPaymentMethod
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP1/RegistrationInstructionsResponse.cs
+++ b/QuickFIXn/Message/FIX50SP1/RegistrationInstructionsResponse.cs
@@ -353,7 +353,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -493,7 +493,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP1/RequestForPositions.cs
+++ b/QuickFIXn/Message/FIX50SP1/RequestForPositions.cs
@@ -3019,7 +3019,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -3159,7 +3159,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -3240,7 +3240,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3320,7 +3320,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -3493,7 +3493,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -3633,7 +3633,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -3714,7 +3714,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -5342,7 +5342,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -5423,7 +5423,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -7423,7 +7423,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -7503,7 +7503,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -7583,7 +7583,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -7723,7 +7723,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -7805,7 +7805,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP1/RequestForPositionsAck.cs
+++ b/QuickFIXn/Message/FIX50SP1/RequestForPositionsAck.cs
@@ -3110,7 +3110,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -3250,7 +3250,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -3331,7 +3331,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3411,7 +3411,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -3584,7 +3584,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -3724,7 +3724,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -3805,7 +3805,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -5433,7 +5433,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -5514,7 +5514,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -7514,7 +7514,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -7594,7 +7594,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -7674,7 +7674,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -7814,7 +7814,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50SP1/SecurityDefinition.cs
+++ b/QuickFIXn/Message/FIX50SP1/SecurityDefinition.cs
@@ -3410,7 +3410,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3490,7 +3490,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -3663,7 +3663,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -3803,7 +3803,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -3884,7 +3884,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrAttribType InstrAttribType
+                public QuickFix.Fields.InstrAttribType InstrAttribType
                 { 
                     get 
                     {
@@ -3964,7 +3964,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -5964,7 +5964,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -6044,7 +6044,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -6124,7 +6124,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -6264,7 +6264,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -6346,7 +6346,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -7974,7 +7974,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -8055,7 +8055,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -8135,7 +8135,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MarketID MarketID
+                public QuickFix.Fields.MarketID MarketID
                 { 
                     get 
                     {
@@ -8802,7 +8802,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StartTickPriceRange StartTickPriceRange
+                    public QuickFix.Fields.StartTickPriceRange StartTickPriceRange
                     { 
                         get 
                         {
@@ -8944,7 +8944,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LotType LotType
+                    public QuickFix.Fields.LotType LotType
                     { 
                         get 
                         {
@@ -9024,7 +9024,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.TradingSessionID TradingSessionID
+                    public QuickFix.Fields.TradingSessionID TradingSessionID
                     { 
                         get 
                         {
@@ -9257,7 +9257,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.OrdType OrdType
+                        public QuickFix.Fields.OrdType OrdType
                         { 
                             get 
                             {
@@ -9306,7 +9306,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.TimeInForce TimeInForce
+                        public QuickFix.Fields.TimeInForce TimeInForce
                         { 
                             get 
                             {
@@ -9355,7 +9355,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ExecInstValue ExecInstValue
+                        public QuickFix.Fields.ExecInstValue ExecInstValue
                         { 
                             get 
                             {
@@ -9404,7 +9404,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.MatchAlgorithm MatchAlgorithm
+                        public QuickFix.Fields.MatchAlgorithm MatchAlgorithm
                         { 
                             get 
                             {
@@ -9484,7 +9484,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.MDFeedType MDFeedType
+                        public QuickFix.Fields.MDFeedType MDFeedType
                         { 
                             get 
                             {
@@ -9596,7 +9596,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedInstrAttribType NestedInstrAttribType
+                    public QuickFix.Fields.NestedInstrAttribType NestedInstrAttribType
                     { 
                         get 
                         {
@@ -9676,7 +9676,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StrikeRuleID StrikeRuleID
+                    public QuickFix.Fields.StrikeRuleID StrikeRuleID
                     { 
                         get 
                         {
@@ -9878,7 +9878,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.MaturityRuleID MaturityRuleID
+                        public QuickFix.Fields.MaturityRuleID MaturityRuleID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50SP1/SecurityDefinitionRequest.cs
+++ b/QuickFIXn/Message/FIX50SP1/SecurityDefinitionRequest.cs
@@ -3325,7 +3325,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3405,7 +3405,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -3578,7 +3578,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -3718,7 +3718,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -3799,7 +3799,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrAttribType InstrAttribType
+                public QuickFix.Fields.InstrAttribType InstrAttribType
                 { 
                     get 
                     {
@@ -3879,7 +3879,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -5879,7 +5879,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -5959,7 +5959,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -6039,7 +6039,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -6179,7 +6179,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -6261,7 +6261,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -7889,7 +7889,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -7970,7 +7970,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP1/SecurityDefinitionUpdateReport.cs
+++ b/QuickFIXn/Message/FIX50SP1/SecurityDefinitionUpdateReport.cs
@@ -3441,7 +3441,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3521,7 +3521,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -3694,7 +3694,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -3834,7 +3834,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -3915,7 +3915,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -5915,7 +5915,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -5995,7 +5995,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -6075,7 +6075,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -6215,7 +6215,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -6297,7 +6297,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -7925,7 +7925,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -8006,7 +8006,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrAttribType InstrAttribType
+                public QuickFix.Fields.InstrAttribType InstrAttribType
                 { 
                     get 
                     {
@@ -8086,7 +8086,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -8166,7 +8166,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MarketID MarketID
+                public QuickFix.Fields.MarketID MarketID
                 { 
                     get 
                     {
@@ -8833,7 +8833,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StartTickPriceRange StartTickPriceRange
+                    public QuickFix.Fields.StartTickPriceRange StartTickPriceRange
                     { 
                         get 
                         {
@@ -8975,7 +8975,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LotType LotType
+                    public QuickFix.Fields.LotType LotType
                     { 
                         get 
                         {
@@ -9055,7 +9055,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.TradingSessionID TradingSessionID
+                    public QuickFix.Fields.TradingSessionID TradingSessionID
                     { 
                         get 
                         {
@@ -9288,7 +9288,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.OrdType OrdType
+                        public QuickFix.Fields.OrdType OrdType
                         { 
                             get 
                             {
@@ -9337,7 +9337,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.TimeInForce TimeInForce
+                        public QuickFix.Fields.TimeInForce TimeInForce
                         { 
                             get 
                             {
@@ -9386,7 +9386,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ExecInstValue ExecInstValue
+                        public QuickFix.Fields.ExecInstValue ExecInstValue
                         { 
                             get 
                             {
@@ -9435,7 +9435,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.MatchAlgorithm MatchAlgorithm
+                        public QuickFix.Fields.MatchAlgorithm MatchAlgorithm
                         { 
                             get 
                             {
@@ -9515,7 +9515,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.MDFeedType MDFeedType
+                        public QuickFix.Fields.MDFeedType MDFeedType
                         { 
                             get 
                             {
@@ -9627,7 +9627,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedInstrAttribType NestedInstrAttribType
+                    public QuickFix.Fields.NestedInstrAttribType NestedInstrAttribType
                     { 
                         get 
                         {
@@ -9707,7 +9707,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StrikeRuleID StrikeRuleID
+                    public QuickFix.Fields.StrikeRuleID StrikeRuleID
                     { 
                         get 
                         {
@@ -9909,7 +9909,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.MaturityRuleID MaturityRuleID
+                        public QuickFix.Fields.MaturityRuleID MaturityRuleID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50SP1/SecurityList.cs
+++ b/QuickFIXn/Message/FIX50SP1/SecurityList.cs
@@ -465,7 +465,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -4387,7 +4387,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -4467,7 +4467,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -4640,7 +4640,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                     { 
                         get 
                         {
@@ -4780,7 +4780,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                        public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                         { 
                             get 
                             {
@@ -4861,7 +4861,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrAttribType InstrAttribType
+                    public QuickFix.Fields.InstrAttribType InstrAttribType
                     { 
                         get 
                         {
@@ -4941,7 +4941,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                     { 
                         get 
                         {
@@ -6941,7 +6941,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                        public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                         { 
                             get 
                             {
@@ -7021,7 +7021,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                        public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                         { 
                             get 
                             {
@@ -7101,7 +7101,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                        public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                         { 
                             get 
                             {
@@ -7241,7 +7241,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                             { 
                                 get 
                                 {
@@ -7323,7 +7323,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StipulationType StipulationType
+                    public QuickFix.Fields.StipulationType StipulationType
                     { 
                         get 
                         {
@@ -7403,7 +7403,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSymbol LegSymbol
+                    public QuickFix.Fields.LegSymbol LegSymbol
                     { 
                         get 
                         {
@@ -9279,7 +9279,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                        public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                         { 
                             get 
                             {
@@ -9359,7 +9359,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegStipulationType LegStipulationType
+                        public QuickFix.Fields.LegStipulationType LegStipulationType
                         { 
                             get 
                             {
@@ -9440,7 +9440,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StartTickPriceRange StartTickPriceRange
+                    public QuickFix.Fields.StartTickPriceRange StartTickPriceRange
                     { 
                         get 
                         {
@@ -9582,7 +9582,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LotType LotType
+                    public QuickFix.Fields.LotType LotType
                     { 
                         get 
                         {
@@ -9662,7 +9662,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.TradingSessionID TradingSessionID
+                    public QuickFix.Fields.TradingSessionID TradingSessionID
                     { 
                         get 
                         {
@@ -9895,7 +9895,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.OrdType OrdType
+                        public QuickFix.Fields.OrdType OrdType
                         { 
                             get 
                             {
@@ -9944,7 +9944,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.TimeInForce TimeInForce
+                        public QuickFix.Fields.TimeInForce TimeInForce
                         { 
                             get 
                             {
@@ -9993,7 +9993,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ExecInstValue ExecInstValue
+                        public QuickFix.Fields.ExecInstValue ExecInstValue
                         { 
                             get 
                             {
@@ -10042,7 +10042,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.MatchAlgorithm MatchAlgorithm
+                        public QuickFix.Fields.MatchAlgorithm MatchAlgorithm
                         { 
                             get 
                             {
@@ -10122,7 +10122,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.MDFeedType MDFeedType
+                        public QuickFix.Fields.MDFeedType MDFeedType
                         { 
                             get 
                             {
@@ -10234,7 +10234,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedInstrAttribType NestedInstrAttribType
+                    public QuickFix.Fields.NestedInstrAttribType NestedInstrAttribType
                     { 
                         get 
                         {
@@ -10314,7 +10314,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StrikeRuleID StrikeRuleID
+                    public QuickFix.Fields.StrikeRuleID StrikeRuleID
                     { 
                         get 
                         {
@@ -10516,7 +10516,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.MaturityRuleID MaturityRuleID
+                        public QuickFix.Fields.MaturityRuleID MaturityRuleID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50SP1/SecurityListRequest.cs
+++ b/QuickFIXn/Message/FIX50SP1/SecurityListRequest.cs
@@ -3108,7 +3108,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3188,7 +3188,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -3361,7 +3361,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -3501,7 +3501,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -3582,7 +3582,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrAttribType InstrAttribType
+                public QuickFix.Fields.InstrAttribType InstrAttribType
                 { 
                     get 
                     {
@@ -3662,7 +3662,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -5662,7 +5662,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -5742,7 +5742,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -5822,7 +5822,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -5962,7 +5962,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -6044,7 +6044,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -7672,7 +7672,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP1/SecurityListUpdateReport.cs
+++ b/QuickFIXn/Message/FIX50SP1/SecurityListUpdateReport.cs
@@ -527,7 +527,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -4480,7 +4480,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -4560,7 +4560,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -4733,7 +4733,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                     { 
                         get 
                         {
@@ -4873,7 +4873,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                        public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                         { 
                             get 
                             {
@@ -4954,7 +4954,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrAttribType InstrAttribType
+                    public QuickFix.Fields.InstrAttribType InstrAttribType
                     { 
                         get 
                         {
@@ -5034,7 +5034,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSymbol LegSymbol
+                    public QuickFix.Fields.LegSymbol LegSymbol
                     { 
                         get 
                         {
@@ -6910,7 +6910,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                        public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                         { 
                             get 
                             {
@@ -6990,7 +6990,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegStipulationType LegStipulationType
+                        public QuickFix.Fields.LegStipulationType LegStipulationType
                         { 
                             get 
                             {
@@ -7071,7 +7071,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                     { 
                         get 
                         {
@@ -9071,7 +9071,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                        public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                         { 
                             get 
                             {
@@ -9151,7 +9151,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                        public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                         { 
                             get 
                             {
@@ -9231,7 +9231,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                        public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                         { 
                             get 
                             {
@@ -9371,7 +9371,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                             { 
                                 get 
                                 {
@@ -9453,7 +9453,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StipulationType StipulationType
+                    public QuickFix.Fields.StipulationType StipulationType
                     { 
                         get 
                         {
@@ -9533,7 +9533,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StartTickPriceRange StartTickPriceRange
+                    public QuickFix.Fields.StartTickPriceRange StartTickPriceRange
                     { 
                         get 
                         {
@@ -9675,7 +9675,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LotType LotType
+                    public QuickFix.Fields.LotType LotType
                     { 
                         get 
                         {
@@ -9755,7 +9755,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.TradingSessionID TradingSessionID
+                    public QuickFix.Fields.TradingSessionID TradingSessionID
                     { 
                         get 
                         {
@@ -9988,7 +9988,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.OrdType OrdType
+                        public QuickFix.Fields.OrdType OrdType
                         { 
                             get 
                             {
@@ -10037,7 +10037,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.TimeInForce TimeInForce
+                        public QuickFix.Fields.TimeInForce TimeInForce
                         { 
                             get 
                             {
@@ -10086,7 +10086,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ExecInstValue ExecInstValue
+                        public QuickFix.Fields.ExecInstValue ExecInstValue
                         { 
                             get 
                             {
@@ -10135,7 +10135,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.MatchAlgorithm MatchAlgorithm
+                        public QuickFix.Fields.MatchAlgorithm MatchAlgorithm
                         { 
                             get 
                             {
@@ -10215,7 +10215,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.MDFeedType MDFeedType
+                        public QuickFix.Fields.MDFeedType MDFeedType
                         { 
                             get 
                             {
@@ -10327,7 +10327,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedInstrAttribType NestedInstrAttribType
+                    public QuickFix.Fields.NestedInstrAttribType NestedInstrAttribType
                     { 
                         get 
                         {
@@ -10407,7 +10407,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StrikeRuleID StrikeRuleID
+                    public QuickFix.Fields.StrikeRuleID StrikeRuleID
                     { 
                         get 
                         {
@@ -10609,7 +10609,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.MaturityRuleID MaturityRuleID
+                        public QuickFix.Fields.MaturityRuleID MaturityRuleID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50SP1/SecurityStatus.cs
+++ b/QuickFIXn/Message/FIX50SP1/SecurityStatus.cs
@@ -3441,7 +3441,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3521,7 +3521,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -3694,7 +3694,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -3834,7 +3834,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -3915,7 +3915,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrAttribType InstrAttribType
+                public QuickFix.Fields.InstrAttribType InstrAttribType
                 { 
                     get 
                     {
@@ -3995,7 +3995,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -5995,7 +5995,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -6075,7 +6075,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -6155,7 +6155,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -6295,7 +6295,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -6377,7 +6377,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -8005,7 +8005,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP1/SecurityStatusRequest.cs
+++ b/QuickFIXn/Message/FIX50SP1/SecurityStatusRequest.cs
@@ -2705,7 +2705,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -2785,7 +2785,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -2958,7 +2958,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -3098,7 +3098,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -3179,7 +3179,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrAttribType InstrAttribType
+                public QuickFix.Fields.InstrAttribType InstrAttribType
                 { 
                     get 
                     {
@@ -3259,7 +3259,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -5259,7 +5259,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -5339,7 +5339,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -5419,7 +5419,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -5559,7 +5559,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -5641,7 +5641,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -7269,7 +7269,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP1/SecurityTypeRequest.cs
+++ b/QuickFIXn/Message/FIX50SP1/SecurityTypeRequest.cs
@@ -362,7 +362,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.MarketSegmentID);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX50SP1/SecurityTypes.cs
+++ b/QuickFIXn/Message/FIX50SP1/SecurityTypes.cs
@@ -599,7 +599,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityType SecurityType
+                public QuickFix.Fields.SecurityType SecurityType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP1/SettlementInstructionRequest.cs
+++ b/QuickFIXn/Message/FIX50SP1/SettlementInstructionRequest.cs
@@ -535,7 +535,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -675,7 +675,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP1/SettlementInstructions.cs
+++ b/QuickFIXn/Message/FIX50SP1/SettlementInstructions.cs
@@ -351,7 +351,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SettlInstID SettlInstID
+                public QuickFix.Fields.SettlInstID SettlInstID
                 { 
                     get 
                     {
@@ -1173,7 +1173,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -1313,7 +1313,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.PartySubID PartySubID
+                        public QuickFix.Fields.PartySubID PartySubID
                         { 
                             get 
                             {
@@ -1394,7 +1394,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SettlInstSource SettlInstSource
+                    public QuickFix.Fields.SettlInstSource SettlInstSource
                     { 
                         get 
                         {
@@ -1503,7 +1503,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SettlPartyID SettlPartyID
+                        public QuickFix.Fields.SettlPartyID SettlPartyID
                         { 
                             get 
                             {
@@ -1643,7 +1643,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.SettlPartySubID SettlPartySubID
+                            public QuickFix.Fields.SettlPartySubID SettlPartySubID
                             { 
                                 get 
                                 {

--- a/QuickFIXn/Message/FIX50SP1/SettlementObligationReport.cs
+++ b/QuickFIXn/Message/FIX50SP1/SettlementObligationReport.cs
@@ -442,7 +442,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.NetGrossInd NetGrossInd
+                public QuickFix.Fields.NetGrossInd NetGrossInd
                 { 
                     get 
                     {
@@ -3217,7 +3217,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -3297,7 +3297,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -3470,7 +3470,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                     { 
                         get 
                         {
@@ -3610,7 +3610,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                        public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                         { 
                             get 
                             {
@@ -3691,7 +3691,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -3831,7 +3831,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.PartySubID PartySubID
+                        public QuickFix.Fields.PartySubID PartySubID
                         { 
                             get 
                             {
@@ -3912,7 +3912,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SettlObligSource SettlObligSource
+                    public QuickFix.Fields.SettlObligSource SettlObligSource
                     { 
                         get 
                         {
@@ -3990,7 +3990,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SettlPartyID SettlPartyID
+                        public QuickFix.Fields.SettlPartyID SettlPartyID
                         { 
                             get 
                             {
@@ -4130,7 +4130,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.SettlPartySubID SettlPartySubID
+                            public QuickFix.Fields.SettlPartySubID SettlPartySubID
                             { 
                                 get 
                                 {

--- a/QuickFIXn/Message/FIX50SP1/TradeCaptureReport.cs
+++ b/QuickFIXn/Message/FIX50SP1/TradeCaptureReport.cs
@@ -6022,7 +6022,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -6102,7 +6102,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -6275,7 +6275,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -6415,7 +6415,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -6496,7 +6496,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -8496,7 +8496,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -8576,7 +8576,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -8656,7 +8656,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -8796,7 +8796,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -8878,7 +8878,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosAmtType PosAmtType
+                public QuickFix.Fields.PosAmtType PosAmtType
                 { 
                     get 
                     {
@@ -8989,7 +8989,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -11299,7 +11299,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -11379,7 +11379,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegStipulationType LegStipulationType
+                    public QuickFix.Fields.LegStipulationType LegStipulationType
                     { 
                         get 
                         {
@@ -11459,7 +11459,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -11599,7 +11599,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -11680,7 +11680,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingLegSymbol UnderlyingLegSymbol
+                    public QuickFix.Fields.UnderlyingLegSymbol UnderlyingLegSymbol
                     { 
                         get 
                         {
@@ -12192,7 +12192,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingLegSecurityAltID UnderlyingLegSecurityAltID
+                        public QuickFix.Fields.UnderlyingLegSecurityAltID UnderlyingLegSecurityAltID
                         { 
                             get 
                             {
@@ -12274,7 +12274,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
+                public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
                 { 
                     get 
                     {
@@ -12478,7 +12478,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Side Side
+                public QuickFix.Fields.Side Side
                 { 
                     get 
                     {
@@ -14788,7 +14788,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -14928,7 +14928,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.PartySubID PartySubID
+                        public QuickFix.Fields.PartySubID PartySubID
                         { 
                             get 
                             {
@@ -15009,7 +15009,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ClearingInstruction ClearingInstruction
+                    public QuickFix.Fields.ClearingInstruction ClearingInstruction
                     { 
                         get 
                         {
@@ -15058,7 +15058,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ContAmtType ContAmtType
+                    public QuickFix.Fields.ContAmtType ContAmtType
                     { 
                         get 
                         {
@@ -15169,7 +15169,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StipulationType StipulationType
+                    public QuickFix.Fields.StipulationType StipulationType
                     { 
                         get 
                         {
@@ -15249,7 +15249,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
+                    public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
                     { 
                         get 
                         {
@@ -15391,7 +15391,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.AllocAccount AllocAccount
+                    public QuickFix.Fields.AllocAccount AllocAccount
                     { 
                         get 
                         {
@@ -15717,7 +15717,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested2PartyID Nested2PartyID
+                        public QuickFix.Fields.Nested2PartyID Nested2PartyID
                         { 
                             get 
                             {
@@ -15857,7 +15857,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
+                            public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
                             { 
                                 get 
                                 {
@@ -15939,7 +15939,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SideTrdRegTimestamp SideTrdRegTimestamp
+                    public QuickFix.Fields.SideTrdRegTimestamp SideTrdRegTimestamp
                     { 
                         get 
                         {
@@ -16050,7 +16050,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SettlObligSource SettlObligSource
+                    public QuickFix.Fields.SettlObligSource SettlObligSource
                     { 
                         get 
                         {
@@ -16128,7 +16128,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SettlPartyID SettlPartyID
+                        public QuickFix.Fields.SettlPartyID SettlPartyID
                         { 
                             get 
                             {
@@ -16268,7 +16268,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.SettlPartySubID SettlPartySubID
+                            public QuickFix.Fields.SettlPartySubID SettlPartySubID
                             { 
                                 get 
                                 {
@@ -16351,7 +16351,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RootPartyID RootPartyID
+                public QuickFix.Fields.RootPartyID RootPartyID
                 { 
                     get 
                     {
@@ -16491,7 +16491,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.RootPartySubID RootPartySubID
+                    public QuickFix.Fields.RootPartySubID RootPartySubID
                     { 
                         get 
                         {
@@ -16572,7 +16572,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TrdRepPartyRole TrdRepPartyRole
+                public QuickFix.Fields.TrdRepPartyRole TrdRepPartyRole
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP1/TradeCaptureReportAck.cs
+++ b/QuickFIXn/Message/FIX50SP1/TradeCaptureReportAck.cs
@@ -4867,7 +4867,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -4947,7 +4947,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -5120,7 +5120,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -5260,7 +5260,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -5341,7 +5341,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
+                public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
                 { 
                     get 
                     {
@@ -5545,7 +5545,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -7855,7 +7855,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -7935,7 +7935,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegStipulationType LegStipulationType
+                    public QuickFix.Fields.LegStipulationType LegStipulationType
                     { 
                         get 
                         {
@@ -8015,7 +8015,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -8155,7 +8155,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -8236,7 +8236,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingLegSymbol UnderlyingLegSymbol
+                    public QuickFix.Fields.UnderlyingLegSymbol UnderlyingLegSymbol
                     { 
                         get 
                         {
@@ -8748,7 +8748,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingLegSecurityAltID UnderlyingLegSecurityAltID
+                        public QuickFix.Fields.UnderlyingLegSecurityAltID UnderlyingLegSecurityAltID
                         { 
                             get 
                             {
@@ -8830,7 +8830,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosAmtType PosAmtType
+                public QuickFix.Fields.PosAmtType PosAmtType
                 { 
                     get 
                     {
@@ -8941,7 +8941,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Side Side
+                public QuickFix.Fields.Side Side
                 { 
                     get 
                     {
@@ -11096,7 +11096,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -11236,7 +11236,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.PartySubID PartySubID
+                        public QuickFix.Fields.PartySubID PartySubID
                         { 
                             get 
                             {
@@ -11317,7 +11317,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ClearingInstruction ClearingInstruction
+                    public QuickFix.Fields.ClearingInstruction ClearingInstruction
                     { 
                         get 
                         {
@@ -11366,7 +11366,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ContAmtType ContAmtType
+                    public QuickFix.Fields.ContAmtType ContAmtType
                     { 
                         get 
                         {
@@ -11477,7 +11477,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StipulationType StipulationType
+                    public QuickFix.Fields.StipulationType StipulationType
                     { 
                         get 
                         {
@@ -11557,7 +11557,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
+                    public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
                     { 
                         get 
                         {
@@ -11699,7 +11699,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.AllocAccount AllocAccount
+                    public QuickFix.Fields.AllocAccount AllocAccount
                     { 
                         get 
                         {
@@ -12025,7 +12025,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested2PartyID Nested2PartyID
+                        public QuickFix.Fields.Nested2PartyID Nested2PartyID
                         { 
                             get 
                             {
@@ -12165,7 +12165,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
+                            public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
                             { 
                                 get 
                                 {
@@ -12247,7 +12247,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SideTrdRegTimestamp SideTrdRegTimestamp
+                    public QuickFix.Fields.SideTrdRegTimestamp SideTrdRegTimestamp
                     { 
                         get 
                         {
@@ -12358,7 +12358,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SettlObligSource SettlObligSource
+                    public QuickFix.Fields.SettlObligSource SettlObligSource
                     { 
                         get 
                         {
@@ -12436,7 +12436,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SettlPartyID SettlPartyID
+                        public QuickFix.Fields.SettlPartyID SettlPartyID
                         { 
                             get 
                             {
@@ -12576,7 +12576,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.SettlPartySubID SettlPartySubID
+                            public QuickFix.Fields.SettlPartySubID SettlPartySubID
                             { 
                                 get 
                                 {
@@ -12659,7 +12659,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RootPartyID RootPartyID
+                public QuickFix.Fields.RootPartyID RootPartyID
                 { 
                     get 
                     {
@@ -12799,7 +12799,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.RootPartySubID RootPartySubID
+                    public QuickFix.Fields.RootPartySubID RootPartySubID
                     { 
                         get 
                         {
@@ -12880,7 +12880,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -14880,7 +14880,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -14960,7 +14960,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -15040,7 +15040,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -15180,7 +15180,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -15262,7 +15262,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TrdRepPartyRole TrdRepPartyRole
+                public QuickFix.Fields.TrdRepPartyRole TrdRepPartyRole
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP1/TradeCaptureReportRequest.cs
+++ b/QuickFIXn/Message/FIX50SP1/TradeCaptureReportRequest.cs
@@ -3914,7 +3914,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -4054,7 +4054,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -4135,7 +4135,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -4215,7 +4215,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -4388,7 +4388,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -4528,7 +4528,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -4609,7 +4609,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrAttribType InstrAttribType
+                public QuickFix.Fields.InstrAttribType InstrAttribType
                 { 
                     get 
                     {
@@ -4689,7 +4689,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -6689,7 +6689,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -6769,7 +6769,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -6849,7 +6849,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -6989,7 +6989,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -7071,7 +7071,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -8699,7 +8699,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -8780,7 +8780,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradeDate TradeDate
+                public QuickFix.Fields.TradeDate TradeDate
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP1/TradeCaptureReportRequestAck.cs
+++ b/QuickFIXn/Message/FIX50SP1/TradeCaptureReportRequestAck.cs
@@ -2926,7 +2926,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3006,7 +3006,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -3179,7 +3179,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -3319,7 +3319,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -3400,7 +3400,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -5400,7 +5400,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -5480,7 +5480,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -5560,7 +5560,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
+                    public QuickFix.Fields.UndlyInstrumentPartyID UndlyInstrumentPartyID
                     { 
                         get 
                         {
@@ -5700,7 +5700,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
+                        public QuickFix.Fields.UndlyInstrumentPartySubID UndlyInstrumentPartySubID
                         { 
                             get 
                             {
@@ -5782,7 +5782,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -7410,7 +7410,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP1/TradingSessionList.cs
+++ b/QuickFIXn/Message/FIX50SP1/TradingSessionList.cs
@@ -217,7 +217,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {
@@ -1008,7 +1008,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.OrdType OrdType
+                    public QuickFix.Fields.OrdType OrdType
                     { 
                         get 
                         {
@@ -1057,7 +1057,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.TimeInForce TimeInForce
+                    public QuickFix.Fields.TimeInForce TimeInForce
                     { 
                         get 
                         {
@@ -1106,7 +1106,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ExecInstValue ExecInstValue
+                    public QuickFix.Fields.ExecInstValue ExecInstValue
                     { 
                         get 
                         {
@@ -1155,7 +1155,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.MatchAlgorithm MatchAlgorithm
+                    public QuickFix.Fields.MatchAlgorithm MatchAlgorithm
                     { 
                         get 
                         {
@@ -1235,7 +1235,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.MDFeedType MDFeedType
+                    public QuickFix.Fields.MDFeedType MDFeedType
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP1/TradingSessionListRequest.cs
+++ b/QuickFIXn/Message/FIX50SP1/TradingSessionListRequest.cs
@@ -302,7 +302,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.MarketSegmentID);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX50SP1/TradingSessionListUpdateReport.cs
+++ b/QuickFIXn/Message/FIX50SP1/TradingSessionListUpdateReport.cs
@@ -248,7 +248,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {
@@ -1039,7 +1039,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.OrdType OrdType
+                    public QuickFix.Fields.OrdType OrdType
                     { 
                         get 
                         {
@@ -1088,7 +1088,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.TimeInForce TimeInForce
+                    public QuickFix.Fields.TimeInForce TimeInForce
                     { 
                         get 
                         {
@@ -1137,7 +1137,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ExecInstValue ExecInstValue
+                    public QuickFix.Fields.ExecInstValue ExecInstValue
                     { 
                         get 
                         {
@@ -1186,7 +1186,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.MatchAlgorithm MatchAlgorithm
+                    public QuickFix.Fields.MatchAlgorithm MatchAlgorithm
                     { 
                         get 
                         {
@@ -1266,7 +1266,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.MDFeedType MDFeedType
+                    public QuickFix.Fields.MDFeedType MDFeedType
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP1/TradingSessionStatus.cs
+++ b/QuickFIXn/Message/FIX50SP1/TradingSessionStatus.cs
@@ -3077,7 +3077,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3157,7 +3157,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -3330,7 +3330,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -3470,7 +3470,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP1/TradingSessionStatusRequest.cs
+++ b/QuickFIXn/Message/FIX50SP1/TradingSessionStatusRequest.cs
@@ -302,7 +302,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.MarketSegmentID);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX50SP1/UserNotification.cs
+++ b/QuickFIXn/Message/FIX50SP1/UserNotification.cs
@@ -176,7 +176,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EncodedText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX50SP1/UserRequest.cs
+++ b/QuickFIXn/Message/FIX50SP1/UserRequest.cs
@@ -397,7 +397,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EncryptedNewPassword);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX50SP1/UserResponse.cs
+++ b/QuickFIXn/Message/FIX50SP1/UserResponse.cs
@@ -147,7 +147,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.UserStatusText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX50SP2/AdjustedPositionReport.cs
+++ b/QuickFIXn/Message/FIX50SP2/AdjustedPositionReport.cs
@@ -349,7 +349,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -489,7 +489,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -570,7 +570,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosType PosType
+                public QuickFix.Fields.PosType PosType
                 { 
                     get 
                     {
@@ -772,7 +772,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -912,7 +912,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -994,7 +994,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -3738,7 +3738,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -3818,7 +3818,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -3991,7 +3991,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                     { 
                         get 
                         {
@@ -4131,7 +4131,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                        public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                         { 
                             get 
                             {
@@ -4212,7 +4212,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventType ComplexEventType
+                    public QuickFix.Fields.ComplexEventType ComplexEventType
                     { 
                         get 
                         {
@@ -4476,7 +4476,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                        public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                         { 
                             get 
                             {
@@ -4585,7 +4585,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                             { 
                                 get 
                                 {

--- a/QuickFIXn/Message/FIX50SP2/Advertisement.cs
+++ b/QuickFIXn/Message/FIX50SP2/Advertisement.cs
@@ -3360,7 +3360,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3440,7 +3440,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -3613,7 +3613,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -3753,7 +3753,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -3834,7 +3834,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -4098,7 +4098,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -4207,7 +4207,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -4289,7 +4289,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -5979,7 +5979,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -6060,7 +6060,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -8308,7 +8308,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -8388,7 +8388,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -8468,7 +8468,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -8608,7 +8608,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50SP2/AllocationInstruction.cs
+++ b/QuickFIXn/Message/FIX50SP2/AllocationInstruction.cs
@@ -5720,7 +5720,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ClOrdID ClOrdID
+                public QuickFix.Fields.ClOrdID ClOrdID
                 { 
                     get 
                     {
@@ -6015,7 +6015,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.Nested2PartyID Nested2PartyID
+                    public QuickFix.Fields.Nested2PartyID Nested2PartyID
                     { 
                         get 
                         {
@@ -6155,7 +6155,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
+                        public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
                         { 
                             get 
                             {
@@ -6237,7 +6237,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LastQty LastQty
+                public QuickFix.Fields.LastQty LastQty
                 { 
                     get 
                     {
@@ -6503,7 +6503,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -6583,7 +6583,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -6756,7 +6756,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -6896,7 +6896,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -6977,7 +6977,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -7241,7 +7241,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -7350,7 +7350,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -7432,7 +7432,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrAttribType InstrAttribType
+                public QuickFix.Fields.InstrAttribType InstrAttribType
                 { 
                     get 
                     {
@@ -7512,7 +7512,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -9760,7 +9760,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -9840,7 +9840,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -9920,7 +9920,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -10060,7 +10060,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {
@@ -10142,7 +10142,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -11832,7 +11832,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -11913,7 +11913,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -12053,7 +12053,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -12134,7 +12134,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -12214,7 +12214,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AllocAccount AllocAccount
+                public QuickFix.Fields.AllocAccount AllocAccount
                 { 
                     get 
                     {
@@ -13501,7 +13501,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -13641,7 +13641,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -13722,7 +13722,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
+                    public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
                     { 
                         get 
                         {
@@ -13864,7 +13864,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ClearingInstruction ClearingInstruction
+                    public QuickFix.Fields.ClearingInstruction ClearingInstruction
                     { 
                         get 
                         {
@@ -13913,7 +13913,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SettlInstSource SettlInstSource
+                    public QuickFix.Fields.SettlInstSource SettlInstSource
                     { 
                         get 
                         {
@@ -14022,7 +14022,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SettlPartyID SettlPartyID
+                        public QuickFix.Fields.SettlPartyID SettlPartyID
                         { 
                             get 
                             {
@@ -14162,7 +14162,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.SettlPartySubID SettlPartySubID
+                            public QuickFix.Fields.SettlPartySubID SettlPartySubID
                             { 
                                 get 
                                 {
@@ -14245,7 +14245,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosAmtType PosAmtType
+                public QuickFix.Fields.PosAmtType PosAmtType
                 { 
                     get 
                     {
@@ -14356,7 +14356,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RateSource RateSource
+                public QuickFix.Fields.RateSource RateSource
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP2/AllocationInstructionAck.cs
+++ b/QuickFIXn/Message/FIX50SP2/AllocationInstructionAck.cs
@@ -535,7 +535,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -675,7 +675,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -756,7 +756,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AllocAccount AllocAccount
+                public QuickFix.Fields.AllocAccount AllocAccount
                 { 
                     get 
                     {
@@ -1206,7 +1206,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -1346,7 +1346,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50SP2/AllocationInstructionAlert.cs
+++ b/QuickFIXn/Message/FIX50SP2/AllocationInstructionAlert.cs
@@ -5689,7 +5689,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ClOrdID ClOrdID
+                public QuickFix.Fields.ClOrdID ClOrdID
                 { 
                     get 
                     {
@@ -5984,7 +5984,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.Nested2PartyID Nested2PartyID
+                    public QuickFix.Fields.Nested2PartyID Nested2PartyID
                     { 
                         get 
                         {
@@ -6124,7 +6124,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
+                        public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
                         { 
                             get 
                             {
@@ -6206,7 +6206,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LastQty LastQty
+                public QuickFix.Fields.LastQty LastQty
                 { 
                     get 
                     {
@@ -6472,7 +6472,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -6552,7 +6552,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -6725,7 +6725,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -6865,7 +6865,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -6946,7 +6946,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -7210,7 +7210,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -7319,7 +7319,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -7401,7 +7401,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrAttribType InstrAttribType
+                public QuickFix.Fields.InstrAttribType InstrAttribType
                 { 
                     get 
                     {
@@ -7481,7 +7481,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -9729,7 +9729,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -9809,7 +9809,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -9889,7 +9889,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -10029,7 +10029,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {
@@ -10111,7 +10111,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -11801,7 +11801,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -11882,7 +11882,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -12022,7 +12022,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -12103,7 +12103,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -12183,7 +12183,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosAmtType PosAmtType
+                public QuickFix.Fields.PosAmtType PosAmtType
                 { 
                     get 
                     {
@@ -12294,7 +12294,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AllocAccount AllocAccount
+                public QuickFix.Fields.AllocAccount AllocAccount
                 { 
                     get 
                     {
@@ -13581,7 +13581,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -13721,7 +13721,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -13802,7 +13802,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
+                    public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
                     { 
                         get 
                         {
@@ -13944,7 +13944,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ClearingInstruction ClearingInstruction
+                    public QuickFix.Fields.ClearingInstruction ClearingInstruction
                     { 
                         get 
                         {
@@ -13993,7 +13993,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SettlInstSource SettlInstSource
+                    public QuickFix.Fields.SettlInstSource SettlInstSource
                     { 
                         get 
                         {
@@ -14102,7 +14102,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SettlPartyID SettlPartyID
+                        public QuickFix.Fields.SettlPartyID SettlPartyID
                         { 
                             get 
                             {
@@ -14242,7 +14242,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.SettlPartySubID SettlPartySubID
+                            public QuickFix.Fields.SettlPartySubID SettlPartySubID
                             { 
                                 get 
                                 {

--- a/QuickFIXn/Message/FIX50SP2/AllocationReport.cs
+++ b/QuickFIXn/Message/FIX50SP2/AllocationReport.cs
@@ -5879,7 +5879,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ClOrdID ClOrdID
+                public QuickFix.Fields.ClOrdID ClOrdID
                 { 
                     get 
                     {
@@ -6174,7 +6174,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.Nested2PartyID Nested2PartyID
+                    public QuickFix.Fields.Nested2PartyID Nested2PartyID
                     { 
                         get 
                         {
@@ -6314,7 +6314,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
+                        public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
                         { 
                             get 
                             {
@@ -6396,7 +6396,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LastQty LastQty
+                public QuickFix.Fields.LastQty LastQty
                 { 
                     get 
                     {
@@ -6662,7 +6662,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -6742,7 +6742,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -6915,7 +6915,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -7055,7 +7055,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -7136,7 +7136,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -7400,7 +7400,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -7509,7 +7509,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -7591,7 +7591,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrAttribType InstrAttribType
+                public QuickFix.Fields.InstrAttribType InstrAttribType
                 { 
                     get 
                     {
@@ -7671,7 +7671,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -9919,7 +9919,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -9999,7 +9999,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -10079,7 +10079,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -10219,7 +10219,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {
@@ -10301,7 +10301,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -11991,7 +11991,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -12072,7 +12072,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -12212,7 +12212,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -12293,7 +12293,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -12373,7 +12373,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AllocAccount AllocAccount
+                public QuickFix.Fields.AllocAccount AllocAccount
                 { 
                     get 
                     {
@@ -13660,7 +13660,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -13800,7 +13800,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -13881,7 +13881,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
+                    public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
                     { 
                         get 
                         {
@@ -14023,7 +14023,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ClearingInstruction ClearingInstruction
+                    public QuickFix.Fields.ClearingInstruction ClearingInstruction
                     { 
                         get 
                         {
@@ -14072,7 +14072,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SettlInstSource SettlInstSource
+                    public QuickFix.Fields.SettlInstSource SettlInstSource
                     { 
                         get 
                         {
@@ -14181,7 +14181,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SettlPartyID SettlPartyID
+                        public QuickFix.Fields.SettlPartyID SettlPartyID
                         { 
                             get 
                             {
@@ -14321,7 +14321,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.SettlPartySubID SettlPartySubID
+                            public QuickFix.Fields.SettlPartySubID SettlPartySubID
                             { 
                                 get 
                                 {
@@ -14404,7 +14404,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosAmtType PosAmtType
+                public QuickFix.Fields.PosAmtType PosAmtType
                 { 
                     get 
                     {
@@ -14515,7 +14515,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RateSource RateSource
+                public QuickFix.Fields.RateSource RateSource
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP2/AllocationReportAck.cs
+++ b/QuickFIXn/Message/FIX50SP2/AllocationReportAck.cs
@@ -688,7 +688,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -828,7 +828,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -909,7 +909,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AllocAccount AllocAccount
+                public QuickFix.Fields.AllocAccount AllocAccount
                 { 
                     get 
                     {
@@ -1359,7 +1359,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -1499,7 +1499,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50SP2/ApplicationMessageReport.cs
+++ b/QuickFIXn/Message/FIX50SP2/ApplicationMessageReport.cs
@@ -256,7 +256,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RefApplID RefApplID
+                public QuickFix.Fields.RefApplID RefApplID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP2/ApplicationMessageRequest.cs
+++ b/QuickFIXn/Message/FIX50SP2/ApplicationMessageRequest.cs
@@ -256,7 +256,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RefApplID RefApplID
+                public QuickFix.Fields.RefApplID RefApplID
                 { 
                     get 
                     {
@@ -427,7 +427,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -567,7 +567,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -649,7 +649,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -789,7 +789,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP2/ApplicationMessageRequestAck.cs
+++ b/QuickFIXn/Message/FIX50SP2/ApplicationMessageRequestAck.cs
@@ -347,7 +347,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RefApplID RefApplID
+                public QuickFix.Fields.RefApplID RefApplID
                 { 
                     get 
                     {
@@ -580,7 +580,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -720,7 +720,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -802,7 +802,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -942,7 +942,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP2/AssignmentReport.cs
+++ b/QuickFIXn/Message/FIX50SP2/AssignmentReport.cs
@@ -3759,7 +3759,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -3899,7 +3899,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -3980,7 +3980,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -4060,7 +4060,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -4233,7 +4233,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -4373,7 +4373,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -4454,7 +4454,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -4718,7 +4718,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -4827,7 +4827,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -4909,7 +4909,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -6599,7 +6599,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -6680,7 +6680,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -8928,7 +8928,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -9008,7 +9008,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -9088,7 +9088,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -9228,7 +9228,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {
@@ -9310,7 +9310,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosType PosType
+                public QuickFix.Fields.PosType PosType
                 { 
                     get 
                     {
@@ -9512,7 +9512,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -9652,7 +9652,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -9734,7 +9734,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosAmtType PosAmtType
+                public QuickFix.Fields.PosAmtType PosAmtType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP2/BidRequest.cs
+++ b/QuickFIXn/Message/FIX50SP2/BidRequest.cs
@@ -946,7 +946,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.BidDescriptorType BidDescriptorType
+                public QuickFix.Fields.BidDescriptorType BidDescriptorType
                 { 
                     get 
                     {
@@ -1305,7 +1305,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ListID ListID
+                public QuickFix.Fields.ListID ListID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP2/BidResponse.cs
+++ b/QuickFIXn/Message/FIX50SP2/BidResponse.cs
@@ -124,7 +124,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Commission Commission
+                public QuickFix.Fields.Commission Commission
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP2/BusinessMessageReject.cs
+++ b/QuickFIXn/Message/FIX50SP2/BusinessMessageReject.cs
@@ -333,7 +333,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.RefCstmApplVerID);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX50SP2/CollateralAssignment.cs
+++ b/QuickFIXn/Message/FIX50SP2/CollateralAssignment.cs
@@ -4786,7 +4786,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -4926,7 +4926,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -5007,7 +5007,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ExecID ExecID
+                public QuickFix.Fields.ExecID ExecID
                 { 
                     get 
                     {
@@ -5056,7 +5056,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradeReportID TradeReportID
+                public QuickFix.Fields.TradeReportID TradeReportID
                 { 
                     get 
                     {
@@ -5136,7 +5136,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -5216,7 +5216,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -5389,7 +5389,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -5529,7 +5529,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -5610,7 +5610,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -5874,7 +5874,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -5983,7 +5983,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -6065,7 +6065,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -7755,7 +7755,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -7836,7 +7836,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -10115,7 +10115,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -10195,7 +10195,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -10275,7 +10275,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -10415,7 +10415,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {
@@ -10497,7 +10497,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
+                public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
                 { 
                     get 
                     {
@@ -10701,7 +10701,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
+                public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
                 { 
                     get 
                     {
@@ -10843,7 +10843,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -10923,7 +10923,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SettlInstSource SettlInstSource
+                public QuickFix.Fields.SettlInstSource SettlInstSource
                 { 
                     get 
                     {
@@ -11032,7 +11032,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SettlPartyID SettlPartyID
+                    public QuickFix.Fields.SettlPartyID SettlPartyID
                     { 
                         get 
                         {
@@ -11172,7 +11172,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SettlPartySubID SettlPartySubID
+                        public QuickFix.Fields.SettlPartySubID SettlPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50SP2/CollateralInquiry.cs
+++ b/QuickFIXn/Message/FIX50SP2/CollateralInquiry.cs
@@ -4687,7 +4687,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.CollInquiryQualifier CollInquiryQualifier
+                public QuickFix.Fields.CollInquiryQualifier CollInquiryQualifier
                 { 
                     get 
                     {
@@ -4736,7 +4736,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -4876,7 +4876,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -4957,7 +4957,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ExecID ExecID
+                public QuickFix.Fields.ExecID ExecID
                 { 
                     get 
                     {
@@ -5006,7 +5006,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradeReportID TradeReportID
+                public QuickFix.Fields.TradeReportID TradeReportID
                 { 
                     get 
                     {
@@ -5086,7 +5086,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -5166,7 +5166,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -5339,7 +5339,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -5479,7 +5479,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -5560,7 +5560,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -5824,7 +5824,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -5933,7 +5933,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -6015,7 +6015,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -7705,7 +7705,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -7786,7 +7786,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -10034,7 +10034,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -10114,7 +10114,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -10194,7 +10194,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -10334,7 +10334,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {
@@ -10416,7 +10416,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
+                public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
                 { 
                     get 
                     {
@@ -10620,7 +10620,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -10700,7 +10700,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SettlInstSource SettlInstSource
+                public QuickFix.Fields.SettlInstSource SettlInstSource
                 { 
                     get 
                     {
@@ -10809,7 +10809,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SettlPartyID SettlPartyID
+                    public QuickFix.Fields.SettlPartyID SettlPartyID
                     { 
                         get 
                         {
@@ -10949,7 +10949,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SettlPartySubID SettlPartySubID
+                        public QuickFix.Fields.SettlPartySubID SettlPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50SP2/CollateralInquiryAck.cs
+++ b/QuickFIXn/Message/FIX50SP2/CollateralInquiryAck.cs
@@ -3976,7 +3976,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.CollInquiryQualifier CollInquiryQualifier
+                public QuickFix.Fields.CollInquiryQualifier CollInquiryQualifier
                 { 
                     get 
                     {
@@ -4025,7 +4025,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -4165,7 +4165,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -4246,7 +4246,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ExecID ExecID
+                public QuickFix.Fields.ExecID ExecID
                 { 
                     get 
                     {
@@ -4295,7 +4295,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradeReportID TradeReportID
+                public QuickFix.Fields.TradeReportID TradeReportID
                 { 
                     get 
                     {
@@ -4375,7 +4375,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -4455,7 +4455,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -4628,7 +4628,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -4768,7 +4768,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -4849,7 +4849,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -5113,7 +5113,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -5222,7 +5222,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -5304,7 +5304,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -6994,7 +6994,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -7075,7 +7075,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -9323,7 +9323,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -9403,7 +9403,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -9483,7 +9483,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -9623,7 +9623,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50SP2/CollateralReport.cs
+++ b/QuickFIXn/Message/FIX50SP2/CollateralReport.cs
@@ -4813,7 +4813,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -4953,7 +4953,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -5034,7 +5034,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ExecID ExecID
+                public QuickFix.Fields.ExecID ExecID
                 { 
                     get 
                     {
@@ -5083,7 +5083,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradeReportID TradeReportID
+                public QuickFix.Fields.TradeReportID TradeReportID
                 { 
                     get 
                     {
@@ -5163,7 +5163,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -5243,7 +5243,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -5416,7 +5416,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -5556,7 +5556,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -5637,7 +5637,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -5901,7 +5901,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -6010,7 +6010,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -6092,7 +6092,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -7782,7 +7782,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -7863,7 +7863,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -10111,7 +10111,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -10191,7 +10191,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -10271,7 +10271,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -10411,7 +10411,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {
@@ -10493,7 +10493,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
+                public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
                 { 
                     get 
                     {
@@ -10697,7 +10697,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
+                public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
                 { 
                     get 
                     {
@@ -10839,7 +10839,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -10919,7 +10919,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SettlInstSource SettlInstSource
+                public QuickFix.Fields.SettlInstSource SettlInstSource
                 { 
                     get 
                     {
@@ -11028,7 +11028,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SettlPartyID SettlPartyID
+                    public QuickFix.Fields.SettlPartyID SettlPartyID
                     { 
                         get 
                         {
@@ -11168,7 +11168,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SettlPartySubID SettlPartySubID
+                        public QuickFix.Fields.SettlPartySubID SettlPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50SP2/CollateralRequest.cs
+++ b/QuickFIXn/Message/FIX50SP2/CollateralRequest.cs
@@ -4536,7 +4536,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -4676,7 +4676,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -4757,7 +4757,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ExecID ExecID
+                public QuickFix.Fields.ExecID ExecID
                 { 
                     get 
                     {
@@ -4806,7 +4806,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradeReportID TradeReportID
+                public QuickFix.Fields.TradeReportID TradeReportID
                 { 
                     get 
                     {
@@ -4886,7 +4886,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -4966,7 +4966,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -5139,7 +5139,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -5279,7 +5279,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -5360,7 +5360,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -5624,7 +5624,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -5733,7 +5733,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -5815,7 +5815,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -7505,7 +7505,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -7586,7 +7586,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -9865,7 +9865,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -9945,7 +9945,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -10025,7 +10025,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -10165,7 +10165,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {
@@ -10247,7 +10247,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
+                public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
                 { 
                     get 
                     {
@@ -10451,7 +10451,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
+                public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
                 { 
                     get 
                     {
@@ -10593,7 +10593,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP2/CollateralResponse.cs
+++ b/QuickFIXn/Message/FIX50SP2/CollateralResponse.cs
@@ -4598,7 +4598,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -4738,7 +4738,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -4819,7 +4819,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ExecID ExecID
+                public QuickFix.Fields.ExecID ExecID
                 { 
                     get 
                     {
@@ -4868,7 +4868,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradeReportID TradeReportID
+                public QuickFix.Fields.TradeReportID TradeReportID
                 { 
                     get 
                     {
@@ -4948,7 +4948,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -5028,7 +5028,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -5201,7 +5201,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -5341,7 +5341,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -5422,7 +5422,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -5686,7 +5686,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -5795,7 +5795,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -5877,7 +5877,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -7567,7 +7567,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -7648,7 +7648,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -9927,7 +9927,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -10007,7 +10007,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -10087,7 +10087,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -10227,7 +10227,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {
@@ -10309,7 +10309,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
+                public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
                 { 
                     get 
                     {
@@ -10513,7 +10513,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
+                public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
                 { 
                     get 
                     {
@@ -10655,7 +10655,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP2/Confirmation.cs
+++ b/QuickFIXn/Message/FIX50SP2/Confirmation.cs
@@ -5670,7 +5670,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -5810,7 +5810,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -5891,7 +5891,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ClOrdID ClOrdID
+                public QuickFix.Fields.ClOrdID ClOrdID
                 { 
                     get 
                     {
@@ -6186,7 +6186,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.Nested2PartyID Nested2PartyID
+                    public QuickFix.Fields.Nested2PartyID Nested2PartyID
                     { 
                         get 
                         {
@@ -6326,7 +6326,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
+                        public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
                         { 
                             get 
                             {
@@ -6408,7 +6408,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
+                public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
                 { 
                     get 
                     {
@@ -6612,7 +6612,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -6692,7 +6692,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -6865,7 +6865,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -7005,7 +7005,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -7086,7 +7086,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -7350,7 +7350,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -7459,7 +7459,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -7541,7 +7541,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrAttribType InstrAttribType
+                public QuickFix.Fields.InstrAttribType InstrAttribType
                 { 
                     get 
                     {
@@ -7621,7 +7621,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -9869,7 +9869,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -9949,7 +9949,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -10029,7 +10029,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -10169,7 +10169,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {
@@ -10251,7 +10251,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -11941,7 +11941,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -12022,7 +12022,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.OrderCapacity OrderCapacity
+                public QuickFix.Fields.OrderCapacity OrderCapacity
                 { 
                     get 
                     {
@@ -12133,7 +12133,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SettlInstSource SettlInstSource
+                public QuickFix.Fields.SettlInstSource SettlInstSource
                 { 
                     get 
                     {
@@ -12242,7 +12242,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SettlPartyID SettlPartyID
+                    public QuickFix.Fields.SettlPartyID SettlPartyID
                     { 
                         get 
                         {
@@ -12382,7 +12382,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SettlPartySubID SettlPartySubID
+                        public QuickFix.Fields.SettlPartySubID SettlPartySubID
                         { 
                             get 
                             {
@@ -12464,7 +12464,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -12544,7 +12544,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
+                public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP2/ConfirmationAck.cs
+++ b/QuickFIXn/Message/FIX50SP2/ConfirmationAck.cs
@@ -306,7 +306,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EncodedText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX50SP2/ConfirmationRequest.cs
+++ b/QuickFIXn/Message/FIX50SP2/ConfirmationRequest.cs
@@ -444,7 +444,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ClOrdID ClOrdID
+                public QuickFix.Fields.ClOrdID ClOrdID
                 { 
                     get 
                     {
@@ -739,7 +739,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.Nested2PartyID Nested2PartyID
+                    public QuickFix.Fields.Nested2PartyID Nested2PartyID
                     { 
                         get 
                         {
@@ -879,7 +879,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
+                        public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50SP2/ContraryIntentionReport.cs
+++ b/QuickFIXn/Message/FIX50SP2/ContraryIntentionReport.cs
@@ -3232,7 +3232,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -3372,7 +3372,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -3453,7 +3453,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ExpirationQtyType ExpirationQtyType
+                public QuickFix.Fields.ExpirationQtyType ExpirationQtyType
                 { 
                     get 
                     {
@@ -3533,7 +3533,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3613,7 +3613,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -3786,7 +3786,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -3926,7 +3926,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -4007,7 +4007,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -4271,7 +4271,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -4380,7 +4380,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -4462,7 +4462,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -6710,7 +6710,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -6790,7 +6790,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -6870,7 +6870,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -7010,7 +7010,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50SP2/CrossOrderCancelReplaceRequest.cs
+++ b/QuickFIXn/Message/FIX50SP2/CrossOrderCancelReplaceRequest.cs
@@ -6030,7 +6030,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Side Side
+                public QuickFix.Fields.Side Side
                 { 
                     get 
                     {
@@ -7379,7 +7379,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -7519,7 +7519,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.PartySubID PartySubID
+                        public QuickFix.Fields.PartySubID PartySubID
                         { 
                             get 
                             {
@@ -7600,7 +7600,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.AllocAccount AllocAccount
+                    public QuickFix.Fields.AllocAccount AllocAccount
                     { 
                         get 
                         {
@@ -7802,7 +7802,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartyID NestedPartyID
+                        public QuickFix.Fields.NestedPartyID NestedPartyID
                         { 
                             get 
                             {
@@ -7942,7 +7942,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
                             { 
                                 get 
                                 {
@@ -8025,7 +8025,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -8105,7 +8105,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -8278,7 +8278,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -8418,7 +8418,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -8499,7 +8499,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -8763,7 +8763,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -8872,7 +8872,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -8954,7 +8954,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -11202,7 +11202,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -11282,7 +11282,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -11362,7 +11362,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -11502,7 +11502,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {
@@ -11584,7 +11584,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -13274,7 +13274,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -13355,7 +13355,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {
@@ -13435,7 +13435,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -13515,7 +13515,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StrategyParameterName StrategyParameterName
+                public QuickFix.Fields.StrategyParameterName StrategyParameterName
                 { 
                     get 
                     {
@@ -13626,7 +13626,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RootPartyID RootPartyID
+                public QuickFix.Fields.RootPartyID RootPartyID
                 { 
                     get 
                     {
@@ -13766,7 +13766,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.RootPartySubID RootPartySubID
+                    public QuickFix.Fields.RootPartySubID RootPartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP2/CrossOrderCancelRequest.cs
+++ b/QuickFIXn/Message/FIX50SP2/CrossOrderCancelRequest.cs
@@ -3114,7 +3114,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Side Side
+                public QuickFix.Fields.Side Side
                 { 
                     get 
                     {
@@ -3688,7 +3688,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -3828,7 +3828,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.PartySubID PartySubID
+                        public QuickFix.Fields.PartySubID PartySubID
                         { 
                             get 
                             {
@@ -3910,7 +3910,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3990,7 +3990,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -4163,7 +4163,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -4303,7 +4303,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -4384,7 +4384,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -4648,7 +4648,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -4757,7 +4757,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -4839,7 +4839,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -7087,7 +7087,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -7167,7 +7167,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -7247,7 +7247,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -7387,7 +7387,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {
@@ -7469,7 +7469,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -9159,7 +9159,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -9240,7 +9240,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RootPartyID RootPartyID
+                public QuickFix.Fields.RootPartyID RootPartyID
                 { 
                     get 
                     {
@@ -9380,7 +9380,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.RootPartySubID RootPartySubID
+                    public QuickFix.Fields.RootPartySubID RootPartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP2/DerivativeSecurityList.cs
+++ b/QuickFIXn/Message/FIX50SP2/DerivativeSecurityList.cs
@@ -4650,7 +4650,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                 { 
                     get 
                     {
@@ -4730,7 +4730,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                 { 
                     get 
                     {
@@ -4810,7 +4810,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                 { 
                     get 
                     {
@@ -4950,7 +4950,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                    public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                     { 
                         get 
                         {
@@ -5031,7 +5031,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -8209,7 +8209,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -8289,7 +8289,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -8462,7 +8462,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                     { 
                         get 
                         {
@@ -8602,7 +8602,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                        public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                         { 
                             get 
                             {
@@ -8683,7 +8683,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventType ComplexEventType
+                    public QuickFix.Fields.ComplexEventType ComplexEventType
                     { 
                         get 
                         {
@@ -8947,7 +8947,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                        public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                         { 
                             get 
                             {
@@ -9056,7 +9056,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                             { 
                                 get 
                                 {
@@ -9138,7 +9138,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrAttribType InstrAttribType
+                    public QuickFix.Fields.InstrAttribType InstrAttribType
                     { 
                         get 
                         {
@@ -9218,7 +9218,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSymbol LegSymbol
+                    public QuickFix.Fields.LegSymbol LegSymbol
                     { 
                         get 
                         {
@@ -10908,7 +10908,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                        public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                         { 
                             get 
                             {
@@ -10990,7 +10990,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.DerivativeSecurityAltID DerivativeSecurityAltID
+                public QuickFix.Fields.DerivativeSecurityAltID DerivativeSecurityAltID
                 { 
                     get 
                     {
@@ -11070,7 +11070,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.DerivativeEventType DerivativeEventType
+                public QuickFix.Fields.DerivativeEventType DerivativeEventType
                 { 
                     get 
                     {
@@ -11243,7 +11243,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.DerivativeInstrumentPartyID DerivativeInstrumentPartyID
+                public QuickFix.Fields.DerivativeInstrumentPartyID DerivativeInstrumentPartyID
                 { 
                     get 
                     {
@@ -11383,7 +11383,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.DerivativeInstrumentPartySubID DerivativeInstrumentPartySubID
+                    public QuickFix.Fields.DerivativeInstrumentPartySubID DerivativeInstrumentPartySubID
                     { 
                         get 
                         {
@@ -11464,7 +11464,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.DerivativeInstrAttribType DerivativeInstrAttribType
+                public QuickFix.Fields.DerivativeInstrAttribType DerivativeInstrAttribType
                 { 
                     get 
                     {
@@ -11544,7 +11544,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MarketID MarketID
+                public QuickFix.Fields.MarketID MarketID
                 { 
                     get 
                     {
@@ -12211,7 +12211,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StartTickPriceRange StartTickPriceRange
+                    public QuickFix.Fields.StartTickPriceRange StartTickPriceRange
                     { 
                         get 
                         {
@@ -12353,7 +12353,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LotType LotType
+                    public QuickFix.Fields.LotType LotType
                     { 
                         get 
                         {
@@ -12433,7 +12433,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.TradingSessionID TradingSessionID
+                    public QuickFix.Fields.TradingSessionID TradingSessionID
                     { 
                         get 
                         {
@@ -12666,7 +12666,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.OrdType OrdType
+                        public QuickFix.Fields.OrdType OrdType
                         { 
                             get 
                             {
@@ -12715,7 +12715,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.TimeInForce TimeInForce
+                        public QuickFix.Fields.TimeInForce TimeInForce
                         { 
                             get 
                             {
@@ -12764,7 +12764,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ExecInstValue ExecInstValue
+                        public QuickFix.Fields.ExecInstValue ExecInstValue
                         { 
                             get 
                             {
@@ -12813,7 +12813,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.MatchAlgorithm MatchAlgorithm
+                        public QuickFix.Fields.MatchAlgorithm MatchAlgorithm
                         { 
                             get 
                             {
@@ -12893,7 +12893,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.MDFeedType MDFeedType
+                        public QuickFix.Fields.MDFeedType MDFeedType
                         { 
                             get 
                             {
@@ -13005,7 +13005,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedInstrAttribType NestedInstrAttribType
+                    public QuickFix.Fields.NestedInstrAttribType NestedInstrAttribType
                     { 
                         get 
                         {
@@ -13085,7 +13085,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StrikeRuleID StrikeRuleID
+                    public QuickFix.Fields.StrikeRuleID StrikeRuleID
                     { 
                         get 
                         {
@@ -13287,7 +13287,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.MaturityRuleID MaturityRuleID
+                        public QuickFix.Fields.MaturityRuleID MaturityRuleID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50SP2/DerivativeSecurityListRequest.cs
+++ b/QuickFIXn/Message/FIX50SP2/DerivativeSecurityListRequest.cs
@@ -4565,7 +4565,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                 { 
                     get 
                     {
@@ -4645,7 +4645,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                 { 
                     get 
                     {
@@ -4725,7 +4725,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                 { 
                     get 
                     {
@@ -4865,7 +4865,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                    public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                     { 
                         get 
                         {
@@ -4946,7 +4946,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.DerivativeSecurityAltID DerivativeSecurityAltID
+                public QuickFix.Fields.DerivativeSecurityAltID DerivativeSecurityAltID
                 { 
                     get 
                     {
@@ -5026,7 +5026,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.DerivativeEventType DerivativeEventType
+                public QuickFix.Fields.DerivativeEventType DerivativeEventType
                 { 
                     get 
                     {
@@ -5199,7 +5199,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.DerivativeInstrumentPartyID DerivativeInstrumentPartyID
+                public QuickFix.Fields.DerivativeInstrumentPartyID DerivativeInstrumentPartyID
                 { 
                     get 
                     {
@@ -5339,7 +5339,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.DerivativeInstrumentPartySubID DerivativeInstrumentPartySubID
+                    public QuickFix.Fields.DerivativeInstrumentPartySubID DerivativeInstrumentPartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP2/DerivativeSecurityListUpdateReport.cs
+++ b/QuickFIXn/Message/FIX50SP2/DerivativeSecurityListUpdateReport.cs
@@ -4619,7 +4619,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                 { 
                     get 
                     {
@@ -4699,7 +4699,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                 { 
                     get 
                     {
@@ -4779,7 +4779,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                 { 
                     get 
                     {
@@ -4919,7 +4919,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                    public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                     { 
                         get 
                         {
@@ -5000,7 +5000,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.DerivativeSecurityAltID DerivativeSecurityAltID
+                public QuickFix.Fields.DerivativeSecurityAltID DerivativeSecurityAltID
                 { 
                     get 
                     {
@@ -5080,7 +5080,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.DerivativeEventType DerivativeEventType
+                public QuickFix.Fields.DerivativeEventType DerivativeEventType
                 { 
                     get 
                     {
@@ -5253,7 +5253,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.DerivativeInstrumentPartyID DerivativeInstrumentPartyID
+                public QuickFix.Fields.DerivativeInstrumentPartyID DerivativeInstrumentPartyID
                 { 
                     get 
                     {
@@ -5393,7 +5393,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.DerivativeInstrumentPartySubID DerivativeInstrumentPartySubID
+                    public QuickFix.Fields.DerivativeInstrumentPartySubID DerivativeInstrumentPartySubID
                     { 
                         get 
                         {
@@ -5474,7 +5474,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.DerivativeInstrAttribType DerivativeInstrAttribType
+                public QuickFix.Fields.DerivativeInstrAttribType DerivativeInstrAttribType
                 { 
                     get 
                     {
@@ -5554,7 +5554,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MarketID MarketID
+                public QuickFix.Fields.MarketID MarketID
                 { 
                     get 
                     {
@@ -6221,7 +6221,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StartTickPriceRange StartTickPriceRange
+                    public QuickFix.Fields.StartTickPriceRange StartTickPriceRange
                     { 
                         get 
                         {
@@ -6363,7 +6363,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LotType LotType
+                    public QuickFix.Fields.LotType LotType
                     { 
                         get 
                         {
@@ -6443,7 +6443,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.TradingSessionID TradingSessionID
+                    public QuickFix.Fields.TradingSessionID TradingSessionID
                     { 
                         get 
                         {
@@ -6676,7 +6676,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.OrdType OrdType
+                        public QuickFix.Fields.OrdType OrdType
                         { 
                             get 
                             {
@@ -6725,7 +6725,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.TimeInForce TimeInForce
+                        public QuickFix.Fields.TimeInForce TimeInForce
                         { 
                             get 
                             {
@@ -6774,7 +6774,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ExecInstValue ExecInstValue
+                        public QuickFix.Fields.ExecInstValue ExecInstValue
                         { 
                             get 
                             {
@@ -6823,7 +6823,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.MatchAlgorithm MatchAlgorithm
+                        public QuickFix.Fields.MatchAlgorithm MatchAlgorithm
                         { 
                             get 
                             {
@@ -6903,7 +6903,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.MDFeedType MDFeedType
+                        public QuickFix.Fields.MDFeedType MDFeedType
                         { 
                             get 
                             {
@@ -7015,7 +7015,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedInstrAttribType NestedInstrAttribType
+                    public QuickFix.Fields.NestedInstrAttribType NestedInstrAttribType
                     { 
                         get 
                         {
@@ -7095,7 +7095,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StrikeRuleID StrikeRuleID
+                    public QuickFix.Fields.StrikeRuleID StrikeRuleID
                     { 
                         get 
                         {
@@ -7297,7 +7297,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.MaturityRuleID MaturityRuleID
+                        public QuickFix.Fields.MaturityRuleID MaturityRuleID
                         { 
                             get 
                             {
@@ -7503,7 +7503,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ListUpdateAction ListUpdateAction
+                public QuickFix.Fields.ListUpdateAction ListUpdateAction
                 { 
                     get 
                     {
@@ -10712,7 +10712,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -10792,7 +10792,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -10965,7 +10965,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                     { 
                         get 
                         {
@@ -11105,7 +11105,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                        public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                         { 
                             get 
                             {
@@ -11186,7 +11186,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventType ComplexEventType
+                    public QuickFix.Fields.ComplexEventType ComplexEventType
                     { 
                         get 
                         {
@@ -11450,7 +11450,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                        public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                         { 
                             get 
                             {
@@ -11559,7 +11559,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                             { 
                                 get 
                                 {
@@ -11641,7 +11641,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrAttribType InstrAttribType
+                    public QuickFix.Fields.InstrAttribType InstrAttribType
                     { 
                         get 
                         {
@@ -11721,7 +11721,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSymbol LegSymbol
+                    public QuickFix.Fields.LegSymbol LegSymbol
                     { 
                         get 
                         {
@@ -13411,7 +13411,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                        public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50SP2/DontKnowTrade.cs
+++ b/QuickFIXn/Message/FIX50SP2/DontKnowTrade.cs
@@ -3298,7 +3298,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3378,7 +3378,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -3551,7 +3551,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -3691,7 +3691,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -3772,7 +3772,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -4036,7 +4036,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -4145,7 +4145,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -4227,7 +4227,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -6475,7 +6475,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -6555,7 +6555,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -6635,7 +6635,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -6775,7 +6775,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {
@@ -6857,7 +6857,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -8547,7 +8547,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP2/Email.cs
+++ b/QuickFIXn/Message/FIX50SP2/Email.cs
@@ -506,7 +506,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RoutingType RoutingType
+                public QuickFix.Fields.RoutingType RoutingType
                 { 
                     get 
                     {
@@ -586,7 +586,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -3330,7 +3330,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -3410,7 +3410,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -3583,7 +3583,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                     { 
                         get 
                         {
@@ -3723,7 +3723,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                        public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                         { 
                             get 
                             {
@@ -3804,7 +3804,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventType ComplexEventType
+                    public QuickFix.Fields.ComplexEventType ComplexEventType
                     { 
                         get 
                         {
@@ -4068,7 +4068,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                        public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                         { 
                             get 
                             {
@@ -4177,7 +4177,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                             { 
                                 get 
                                 {
@@ -4260,7 +4260,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -6508,7 +6508,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -6588,7 +6588,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -6668,7 +6668,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -6808,7 +6808,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {
@@ -6890,7 +6890,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -8580,7 +8580,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -8661,7 +8661,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Text Text
+                public QuickFix.Fields.Text Text
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP2/ExecutionAcknowledgement.cs
+++ b/QuickFIXn/Message/FIX50SP2/ExecutionAcknowledgement.cs
@@ -3484,7 +3484,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3564,7 +3564,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -3737,7 +3737,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -3877,7 +3877,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -3958,7 +3958,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -4222,7 +4222,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -4331,7 +4331,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -4413,7 +4413,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -6661,7 +6661,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -6741,7 +6741,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -6821,7 +6821,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -6961,7 +6961,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {
@@ -7043,7 +7043,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -8733,7 +8733,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP2/ExecutionReport.cs
+++ b/QuickFIXn/Message/FIX50SP2/ExecutionReport.cs
@@ -10155,7 +10155,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -10295,7 +10295,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -10376,7 +10376,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ContraBroker ContraBroker
+                public QuickFix.Fields.ContraBroker ContraBroker
                 { 
                     get 
                     {
@@ -10549,7 +10549,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -10629,7 +10629,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -10802,7 +10802,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -10942,7 +10942,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -11023,7 +11023,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -11287,7 +11287,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -11396,7 +11396,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -11478,7 +11478,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -13726,7 +13726,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -13806,7 +13806,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -13886,7 +13886,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -14026,7 +14026,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {
@@ -14108,7 +14108,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -14188,7 +14188,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ContAmtType ContAmtType
+                public QuickFix.Fields.ContAmtType ContAmtType
                 { 
                     get 
                     {
@@ -14299,7 +14299,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -16671,7 +16671,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -16751,7 +16751,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegStipulationType LegStipulationType
+                    public QuickFix.Fields.LegStipulationType LegStipulationType
                     { 
                         get 
                         {
@@ -16831,7 +16831,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.Nested3PartyID Nested3PartyID
+                    public QuickFix.Fields.Nested3PartyID Nested3PartyID
                     { 
                         get 
                         {
@@ -16971,7 +16971,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested3PartySubID Nested3PartySubID
+                        public QuickFix.Fields.Nested3PartySubID Nested3PartySubID
                         { 
                             get 
                             {
@@ -17052,7 +17052,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegAllocAccount LegAllocAccount
+                    public QuickFix.Fields.LegAllocAccount LegAllocAccount
                     { 
                         get 
                         {
@@ -17254,7 +17254,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested2PartyID Nested2PartyID
+                        public QuickFix.Fields.Nested2PartyID Nested2PartyID
                         { 
                             get 
                             {
@@ -17394,7 +17394,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
+                            public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
                             { 
                                 get 
                                 {
@@ -17477,7 +17477,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
+                public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
                 { 
                     get 
                     {
@@ -17619,7 +17619,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StrategyParameterName StrategyParameterName
+                public QuickFix.Fields.StrategyParameterName StrategyParameterName
                 { 
                     get 
                     {
@@ -17730,7 +17730,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
+                public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
                 { 
                     get 
                     {
@@ -17934,7 +17934,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AllocAccount AllocAccount
+                public QuickFix.Fields.AllocAccount AllocAccount
                 { 
                     get 
                     {
@@ -18136,7 +18136,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -18276,7 +18276,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -18358,7 +18358,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.FillExecID FillExecID
+                public QuickFix.Fields.FillExecID FillExecID
                 { 
                     get 
                     {
@@ -18529,7 +18529,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.Nested4PartyID Nested4PartyID
+                    public QuickFix.Fields.Nested4PartyID Nested4PartyID
                     { 
                         get 
                         {
@@ -18669,7 +18669,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested4PartySubID Nested4PartySubID
+                        public QuickFix.Fields.Nested4PartySubID Nested4PartySubID
                         { 
                             get 
                             {
@@ -18751,7 +18751,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RateSource RateSource
+                public QuickFix.Fields.RateSource RateSource
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP2/IOI.cs
+++ b/QuickFIXn/Message/FIX50SP2/IOI.cs
@@ -4476,7 +4476,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -4556,7 +4556,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -4729,7 +4729,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -4869,7 +4869,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -4950,7 +4950,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -5214,7 +5214,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -5323,7 +5323,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -5405,7 +5405,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -7653,7 +7653,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -7733,7 +7733,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -7813,7 +7813,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -7953,7 +7953,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {
@@ -8035,7 +8035,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -8115,7 +8115,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -9867,7 +9867,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -9947,7 +9947,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegStipulationType LegStipulationType
+                    public QuickFix.Fields.LegStipulationType LegStipulationType
                     { 
                         get 
                         {
@@ -10028,7 +10028,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.IOIQualifier IOIQualifier
+                public QuickFix.Fields.IOIQualifier IOIQualifier
                 { 
                     get 
                     {
@@ -10077,7 +10077,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RoutingType RoutingType
+                public QuickFix.Fields.RoutingType RoutingType
                 { 
                     get 
                     {
@@ -10157,7 +10157,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -10297,7 +10297,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP2/ListCancelRequest.cs
+++ b/QuickFIXn/Message/FIX50SP2/ListCancelRequest.cs
@@ -287,7 +287,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -427,7 +427,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP2/ListExecute.cs
+++ b/QuickFIXn/Message/FIX50SP2/ListExecute.cs
@@ -240,7 +240,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EncodedText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX50SP2/ListStatus.cs
+++ b/QuickFIXn/Message/FIX50SP2/ListStatus.cs
@@ -481,7 +481,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ClOrdID ClOrdID
+                public QuickFix.Fields.ClOrdID ClOrdID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP2/ListStatusRequest.cs
+++ b/QuickFIXn/Message/FIX50SP2/ListStatusRequest.cs
@@ -145,7 +145,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EncodedText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX50SP2/ListStrikePrice.cs
+++ b/QuickFIXn/Message/FIX50SP2/ListStrikePrice.cs
@@ -163,7 +163,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -3217,7 +3217,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -3297,7 +3297,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -3470,7 +3470,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                     { 
                         get 
                         {
@@ -3610,7 +3610,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                        public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                         { 
                             get 
                             {
@@ -3691,7 +3691,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventType ComplexEventType
+                    public QuickFix.Fields.ComplexEventType ComplexEventType
                     { 
                         get 
                         {
@@ -3955,7 +3955,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                        public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                         { 
                             get 
                             {
@@ -4064,7 +4064,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                             { 
                                 get 
                                 {
@@ -4146,7 +4146,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                     { 
                         get 
                         {
@@ -6394,7 +6394,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                        public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                         { 
                             get 
                             {
@@ -6474,7 +6474,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                        public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                         { 
                             get 
                             {
@@ -6554,7 +6554,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                        public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                         { 
                             get 
                             {
@@ -6694,7 +6694,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                             { 
                                 get 
                                 {

--- a/QuickFIXn/Message/FIX50SP2/MarketDataIncrementalRefresh.cs
+++ b/QuickFIXn/Message/FIX50SP2/MarketDataIncrementalRefresh.cs
@@ -403,7 +403,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MDUpdateAction MDUpdateAction
+                public QuickFix.Fields.MDUpdateAction MDUpdateAction
                 { 
                     get 
                     {
@@ -5937,7 +5937,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -6017,7 +6017,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -6190,7 +6190,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                     { 
                         get 
                         {
@@ -6330,7 +6330,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                        public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                         { 
                             get 
                             {
@@ -6411,7 +6411,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventType ComplexEventType
+                    public QuickFix.Fields.ComplexEventType ComplexEventType
                     { 
                         get 
                         {
@@ -6675,7 +6675,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                        public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                         { 
                             get 
                             {
@@ -6784,7 +6784,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                             { 
                                 get 
                                 {
@@ -6866,7 +6866,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                     { 
                         get 
                         {
@@ -9114,7 +9114,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                        public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                         { 
                             get 
                             {
@@ -9194,7 +9194,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                        public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                         { 
                             get 
                             {
@@ -9274,7 +9274,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                        public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                         { 
                             get 
                             {
@@ -9414,7 +9414,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                             { 
                                 get 
                                 {
@@ -9496,7 +9496,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSymbol LegSymbol
+                    public QuickFix.Fields.LegSymbol LegSymbol
                     { 
                         get 
                         {
@@ -11186,7 +11186,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                        public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                         { 
                             get 
                             {
@@ -11267,7 +11267,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -11407,7 +11407,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.PartySubID PartySubID
+                        public QuickFix.Fields.PartySubID PartySubID
                         { 
                             get 
                             {
@@ -11488,7 +11488,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.MDSecSizeType MDSecSizeType
+                    public QuickFix.Fields.MDSecSizeType MDSecSizeType
                     { 
                         get 
                         {
@@ -11568,7 +11568,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StatsType StatsType
+                    public QuickFix.Fields.StatsType StatsType
                     { 
                         get 
                         {
@@ -11617,7 +11617,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.RateSource RateSource
+                    public QuickFix.Fields.RateSource RateSource
                     { 
                         get 
                         {
@@ -11729,7 +11729,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RoutingType RoutingType
+                public QuickFix.Fields.RoutingType RoutingType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP2/MarketDataRequest.cs
+++ b/QuickFIXn/Message/FIX50SP2/MarketDataRequest.cs
@@ -506,7 +506,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MDEntryType MDEntryType
+                public QuickFix.Fields.MDEntryType MDEntryType
                 { 
                     get 
                     {
@@ -555,7 +555,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -3547,7 +3547,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -3627,7 +3627,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -3800,7 +3800,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                     { 
                         get 
                         {
@@ -3940,7 +3940,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                        public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                         { 
                             get 
                             {
@@ -4021,7 +4021,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventType ComplexEventType
+                    public QuickFix.Fields.ComplexEventType ComplexEventType
                     { 
                         get 
                         {
@@ -4285,7 +4285,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                        public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                         { 
                             get 
                             {
@@ -4394,7 +4394,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                             { 
                                 get 
                                 {
@@ -4476,7 +4476,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                     { 
                         get 
                         {
@@ -6724,7 +6724,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                        public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                         { 
                             get 
                             {
@@ -6804,7 +6804,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                        public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                         { 
                             get 
                             {
@@ -6884,7 +6884,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                        public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                         { 
                             get 
                             {
@@ -7024,7 +7024,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                             { 
                                 get 
                                 {
@@ -7106,7 +7106,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSymbol LegSymbol
+                    public QuickFix.Fields.LegSymbol LegSymbol
                     { 
                         get 
                         {
@@ -8796,7 +8796,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                        public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                         { 
                             get 
                             {
@@ -8878,7 +8878,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {
@@ -8958,7 +8958,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -9098,7 +9098,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP2/MarketDataRequestReject.cs
+++ b/QuickFIXn/Message/FIX50SP2/MarketDataRequestReject.cs
@@ -254,7 +254,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AltMDSourceID AltMDSourceID
+                public QuickFix.Fields.AltMDSourceID AltMDSourceID
                 { 
                     get 
                     {
@@ -303,7 +303,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -443,7 +443,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP2/MarketDataSnapshotFullRefresh.cs
+++ b/QuickFIXn/Message/FIX50SP2/MarketDataSnapshotFullRefresh.cs
@@ -3503,7 +3503,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3583,7 +3583,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -3756,7 +3756,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -3896,7 +3896,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -3977,7 +3977,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -4241,7 +4241,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -4350,7 +4350,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -4432,7 +4432,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -6680,7 +6680,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -6760,7 +6760,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -6840,7 +6840,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -6980,7 +6980,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {
@@ -7062,7 +7062,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -8752,7 +8752,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -8833,7 +8833,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MDEntryType MDEntryType
+                public QuickFix.Fields.MDEntryType MDEntryType
                 { 
                     get 
                     {
@@ -11143,7 +11143,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -11283,7 +11283,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.PartySubID PartySubID
+                        public QuickFix.Fields.PartySubID PartySubID
                         { 
                             get 
                             {
@@ -11364,7 +11364,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.MDSecSizeType MDSecSizeType
+                    public QuickFix.Fields.MDSecSizeType MDSecSizeType
                     { 
                         get 
                         {
@@ -11444,7 +11444,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.RateSource RateSource
+                    public QuickFix.Fields.RateSource RateSource
                     { 
                         get 
                         {
@@ -11556,7 +11556,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RoutingType RoutingType
+                public QuickFix.Fields.RoutingType RoutingType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP2/MarketDefinition.cs
+++ b/QuickFIXn/Message/FIX50SP2/MarketDefinition.cs
@@ -1155,7 +1155,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StartTickPriceRange StartTickPriceRange
+                public QuickFix.Fields.StartTickPriceRange StartTickPriceRange
                 { 
                     get 
                     {
@@ -1297,7 +1297,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LotType LotType
+                public QuickFix.Fields.LotType LotType
                 { 
                     get 
                     {
@@ -1377,7 +1377,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.OrdType OrdType
+                public QuickFix.Fields.OrdType OrdType
                 { 
                     get 
                     {
@@ -1426,7 +1426,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TimeInForce TimeInForce
+                public QuickFix.Fields.TimeInForce TimeInForce
                 { 
                     get 
                     {
@@ -1475,7 +1475,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ExecInstValue ExecInstValue
+                public QuickFix.Fields.ExecInstValue ExecInstValue
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP2/MarketDefinitionRequest.cs
+++ b/QuickFIXn/Message/FIX50SP2/MarketDefinitionRequest.cs
@@ -178,7 +178,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.ParentMktSegmID);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX50SP2/MarketDefinitionUpdateReport.cs
+++ b/QuickFIXn/Message/FIX50SP2/MarketDefinitionUpdateReport.cs
@@ -1186,7 +1186,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StartTickPriceRange StartTickPriceRange
+                public QuickFix.Fields.StartTickPriceRange StartTickPriceRange
                 { 
                     get 
                     {
@@ -1328,7 +1328,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LotType LotType
+                public QuickFix.Fields.LotType LotType
                 { 
                     get 
                     {
@@ -1408,7 +1408,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.OrdType OrdType
+                public QuickFix.Fields.OrdType OrdType
                 { 
                     get 
                     {
@@ -1457,7 +1457,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TimeInForce TimeInForce
+                public QuickFix.Fields.TimeInForce TimeInForce
                 { 
                     get 
                     {
@@ -1506,7 +1506,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ExecInstValue ExecInstValue
+                public QuickFix.Fields.ExecInstValue ExecInstValue
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP2/MassQuote.cs
+++ b/QuickFIXn/Message/FIX50SP2/MassQuote.cs
@@ -378,7 +378,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -518,7 +518,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -599,7 +599,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.QuoteSetID QuoteSetID
+                public QuickFix.Fields.QuoteSetID QuoteSetID
                 { 
                     get 
                     {
@@ -3002,7 +3002,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -3082,7 +3082,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -3162,7 +3162,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -3302,7 +3302,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {
@@ -3383,7 +3383,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.QuoteEntryID QuoteEntryID
+                    public QuickFix.Fields.QuoteEntryID QuoteEntryID
                     { 
                         get 
                         {
@@ -6995,7 +6995,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                        public QuickFix.Fields.SecurityAltID SecurityAltID
                         { 
                             get 
                             {
@@ -7075,7 +7075,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.EventType EventType
+                        public QuickFix.Fields.EventType EventType
                         { 
                             get 
                             {
@@ -7248,7 +7248,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                        public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                         { 
                             get 
                             {
@@ -7388,7 +7388,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                             { 
                                 get 
                                 {
@@ -7469,7 +7469,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                        public QuickFix.Fields.ComplexEventType ComplexEventType
                         { 
                             get 
                             {
@@ -7733,7 +7733,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                            public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                             { 
                                 get 
                                 {
@@ -7842,7 +7842,7 @@ namespace QuickFix
                                     return clone;
                                 }
                             
-                                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                                public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                                 { 
                                     get 
                                     {
@@ -7924,7 +7924,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegSymbol LegSymbol
+                        public QuickFix.Fields.LegSymbol LegSymbol
                         { 
                             get 
                             {
@@ -9614,7 +9614,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                             { 
                                 get 
                                 {

--- a/QuickFIXn/Message/FIX50SP2/MassQuoteAcknowledgement.cs
+++ b/QuickFIXn/Message/FIX50SP2/MassQuoteAcknowledgement.cs
@@ -533,7 +533,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -673,7 +673,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -754,7 +754,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.QuoteSetID QuoteSetID
+                public QuickFix.Fields.QuoteSetID QuoteSetID
                 { 
                     get 
                     {
@@ -3250,7 +3250,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -3330,7 +3330,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -3410,7 +3410,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -3550,7 +3550,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {
@@ -3631,7 +3631,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.QuoteEntryID QuoteEntryID
+                    public QuickFix.Fields.QuoteEntryID QuoteEntryID
                     { 
                         get 
                         {
@@ -7305,7 +7305,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                        public QuickFix.Fields.SecurityAltID SecurityAltID
                         { 
                             get 
                             {
@@ -7385,7 +7385,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.EventType EventType
+                        public QuickFix.Fields.EventType EventType
                         { 
                             get 
                             {
@@ -7558,7 +7558,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                        public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                         { 
                             get 
                             {
@@ -7698,7 +7698,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                             { 
                                 get 
                                 {
@@ -7779,7 +7779,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                        public QuickFix.Fields.ComplexEventType ComplexEventType
                         { 
                             get 
                             {
@@ -8043,7 +8043,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                            public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                             { 
                                 get 
                                 {
@@ -8152,7 +8152,7 @@ namespace QuickFix
                                     return clone;
                                 }
                             
-                                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                                public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                                 { 
                                     get 
                                     {
@@ -8234,7 +8234,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegSymbol LegSymbol
+                        public QuickFix.Fields.LegSymbol LegSymbol
                         { 
                             get 
                             {
@@ -9924,7 +9924,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                             { 
                                 get 
                                 {
@@ -10007,7 +10007,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TargetPartyID TargetPartyID
+                public QuickFix.Fields.TargetPartyID TargetPartyID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP2/MultilegOrderCancelReplace.cs
+++ b/QuickFIXn/Message/FIX50SP2/MultilegOrderCancelReplace.cs
@@ -6768,7 +6768,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -6908,7 +6908,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -6989,7 +6989,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AllocAccount AllocAccount
+                public QuickFix.Fields.AllocAccount AllocAccount
                 { 
                     get 
                     {
@@ -7191,7 +7191,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.Nested3PartyID Nested3PartyID
+                    public QuickFix.Fields.Nested3PartyID Nested3PartyID
                     { 
                         get 
                         {
@@ -7331,7 +7331,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested3PartySubID Nested3PartySubID
+                        public QuickFix.Fields.Nested3PartySubID Nested3PartySubID
                         { 
                             get 
                             {
@@ -7413,7 +7413,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {
@@ -7493,7 +7493,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -7573,7 +7573,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -7746,7 +7746,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -7886,7 +7886,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -7967,7 +7967,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -8231,7 +8231,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -8340,7 +8340,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -8422,7 +8422,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -10670,7 +10670,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -10750,7 +10750,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -10830,7 +10830,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -10970,7 +10970,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {
@@ -11052,7 +11052,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -13269,7 +13269,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -13349,7 +13349,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegStipulationType LegStipulationType
+                    public QuickFix.Fields.LegStipulationType LegStipulationType
                     { 
                         get 
                         {
@@ -13429,7 +13429,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegAllocAccount LegAllocAccount
+                    public QuickFix.Fields.LegAllocAccount LegAllocAccount
                     { 
                         get 
                         {
@@ -13631,7 +13631,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested2PartyID Nested2PartyID
+                        public QuickFix.Fields.Nested2PartyID Nested2PartyID
                         { 
                             get 
                             {
@@ -13771,7 +13771,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
+                            public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
                             { 
                                 get 
                                 {
@@ -13853,7 +13853,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -13993,7 +13993,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -14075,7 +14075,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StrategyParameterName StrategyParameterName
+                public QuickFix.Fields.StrategyParameterName StrategyParameterName
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP2/NetworkCounterpartySystemStatusRequest.cs
+++ b/QuickFIXn/Message/FIX50SP2/NetworkCounterpartySystemStatusRequest.cs
@@ -132,7 +132,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RefCompID RefCompID
+                public QuickFix.Fields.RefCompID RefCompID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP2/NetworkCounterpartySystemStatusResponse.cs
+++ b/QuickFIXn/Message/FIX50SP2/NetworkCounterpartySystemStatusResponse.cs
@@ -194,7 +194,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RefCompID RefCompID
+                public QuickFix.Fields.RefCompID RefCompID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP2/NewOrderCross.cs
+++ b/QuickFIXn/Message/FIX50SP2/NewOrderCross.cs
@@ -5935,7 +5935,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Side Side
+                public QuickFix.Fields.Side Side
                 { 
                     get 
                     {
@@ -7284,7 +7284,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -7424,7 +7424,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.PartySubID PartySubID
+                        public QuickFix.Fields.PartySubID PartySubID
                         { 
                             get 
                             {
@@ -7505,7 +7505,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.AllocAccount AllocAccount
+                    public QuickFix.Fields.AllocAccount AllocAccount
                     { 
                         get 
                         {
@@ -7707,7 +7707,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartyID NestedPartyID
+                        public QuickFix.Fields.NestedPartyID NestedPartyID
                         { 
                             get 
                             {
@@ -7847,7 +7847,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
                             { 
                                 get 
                                 {
@@ -7930,7 +7930,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -8010,7 +8010,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -8183,7 +8183,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -8323,7 +8323,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -8404,7 +8404,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -8668,7 +8668,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -8777,7 +8777,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -8859,7 +8859,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -11107,7 +11107,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -11187,7 +11187,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -11267,7 +11267,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -11407,7 +11407,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {
@@ -11489,7 +11489,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -13179,7 +13179,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -13260,7 +13260,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {
@@ -13340,7 +13340,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -13420,7 +13420,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StrategyParameterName StrategyParameterName
+                public QuickFix.Fields.StrategyParameterName StrategyParameterName
                 { 
                     get 
                     {
@@ -13531,7 +13531,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RootPartyID RootPartyID
+                public QuickFix.Fields.RootPartyID RootPartyID
                 { 
                     get 
                     {
@@ -13671,7 +13671,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.RootPartySubID RootPartySubID
+                    public QuickFix.Fields.RootPartySubID RootPartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP2/NewOrderList.cs
+++ b/QuickFIXn/Message/FIX50SP2/NewOrderList.cs
@@ -692,7 +692,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ClOrdID ClOrdID
+                public QuickFix.Fields.ClOrdID ClOrdID
                 { 
                     get 
                     {
@@ -7776,7 +7776,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -7916,7 +7916,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.PartySubID PartySubID
+                        public QuickFix.Fields.PartySubID PartySubID
                         { 
                             get 
                             {
@@ -7997,7 +7997,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.AllocAccount AllocAccount
+                    public QuickFix.Fields.AllocAccount AllocAccount
                     { 
                         get 
                         {
@@ -8199,7 +8199,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartyID NestedPartyID
+                        public QuickFix.Fields.NestedPartyID NestedPartyID
                         { 
                             get 
                             {
@@ -8339,7 +8339,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
                             { 
                                 get 
                                 {
@@ -8421,7 +8421,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.TradingSessionID TradingSessionID
+                    public QuickFix.Fields.TradingSessionID TradingSessionID
                     { 
                         get 
                         {
@@ -8501,7 +8501,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -8581,7 +8581,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -8754,7 +8754,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                     { 
                         get 
                         {
@@ -8894,7 +8894,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                        public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                         { 
                             get 
                             {
@@ -8975,7 +8975,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventType ComplexEventType
+                    public QuickFix.Fields.ComplexEventType ComplexEventType
                     { 
                         get 
                         {
@@ -9239,7 +9239,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                        public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                         { 
                             get 
                             {
@@ -9348,7 +9348,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                             { 
                                 get 
                                 {
@@ -9430,7 +9430,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                     { 
                         get 
                         {
@@ -11678,7 +11678,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                        public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                         { 
                             get 
                             {
@@ -11758,7 +11758,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                        public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                         { 
                             get 
                             {
@@ -11838,7 +11838,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                        public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                         { 
                             get 
                             {
@@ -11978,7 +11978,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                             { 
                                 get 
                                 {
@@ -12060,7 +12060,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StipulationType StipulationType
+                    public QuickFix.Fields.StipulationType StipulationType
                     { 
                         get 
                         {
@@ -12140,7 +12140,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StrategyParameterName StrategyParameterName
+                    public QuickFix.Fields.StrategyParameterName StrategyParameterName
                     { 
                         get 
                         {
@@ -12252,7 +12252,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RootPartyID RootPartyID
+                public QuickFix.Fields.RootPartyID RootPartyID
                 { 
                     get 
                     {
@@ -12392,7 +12392,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.RootPartySubID RootPartySubID
+                    public QuickFix.Fields.RootPartySubID RootPartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP2/NewOrderMultileg.cs
+++ b/QuickFIXn/Message/FIX50SP2/NewOrderMultileg.cs
@@ -6739,7 +6739,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -6879,7 +6879,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -6960,7 +6960,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AllocAccount AllocAccount
+                public QuickFix.Fields.AllocAccount AllocAccount
                 { 
                     get 
                     {
@@ -7162,7 +7162,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.Nested3PartyID Nested3PartyID
+                    public QuickFix.Fields.Nested3PartyID Nested3PartyID
                     { 
                         get 
                         {
@@ -7302,7 +7302,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested3PartySubID Nested3PartySubID
+                        public QuickFix.Fields.Nested3PartySubID Nested3PartySubID
                         { 
                             get 
                             {
@@ -7384,7 +7384,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {
@@ -7464,7 +7464,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -7544,7 +7544,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -7717,7 +7717,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -7857,7 +7857,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -7938,7 +7938,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -8202,7 +8202,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -8311,7 +8311,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -8393,7 +8393,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -10641,7 +10641,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -10721,7 +10721,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -10801,7 +10801,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -10941,7 +10941,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {
@@ -11023,7 +11023,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -13240,7 +13240,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -13320,7 +13320,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegStipulationType LegStipulationType
+                    public QuickFix.Fields.LegStipulationType LegStipulationType
                     { 
                         get 
                         {
@@ -13400,7 +13400,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegAllocAccount LegAllocAccount
+                    public QuickFix.Fields.LegAllocAccount LegAllocAccount
                     { 
                         get 
                         {
@@ -13602,7 +13602,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested2PartyID Nested2PartyID
+                        public QuickFix.Fields.Nested2PartyID Nested2PartyID
                         { 
                             get 
                             {
@@ -13742,7 +13742,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
+                            public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
                             { 
                                 get 
                                 {
@@ -13824,7 +13824,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -13964,7 +13964,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -14046,7 +14046,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StrategyParameterName StrategyParameterName
+                public QuickFix.Fields.StrategyParameterName StrategyParameterName
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP2/NewOrderSingle.cs
+++ b/QuickFIXn/Message/FIX50SP2/NewOrderSingle.cs
@@ -7576,7 +7576,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -7716,7 +7716,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -7797,7 +7797,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AllocAccount AllocAccount
+                public QuickFix.Fields.AllocAccount AllocAccount
                 { 
                     get 
                     {
@@ -7999,7 +7999,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -8139,7 +8139,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -8221,7 +8221,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {
@@ -8301,7 +8301,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -8381,7 +8381,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -8554,7 +8554,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -8694,7 +8694,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -8775,7 +8775,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -9039,7 +9039,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -9148,7 +9148,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -9230,7 +9230,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -11478,7 +11478,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -11558,7 +11558,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -11638,7 +11638,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -11778,7 +11778,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {
@@ -11860,7 +11860,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -11940,7 +11940,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StrategyParameterName StrategyParameterName
+                public QuickFix.Fields.StrategyParameterName StrategyParameterName
                 { 
                     get 
                     {
@@ -12051,7 +12051,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
+                public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP2/News.cs
+++ b/QuickFIXn/Message/FIX50SP2/News.cs
@@ -750,7 +750,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RoutingType RoutingType
+                public QuickFix.Fields.RoutingType RoutingType
                 { 
                     get 
                     {
@@ -830,7 +830,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -3574,7 +3574,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -3654,7 +3654,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -3827,7 +3827,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                     { 
                         get 
                         {
@@ -3967,7 +3967,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                        public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                         { 
                             get 
                             {
@@ -4048,7 +4048,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventType ComplexEventType
+                    public QuickFix.Fields.ComplexEventType ComplexEventType
                     { 
                         get 
                         {
@@ -4312,7 +4312,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                        public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                         { 
                             get 
                             {
@@ -4421,7 +4421,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                             { 
                                 get 
                                 {
@@ -4504,7 +4504,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -6194,7 +6194,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -6275,7 +6275,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -8523,7 +8523,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -8603,7 +8603,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -8683,7 +8683,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -8823,7 +8823,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {
@@ -8905,7 +8905,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Text Text
+                public QuickFix.Fields.Text Text
                 { 
                     get 
                     {
@@ -9016,7 +9016,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.NewsRefID NewsRefID
+                public QuickFix.Fields.NewsRefID NewsRefID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP2/OrderCancelReject.cs
+++ b/QuickFIXn/Message/FIX50SP2/OrderCancelReject.cs
@@ -678,7 +678,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EncodedText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX50SP2/OrderCancelReplaceRequest.cs
+++ b/QuickFIXn/Message/FIX50SP2/OrderCancelReplaceRequest.cs
@@ -7483,7 +7483,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -7623,7 +7623,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -7704,7 +7704,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.AllocAccount AllocAccount
+                public QuickFix.Fields.AllocAccount AllocAccount
                 { 
                     get 
                     {
@@ -7906,7 +7906,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -8046,7 +8046,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -8128,7 +8128,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {
@@ -8208,7 +8208,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -8288,7 +8288,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -8461,7 +8461,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -8601,7 +8601,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -8682,7 +8682,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -8946,7 +8946,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -9055,7 +9055,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -9137,7 +9137,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -11385,7 +11385,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -11465,7 +11465,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -11545,7 +11545,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -11685,7 +11685,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {
@@ -11767,7 +11767,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StrategyParameterName StrategyParameterName
+                public QuickFix.Fields.StrategyParameterName StrategyParameterName
                 { 
                     get 
                     {
@@ -11878,7 +11878,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
+                public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP2/OrderCancelRequest.cs
+++ b/QuickFIXn/Message/FIX50SP2/OrderCancelRequest.cs
@@ -3761,7 +3761,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -3901,7 +3901,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -3982,7 +3982,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -4062,7 +4062,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -4235,7 +4235,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -4375,7 +4375,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -4456,7 +4456,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -4720,7 +4720,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -4829,7 +4829,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -4911,7 +4911,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -7159,7 +7159,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -7239,7 +7239,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -7319,7 +7319,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -7459,7 +7459,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50SP2/OrderMassActionReport.cs
+++ b/QuickFIXn/Message/FIX50SP2/OrderMassActionReport.cs
@@ -5654,7 +5654,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.OrigClOrdID OrigClOrdID
+                public QuickFix.Fields.OrigClOrdID OrigClOrdID
                 { 
                     get 
                     {
@@ -5765,7 +5765,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -5905,7 +5905,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -5986,7 +5986,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -6066,7 +6066,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -6239,7 +6239,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -6379,7 +6379,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -6460,7 +6460,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -6724,7 +6724,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -6833,7 +6833,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -6915,7 +6915,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                 { 
                     get 
                     {
@@ -6995,7 +6995,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                 { 
                     get 
                     {
@@ -7075,7 +7075,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                 { 
                     get 
                     {
@@ -7215,7 +7215,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                    public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                     { 
                         get 
                         {
@@ -7296,7 +7296,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.NotAffOrigClOrdID NotAffOrigClOrdID
+                public QuickFix.Fields.NotAffOrigClOrdID NotAffOrigClOrdID
                 { 
                     get 
                     {
@@ -7376,7 +7376,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TargetPartyID TargetPartyID
+                public QuickFix.Fields.TargetPartyID TargetPartyID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP2/OrderMassActionRequest.cs
+++ b/QuickFIXn/Message/FIX50SP2/OrderMassActionRequest.cs
@@ -5468,7 +5468,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -5608,7 +5608,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -5689,7 +5689,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -5769,7 +5769,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -5942,7 +5942,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -6082,7 +6082,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -6163,7 +6163,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -6427,7 +6427,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -6536,7 +6536,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -6618,7 +6618,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                 { 
                     get 
                     {
@@ -6698,7 +6698,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                 { 
                     get 
                     {
@@ -6778,7 +6778,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                 { 
                     get 
                     {
@@ -6918,7 +6918,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                    public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                     { 
                         get 
                         {
@@ -6999,7 +6999,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TargetPartyID TargetPartyID
+                public QuickFix.Fields.TargetPartyID TargetPartyID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP2/OrderMassCancelReport.cs
+++ b/QuickFIXn/Message/FIX50SP2/OrderMassCancelReport.cs
@@ -5685,7 +5685,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.OrigClOrdID OrigClOrdID
+                public QuickFix.Fields.OrigClOrdID OrigClOrdID
                 { 
                     get 
                     {
@@ -5796,7 +5796,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -5876,7 +5876,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -6049,7 +6049,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -6189,7 +6189,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -6270,7 +6270,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -6534,7 +6534,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -6643,7 +6643,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -6725,7 +6725,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                 { 
                     get 
                     {
@@ -6805,7 +6805,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                 { 
                     get 
                     {
@@ -6885,7 +6885,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                 { 
                     get 
                     {
@@ -7025,7 +7025,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                    public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                     { 
                         get 
                         {
@@ -7106,7 +7106,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -7246,7 +7246,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -7327,7 +7327,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.NotAffOrigClOrdID NotAffOrigClOrdID
+                public QuickFix.Fields.NotAffOrigClOrdID NotAffOrigClOrdID
                 { 
                     get 
                     {
@@ -7407,7 +7407,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TargetPartyID TargetPartyID
+                public QuickFix.Fields.TargetPartyID TargetPartyID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP2/OrderMassCancelRequest.cs
+++ b/QuickFIXn/Message/FIX50SP2/OrderMassCancelRequest.cs
@@ -5435,7 +5435,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -5515,7 +5515,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -5688,7 +5688,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -5828,7 +5828,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -5909,7 +5909,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -6173,7 +6173,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -6282,7 +6282,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -6364,7 +6364,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                 { 
                     get 
                     {
@@ -6444,7 +6444,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                 { 
                     get 
                     {
@@ -6524,7 +6524,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                 { 
                     get 
                     {
@@ -6664,7 +6664,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                    public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                     { 
                         get 
                         {
@@ -6745,7 +6745,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -6885,7 +6885,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -6966,7 +6966,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TargetPartyID TargetPartyID
+                public QuickFix.Fields.TargetPartyID TargetPartyID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP2/OrderMassStatusRequest.cs
+++ b/QuickFIXn/Message/FIX50SP2/OrderMassStatusRequest.cs
@@ -5278,7 +5278,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -5418,7 +5418,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -5499,7 +5499,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -5579,7 +5579,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -5752,7 +5752,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -5892,7 +5892,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -5973,7 +5973,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -6237,7 +6237,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -6346,7 +6346,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -6428,7 +6428,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                 { 
                     get 
                     {
@@ -6508,7 +6508,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                 { 
                     get 
                     {
@@ -6588,7 +6588,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                 { 
                     get 
                     {
@@ -6728,7 +6728,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                    public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                     { 
                         get 
                         {
@@ -6809,7 +6809,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TargetPartyID TargetPartyID
+                public QuickFix.Fields.TargetPartyID TargetPartyID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP2/OrderStatusRequest.cs
+++ b/QuickFIXn/Message/FIX50SP2/OrderStatusRequest.cs
@@ -3354,7 +3354,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -3494,7 +3494,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -3575,7 +3575,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3655,7 +3655,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -3828,7 +3828,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -3968,7 +3968,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -4049,7 +4049,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -4313,7 +4313,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -4422,7 +4422,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -4504,7 +4504,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -6752,7 +6752,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -6832,7 +6832,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -6912,7 +6912,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -7052,7 +7052,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50SP2/PartyDetailsListReport.cs
+++ b/QuickFIXn/Message/FIX50SP2/PartyDetailsListReport.cs
@@ -440,7 +440,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -704,7 +704,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -784,7 +784,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyAltID PartyAltID
+                    public QuickFix.Fields.PartyAltID PartyAltID
                     { 
                         get 
                         {
@@ -893,7 +893,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.PartyAltSubID PartyAltSubID
+                        public QuickFix.Fields.PartyAltSubID PartyAltSubID
                         { 
                             get 
                             {
@@ -974,7 +974,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ContextPartyID ContextPartyID
+                    public QuickFix.Fields.ContextPartyID ContextPartyID
                     { 
                         get 
                         {
@@ -1114,7 +1114,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ContextPartySubID ContextPartySubID
+                        public QuickFix.Fields.ContextPartySubID ContextPartySubID
                         { 
                             get 
                             {
@@ -1195,7 +1195,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.RiskLimitType RiskLimitType
+                    public QuickFix.Fields.RiskLimitType RiskLimitType
                     { 
                         get 
                         {
@@ -1397,7 +1397,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.RiskInstrumentOperator RiskInstrumentOperator
+                        public QuickFix.Fields.RiskInstrumentOperator RiskInstrumentOperator
                         { 
                             get 
                             {
@@ -2188,7 +2188,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.RiskSecurityAltID RiskSecurityAltID
+                            public QuickFix.Fields.RiskSecurityAltID RiskSecurityAltID
                             { 
                                 get 
                                 {
@@ -2269,7 +2269,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.RiskWarningLevelPercent RiskWarningLevelPercent
+                        public QuickFix.Fields.RiskWarningLevelPercent RiskWarningLevelPercent
                         { 
                             get 
                             {
@@ -2350,7 +2350,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.RelatedPartyID RelatedPartyID
+                    public QuickFix.Fields.RelatedPartyID RelatedPartyID
                     { 
                         get 
                         {
@@ -2614,7 +2614,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.RelatedPartySubID RelatedPartySubID
+                        public QuickFix.Fields.RelatedPartySubID RelatedPartySubID
                         { 
                             get 
                             {
@@ -2694,7 +2694,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.RelatedPartyAltID RelatedPartyAltID
+                        public QuickFix.Fields.RelatedPartyAltID RelatedPartyAltID
                         { 
                             get 
                             {
@@ -2803,7 +2803,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.RelatedPartyAltSubID RelatedPartyAltSubID
+                            public QuickFix.Fields.RelatedPartyAltSubID RelatedPartyAltSubID
                             { 
                                 get 
                                 {
@@ -2884,7 +2884,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.RelatedContextPartyID RelatedContextPartyID
+                        public QuickFix.Fields.RelatedContextPartyID RelatedContextPartyID
                         { 
                             get 
                             {
@@ -3024,7 +3024,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.RelatedContextPartySubID RelatedContextPartySubID
+                            public QuickFix.Fields.RelatedContextPartySubID RelatedContextPartySubID
                             { 
                                 get 
                                 {
@@ -3105,7 +3105,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.RelationshipRiskLimitType RelationshipRiskLimitType
+                        public QuickFix.Fields.RelationshipRiskLimitType RelationshipRiskLimitType
                         { 
                             get 
                             {
@@ -3307,7 +3307,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.RelationshipRiskInstrumentOperator RelationshipRiskInstrumentOperator
+                            public QuickFix.Fields.RelationshipRiskInstrumentOperator RelationshipRiskInstrumentOperator
                             { 
                                 get 
                                 {
@@ -4098,7 +4098,7 @@ namespace QuickFix
                                     return clone;
                                 }
                             
-                                                            public QuickFix.Fields.RelationshipRiskSecurityAltID RelationshipRiskSecurityAltID
+                                public QuickFix.Fields.RelationshipRiskSecurityAltID RelationshipRiskSecurityAltID
                                 { 
                                     get 
                                     {
@@ -4179,7 +4179,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.RelationshipRiskWarningLevelPercent RelationshipRiskWarningLevelPercent
+                            public QuickFix.Fields.RelationshipRiskWarningLevelPercent RelationshipRiskWarningLevelPercent
                             { 
                                 get 
                                 {
@@ -4260,7 +4260,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.PartyRelationship PartyRelationship
+                        public QuickFix.Fields.PartyRelationship PartyRelationship
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50SP2/PartyDetailsListRequest.cs
+++ b/QuickFIXn/Message/FIX50SP2/PartyDetailsListRequest.cs
@@ -316,7 +316,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyListResponseType PartyListResponseType
+                public QuickFix.Fields.PartyListResponseType PartyListResponseType
                 { 
                     get 
                     {
@@ -365,7 +365,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -505,7 +505,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -586,7 +586,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RequestedPartyRole RequestedPartyRole
+                public QuickFix.Fields.RequestedPartyRole RequestedPartyRole
                 { 
                     get 
                     {
@@ -635,7 +635,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyRelationship PartyRelationship
+                public QuickFix.Fields.PartyRelationship PartyRelationship
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP2/PositionMaintenanceReport.cs
+++ b/QuickFIXn/Message/FIX50SP2/PositionMaintenanceReport.cs
@@ -3703,7 +3703,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -3843,7 +3843,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -3924,7 +3924,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -4004,7 +4004,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -4177,7 +4177,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -4317,7 +4317,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -4398,7 +4398,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -4662,7 +4662,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -4771,7 +4771,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -4853,7 +4853,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -6543,7 +6543,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -6624,7 +6624,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -8872,7 +8872,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -8952,7 +8952,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -9032,7 +9032,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -9172,7 +9172,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {
@@ -9254,7 +9254,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {
@@ -9334,7 +9334,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosType PosType
+                public QuickFix.Fields.PosType PosType
                 { 
                     get 
                     {
@@ -9536,7 +9536,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -9676,7 +9676,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -9758,7 +9758,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosAmtType PosAmtType
+                public QuickFix.Fields.PosAmtType PosAmtType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP2/PositionMaintenanceRequest.cs
+++ b/QuickFIXn/Message/FIX50SP2/PositionMaintenanceRequest.cs
@@ -3606,7 +3606,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -3746,7 +3746,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -3827,7 +3827,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3907,7 +3907,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -4080,7 +4080,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -4220,7 +4220,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -4301,7 +4301,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -4565,7 +4565,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -4674,7 +4674,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -4756,7 +4756,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -6446,7 +6446,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -6527,7 +6527,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -8775,7 +8775,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -8855,7 +8855,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -8935,7 +8935,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -9075,7 +9075,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {
@@ -9157,7 +9157,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {
@@ -9237,7 +9237,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosType PosType
+                public QuickFix.Fields.PosType PosType
                 { 
                     get 
                     {
@@ -9439,7 +9439,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -9579,7 +9579,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -9661,7 +9661,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosAmtType PosAmtType
+                public QuickFix.Fields.PosAmtType PosAmtType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP2/PositionReport.cs
+++ b/QuickFIXn/Message/FIX50SP2/PositionReport.cs
@@ -3914,7 +3914,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -4054,7 +4054,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -4135,7 +4135,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -4215,7 +4215,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -4388,7 +4388,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -4528,7 +4528,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -4609,7 +4609,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -4873,7 +4873,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -4982,7 +4982,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -5064,7 +5064,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -6754,7 +6754,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -6835,7 +6835,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -9207,7 +9207,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -9287,7 +9287,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -9367,7 +9367,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -9507,7 +9507,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {
@@ -9588,7 +9588,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingPayAmount UnderlyingPayAmount
+                    public QuickFix.Fields.UnderlyingPayAmount UnderlyingPayAmount
                     { 
                         get 
                         {
@@ -9731,7 +9731,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosType PosType
+                public QuickFix.Fields.PosType PosType
                 { 
                     get 
                     {
@@ -9933,7 +9933,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -10073,7 +10073,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -10155,7 +10155,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosAmtType PosAmtType
+                public QuickFix.Fields.PosAmtType PosAmtType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP2/Quote.cs
+++ b/QuickFIXn/Message/FIX50SP2/Quote.cs
@@ -5617,7 +5617,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.QuoteQualifier QuoteQualifier
+                public QuickFix.Fields.QuoteQualifier QuoteQualifier
                 { 
                     get 
                     {
@@ -5666,7 +5666,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -5806,7 +5806,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -5887,7 +5887,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -5967,7 +5967,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -6140,7 +6140,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -6280,7 +6280,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -6361,7 +6361,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -6625,7 +6625,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -6734,7 +6734,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -6816,7 +6816,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -9064,7 +9064,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -9144,7 +9144,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -9224,7 +9224,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -9364,7 +9364,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {
@@ -9446,7 +9446,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -9526,7 +9526,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -11774,7 +11774,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -11854,7 +11854,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegStipulationType LegStipulationType
+                    public QuickFix.Fields.LegStipulationType LegStipulationType
                     { 
                         get 
                         {
@@ -11934,7 +11934,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -12074,7 +12074,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -12156,7 +12156,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RateSource RateSource
+                public QuickFix.Fields.RateSource RateSource
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP2/QuoteCancel.cs
+++ b/QuickFIXn/Message/FIX50SP2/QuoteCancel.cs
@@ -471,7 +471,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -611,7 +611,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -692,7 +692,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -3777,7 +3777,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -3857,7 +3857,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -4030,7 +4030,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                     { 
                         get 
                         {
@@ -4170,7 +4170,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                        public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                         { 
                             get 
                             {
@@ -4251,7 +4251,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventType ComplexEventType
+                    public QuickFix.Fields.ComplexEventType ComplexEventType
                     { 
                         get 
                         {
@@ -4515,7 +4515,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                        public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                         { 
                             get 
                             {
@@ -4624,7 +4624,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                             { 
                                 get 
                                 {
@@ -4706,7 +4706,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                     { 
                         get 
                         {
@@ -6954,7 +6954,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                        public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                         { 
                             get 
                             {
@@ -7034,7 +7034,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                        public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                         { 
                             get 
                             {
@@ -7114,7 +7114,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                        public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                         { 
                             get 
                             {
@@ -7254,7 +7254,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                             { 
                                 get 
                                 {
@@ -7336,7 +7336,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSymbol LegSymbol
+                    public QuickFix.Fields.LegSymbol LegSymbol
                     { 
                         get 
                         {
@@ -9026,7 +9026,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                        public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                         { 
                             get 
                             {
@@ -9108,7 +9108,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TargetPartyID TargetPartyID
+                public QuickFix.Fields.TargetPartyID TargetPartyID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP2/QuoteRequest.cs
+++ b/QuickFIXn/Message/FIX50SP2/QuoteRequest.cs
@@ -471,7 +471,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -5075,7 +5075,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -5155,7 +5155,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -5328,7 +5328,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                     { 
                         get 
                         {
@@ -5468,7 +5468,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                        public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                         { 
                             get 
                             {
@@ -5549,7 +5549,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventType ComplexEventType
+                    public QuickFix.Fields.ComplexEventType ComplexEventType
                     { 
                         get 
                         {
@@ -5813,7 +5813,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                        public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                         { 
                             get 
                             {
@@ -5922,7 +5922,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                             { 
                                 get 
                                 {
@@ -6004,7 +6004,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                     { 
                         get 
                         {
@@ -8252,7 +8252,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                        public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                         { 
                             get 
                             {
@@ -8332,7 +8332,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                        public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                         { 
                             get 
                             {
@@ -8412,7 +8412,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                        public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                         { 
                             get 
                             {
@@ -8552,7 +8552,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                             { 
                                 get 
                                 {
@@ -8634,7 +8634,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StipulationType StipulationType
+                    public QuickFix.Fields.StipulationType StipulationType
                     { 
                         get 
                         {
@@ -8714,7 +8714,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSymbol LegSymbol
+                    public QuickFix.Fields.LegSymbol LegSymbol
                     { 
                         get 
                         {
@@ -10807,7 +10807,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                        public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                         { 
                             get 
                             {
@@ -10887,7 +10887,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegStipulationType LegStipulationType
+                        public QuickFix.Fields.LegStipulationType LegStipulationType
                         { 
                             get 
                             {
@@ -10967,7 +10967,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartyID NestedPartyID
+                        public QuickFix.Fields.NestedPartyID NestedPartyID
                         { 
                             get 
                             {
@@ -11107,7 +11107,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
                             { 
                                 get 
                                 {
@@ -11189,7 +11189,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.QuoteQualifier QuoteQualifier
+                    public QuickFix.Fields.QuoteQualifier QuoteQualifier
                     { 
                         get 
                         {
@@ -11238,7 +11238,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -11378,7 +11378,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.PartySubID PartySubID
+                        public QuickFix.Fields.PartySubID PartySubID
                         { 
                             get 
                             {
@@ -11459,7 +11459,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.RateSource RateSource
+                    public QuickFix.Fields.RateSource RateSource
                     { 
                         get 
                         {
@@ -11571,7 +11571,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RootPartyID RootPartyID
+                public QuickFix.Fields.RootPartyID RootPartyID
                 { 
                     get 
                     {
@@ -11711,7 +11711,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.RootPartySubID RootPartySubID
+                    public QuickFix.Fields.RootPartySubID RootPartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP2/QuoteRequestReject.cs
+++ b/QuickFIXn/Message/FIX50SP2/QuoteRequestReject.cs
@@ -380,7 +380,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -4860,7 +4860,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -4940,7 +4940,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -5113,7 +5113,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                     { 
                         get 
                         {
@@ -5253,7 +5253,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                        public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                         { 
                             get 
                             {
@@ -5334,7 +5334,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventType ComplexEventType
+                    public QuickFix.Fields.ComplexEventType ComplexEventType
                     { 
                         get 
                         {
@@ -5598,7 +5598,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                        public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                         { 
                             get 
                             {
@@ -5707,7 +5707,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                             { 
                                 get 
                                 {
@@ -5789,7 +5789,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                     { 
                         get 
                         {
@@ -8037,7 +8037,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                        public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                         { 
                             get 
                             {
@@ -8117,7 +8117,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                        public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                         { 
                             get 
                             {
@@ -8197,7 +8197,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                        public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                         { 
                             get 
                             {
@@ -8337,7 +8337,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                             { 
                                 get 
                                 {
@@ -8419,7 +8419,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StipulationType StipulationType
+                    public QuickFix.Fields.StipulationType StipulationType
                     { 
                         get 
                         {
@@ -8499,7 +8499,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSymbol LegSymbol
+                    public QuickFix.Fields.LegSymbol LegSymbol
                     { 
                         get 
                         {
@@ -10592,7 +10592,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                        public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                         { 
                             get 
                             {
@@ -10672,7 +10672,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegStipulationType LegStipulationType
+                        public QuickFix.Fields.LegStipulationType LegStipulationType
                         { 
                             get 
                             {
@@ -10752,7 +10752,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartyID NestedPartyID
+                        public QuickFix.Fields.NestedPartyID NestedPartyID
                         { 
                             get 
                             {
@@ -10892,7 +10892,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
                             { 
                                 get 
                                 {
@@ -10974,7 +10974,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.QuoteQualifier QuoteQualifier
+                    public QuickFix.Fields.QuoteQualifier QuoteQualifier
                     { 
                         get 
                         {
@@ -11023,7 +11023,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -11163,7 +11163,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.PartySubID PartySubID
+                        public QuickFix.Fields.PartySubID PartySubID
                         { 
                             get 
                             {
@@ -11245,7 +11245,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RootPartyID RootPartyID
+                public QuickFix.Fields.RootPartyID RootPartyID
                 { 
                     get 
                     {
@@ -11385,7 +11385,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.RootPartySubID RootPartySubID
+                    public QuickFix.Fields.RootPartySubID RootPartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP2/QuoteResponse.cs
+++ b/QuickFIXn/Message/FIX50SP2/QuoteResponse.cs
@@ -5526,7 +5526,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.QuoteQualifier QuoteQualifier
+                public QuickFix.Fields.QuoteQualifier QuoteQualifier
                 { 
                     get 
                     {
@@ -5575,7 +5575,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -5715,7 +5715,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -5796,7 +5796,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -5876,7 +5876,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -6049,7 +6049,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -6189,7 +6189,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -6270,7 +6270,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -6534,7 +6534,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -6643,7 +6643,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -6725,7 +6725,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -8973,7 +8973,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -9053,7 +9053,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -9133,7 +9133,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -9273,7 +9273,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {
@@ -9355,7 +9355,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -9435,7 +9435,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -11683,7 +11683,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -11763,7 +11763,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegStipulationType LegStipulationType
+                    public QuickFix.Fields.LegStipulationType LegStipulationType
                     { 
                         get 
                         {
@@ -11843,7 +11843,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -11983,7 +11983,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50SP2/QuoteStatusReport.cs
+++ b/QuickFIXn/Message/FIX50SP2/QuoteStatusReport.cs
@@ -5642,7 +5642,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -5782,7 +5782,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -5863,7 +5863,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -5943,7 +5943,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -6116,7 +6116,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -6256,7 +6256,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -6337,7 +6337,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -6601,7 +6601,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -6710,7 +6710,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -6792,7 +6792,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -9040,7 +9040,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -9120,7 +9120,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -9200,7 +9200,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -9340,7 +9340,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {
@@ -9422,7 +9422,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -9502,7 +9502,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -11409,7 +11409,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -11489,7 +11489,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegStipulationType LegStipulationType
+                    public QuickFix.Fields.LegStipulationType LegStipulationType
                     { 
                         get 
                         {
@@ -11569,7 +11569,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -11709,7 +11709,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -11791,7 +11791,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.QuoteQualifier QuoteQualifier
+                public QuickFix.Fields.QuoteQualifier QuoteQualifier
                 { 
                     get 
                     {
@@ -11840,7 +11840,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TargetPartyID TargetPartyID
+                public QuickFix.Fields.TargetPartyID TargetPartyID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP2/QuoteStatusRequest.cs
+++ b/QuickFIXn/Message/FIX50SP2/QuoteStatusRequest.cs
@@ -3410,7 +3410,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3490,7 +3490,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -3663,7 +3663,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -3803,7 +3803,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -3884,7 +3884,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -4148,7 +4148,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -4257,7 +4257,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -4339,7 +4339,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -6587,7 +6587,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -6667,7 +6667,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -6747,7 +6747,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -6887,7 +6887,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {
@@ -6969,7 +6969,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -8659,7 +8659,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -8740,7 +8740,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -8880,7 +8880,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -8961,7 +8961,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TargetPartyID TargetPartyID
+                public QuickFix.Fields.TargetPartyID TargetPartyID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP2/RFQRequest.cs
+++ b/QuickFIXn/Message/FIX50SP2/RFQRequest.cs
@@ -192,7 +192,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -3153,7 +3153,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -3233,7 +3233,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -3406,7 +3406,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                     { 
                         get 
                         {
@@ -3546,7 +3546,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                        public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                         { 
                             get 
                             {
@@ -3627,7 +3627,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventType ComplexEventType
+                    public QuickFix.Fields.ComplexEventType ComplexEventType
                     { 
                         get 
                         {
@@ -3891,7 +3891,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                        public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                         { 
                             get 
                             {
@@ -4000,7 +4000,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                             { 
                                 get 
                                 {
@@ -4082,7 +4082,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                     { 
                         get 
                         {
@@ -6330,7 +6330,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                        public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                         { 
                             get 
                             {
@@ -6410,7 +6410,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                        public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                         { 
                             get 
                             {
@@ -6490,7 +6490,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                        public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                         { 
                             get 
                             {
@@ -6630,7 +6630,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                             { 
                                 get 
                                 {
@@ -6712,7 +6712,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSymbol LegSymbol
+                    public QuickFix.Fields.LegSymbol LegSymbol
                     { 
                         get 
                         {
@@ -8402,7 +8402,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                        public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                         { 
                             get 
                             {
@@ -8484,7 +8484,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -8624,7 +8624,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP2/RegistrationInstructions.cs
+++ b/QuickFIXn/Message/FIX50SP2/RegistrationInstructions.cs
@@ -413,7 +413,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -553,7 +553,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -634,7 +634,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RegistDtls RegistDtls
+                public QuickFix.Fields.RegistDtls RegistDtls
                 { 
                     get 
                     {
@@ -898,7 +898,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -1038,7 +1038,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -1120,7 +1120,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.DistribPaymentMethod DistribPaymentMethod
+                public QuickFix.Fields.DistribPaymentMethod DistribPaymentMethod
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP2/RegistrationInstructionsResponse.cs
+++ b/QuickFIXn/Message/FIX50SP2/RegistrationInstructionsResponse.cs
@@ -353,7 +353,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -493,7 +493,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP2/RequestForPositions.cs
+++ b/QuickFIXn/Message/FIX50SP2/RequestForPositions.cs
@@ -3453,7 +3453,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -3593,7 +3593,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -3674,7 +3674,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3754,7 +3754,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -3927,7 +3927,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -4067,7 +4067,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -4148,7 +4148,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -4412,7 +4412,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -4521,7 +4521,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -4603,7 +4603,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -6293,7 +6293,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -6374,7 +6374,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -8622,7 +8622,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -8702,7 +8702,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -8782,7 +8782,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -8922,7 +8922,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {
@@ -9004,7 +9004,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP2/RequestForPositionsAck.cs
+++ b/QuickFIXn/Message/FIX50SP2/RequestForPositionsAck.cs
@@ -3544,7 +3544,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -3684,7 +3684,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -3765,7 +3765,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3845,7 +3845,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -4018,7 +4018,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -4158,7 +4158,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -4239,7 +4239,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -4503,7 +4503,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -4612,7 +4612,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -4694,7 +4694,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -6384,7 +6384,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -6465,7 +6465,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -8713,7 +8713,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -8793,7 +8793,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -8873,7 +8873,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -9013,7 +9013,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50SP2/SecurityDefinition.cs
+++ b/QuickFIXn/Message/FIX50SP2/SecurityDefinition.cs
@@ -3875,7 +3875,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3955,7 +3955,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -4128,7 +4128,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -4268,7 +4268,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -4349,7 +4349,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -4613,7 +4613,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -4722,7 +4722,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -4804,7 +4804,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrAttribType InstrAttribType
+                public QuickFix.Fields.InstrAttribType InstrAttribType
                 { 
                     get 
                     {
@@ -4884,7 +4884,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -7132,7 +7132,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -7212,7 +7212,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -7292,7 +7292,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -7432,7 +7432,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {
@@ -7514,7 +7514,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -9204,7 +9204,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -9285,7 +9285,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -9365,7 +9365,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MarketID MarketID
+                public QuickFix.Fields.MarketID MarketID
                 { 
                     get 
                     {
@@ -10032,7 +10032,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StartTickPriceRange StartTickPriceRange
+                    public QuickFix.Fields.StartTickPriceRange StartTickPriceRange
                     { 
                         get 
                         {
@@ -10174,7 +10174,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LotType LotType
+                    public QuickFix.Fields.LotType LotType
                     { 
                         get 
                         {
@@ -10254,7 +10254,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.TradingSessionID TradingSessionID
+                    public QuickFix.Fields.TradingSessionID TradingSessionID
                     { 
                         get 
                         {
@@ -10487,7 +10487,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.OrdType OrdType
+                        public QuickFix.Fields.OrdType OrdType
                         { 
                             get 
                             {
@@ -10536,7 +10536,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.TimeInForce TimeInForce
+                        public QuickFix.Fields.TimeInForce TimeInForce
                         { 
                             get 
                             {
@@ -10585,7 +10585,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ExecInstValue ExecInstValue
+                        public QuickFix.Fields.ExecInstValue ExecInstValue
                         { 
                             get 
                             {
@@ -10634,7 +10634,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.MatchAlgorithm MatchAlgorithm
+                        public QuickFix.Fields.MatchAlgorithm MatchAlgorithm
                         { 
                             get 
                             {
@@ -10714,7 +10714,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.MDFeedType MDFeedType
+                        public QuickFix.Fields.MDFeedType MDFeedType
                         { 
                             get 
                             {
@@ -10826,7 +10826,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedInstrAttribType NestedInstrAttribType
+                    public QuickFix.Fields.NestedInstrAttribType NestedInstrAttribType
                     { 
                         get 
                         {
@@ -10906,7 +10906,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StrikeRuleID StrikeRuleID
+                    public QuickFix.Fields.StrikeRuleID StrikeRuleID
                     { 
                         get 
                         {
@@ -11108,7 +11108,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.MaturityRuleID MaturityRuleID
+                        public QuickFix.Fields.MaturityRuleID MaturityRuleID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50SP2/SecurityDefinitionRequest.cs
+++ b/QuickFIXn/Message/FIX50SP2/SecurityDefinitionRequest.cs
@@ -3759,7 +3759,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3839,7 +3839,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -4012,7 +4012,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -4152,7 +4152,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -4233,7 +4233,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -4497,7 +4497,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -4606,7 +4606,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -4688,7 +4688,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrAttribType InstrAttribType
+                public QuickFix.Fields.InstrAttribType InstrAttribType
                 { 
                     get 
                     {
@@ -4768,7 +4768,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -7016,7 +7016,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -7096,7 +7096,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -7176,7 +7176,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -7316,7 +7316,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {
@@ -7398,7 +7398,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -9088,7 +9088,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -9169,7 +9169,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP2/SecurityDefinitionUpdateReport.cs
+++ b/QuickFIXn/Message/FIX50SP2/SecurityDefinitionUpdateReport.cs
@@ -3906,7 +3906,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3986,7 +3986,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -4159,7 +4159,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -4299,7 +4299,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -4380,7 +4380,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -4644,7 +4644,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -4753,7 +4753,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -4835,7 +4835,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -7083,7 +7083,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -7163,7 +7163,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -7243,7 +7243,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -7383,7 +7383,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {
@@ -7465,7 +7465,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -9155,7 +9155,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -9236,7 +9236,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrAttribType InstrAttribType
+                public QuickFix.Fields.InstrAttribType InstrAttribType
                 { 
                     get 
                     {
@@ -9316,7 +9316,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.StipulationType StipulationType
+                public QuickFix.Fields.StipulationType StipulationType
                 { 
                     get 
                     {
@@ -9396,7 +9396,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.MarketID MarketID
+                public QuickFix.Fields.MarketID MarketID
                 { 
                     get 
                     {
@@ -10063,7 +10063,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StartTickPriceRange StartTickPriceRange
+                    public QuickFix.Fields.StartTickPriceRange StartTickPriceRange
                     { 
                         get 
                         {
@@ -10205,7 +10205,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LotType LotType
+                    public QuickFix.Fields.LotType LotType
                     { 
                         get 
                         {
@@ -10285,7 +10285,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.TradingSessionID TradingSessionID
+                    public QuickFix.Fields.TradingSessionID TradingSessionID
                     { 
                         get 
                         {
@@ -10518,7 +10518,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.OrdType OrdType
+                        public QuickFix.Fields.OrdType OrdType
                         { 
                             get 
                             {
@@ -10567,7 +10567,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.TimeInForce TimeInForce
+                        public QuickFix.Fields.TimeInForce TimeInForce
                         { 
                             get 
                             {
@@ -10616,7 +10616,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ExecInstValue ExecInstValue
+                        public QuickFix.Fields.ExecInstValue ExecInstValue
                         { 
                             get 
                             {
@@ -10665,7 +10665,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.MatchAlgorithm MatchAlgorithm
+                        public QuickFix.Fields.MatchAlgorithm MatchAlgorithm
                         { 
                             get 
                             {
@@ -10745,7 +10745,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.MDFeedType MDFeedType
+                        public QuickFix.Fields.MDFeedType MDFeedType
                         { 
                             get 
                             {
@@ -10857,7 +10857,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedInstrAttribType NestedInstrAttribType
+                    public QuickFix.Fields.NestedInstrAttribType NestedInstrAttribType
                     { 
                         get 
                         {
@@ -10937,7 +10937,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StrikeRuleID StrikeRuleID
+                    public QuickFix.Fields.StrikeRuleID StrikeRuleID
                     { 
                         get 
                         {
@@ -11139,7 +11139,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.MaturityRuleID MaturityRuleID
+                        public QuickFix.Fields.MaturityRuleID MaturityRuleID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50SP2/SecurityList.cs
+++ b/QuickFIXn/Message/FIX50SP2/SecurityList.cs
@@ -713,7 +713,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -5100,7 +5100,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -5180,7 +5180,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -5353,7 +5353,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                     { 
                         get 
                         {
@@ -5493,7 +5493,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                        public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                         { 
                             get 
                             {
@@ -5574,7 +5574,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventType ComplexEventType
+                    public QuickFix.Fields.ComplexEventType ComplexEventType
                     { 
                         get 
                         {
@@ -5838,7 +5838,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                        public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                         { 
                             get 
                             {
@@ -5947,7 +5947,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                             { 
                                 get 
                                 {
@@ -6029,7 +6029,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrAttribType InstrAttribType
+                    public QuickFix.Fields.InstrAttribType InstrAttribType
                     { 
                         get 
                         {
@@ -6109,7 +6109,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                     { 
                         get 
                         {
@@ -8357,7 +8357,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                        public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                         { 
                             get 
                             {
@@ -8437,7 +8437,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                        public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                         { 
                             get 
                             {
@@ -8517,7 +8517,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                        public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                         { 
                             get 
                             {
@@ -8657,7 +8657,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                             { 
                                 get 
                                 {
@@ -8739,7 +8739,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StipulationType StipulationType
+                    public QuickFix.Fields.StipulationType StipulationType
                     { 
                         get 
                         {
@@ -8819,7 +8819,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSymbol LegSymbol
+                    public QuickFix.Fields.LegSymbol LegSymbol
                     { 
                         get 
                         {
@@ -10757,7 +10757,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                        public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                         { 
                             get 
                             {
@@ -10837,7 +10837,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegStipulationType LegStipulationType
+                        public QuickFix.Fields.LegStipulationType LegStipulationType
                         { 
                             get 
                             {
@@ -10918,7 +10918,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StartTickPriceRange StartTickPriceRange
+                    public QuickFix.Fields.StartTickPriceRange StartTickPriceRange
                     { 
                         get 
                         {
@@ -11060,7 +11060,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LotType LotType
+                    public QuickFix.Fields.LotType LotType
                     { 
                         get 
                         {
@@ -11140,7 +11140,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.TradingSessionID TradingSessionID
+                    public QuickFix.Fields.TradingSessionID TradingSessionID
                     { 
                         get 
                         {
@@ -11373,7 +11373,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.OrdType OrdType
+                        public QuickFix.Fields.OrdType OrdType
                         { 
                             get 
                             {
@@ -11422,7 +11422,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.TimeInForce TimeInForce
+                        public QuickFix.Fields.TimeInForce TimeInForce
                         { 
                             get 
                             {
@@ -11471,7 +11471,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ExecInstValue ExecInstValue
+                        public QuickFix.Fields.ExecInstValue ExecInstValue
                         { 
                             get 
                             {
@@ -11520,7 +11520,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.MatchAlgorithm MatchAlgorithm
+                        public QuickFix.Fields.MatchAlgorithm MatchAlgorithm
                         { 
                             get 
                             {
@@ -11600,7 +11600,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.MDFeedType MDFeedType
+                        public QuickFix.Fields.MDFeedType MDFeedType
                         { 
                             get 
                             {
@@ -11712,7 +11712,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedInstrAttribType NestedInstrAttribType
+                    public QuickFix.Fields.NestedInstrAttribType NestedInstrAttribType
                     { 
                         get 
                         {
@@ -11792,7 +11792,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StrikeRuleID StrikeRuleID
+                    public QuickFix.Fields.StrikeRuleID StrikeRuleID
                     { 
                         get 
                         {
@@ -11994,7 +11994,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.MaturityRuleID MaturityRuleID
+                        public QuickFix.Fields.MaturityRuleID MaturityRuleID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50SP2/SecurityListRequest.cs
+++ b/QuickFIXn/Message/FIX50SP2/SecurityListRequest.cs
@@ -3635,7 +3635,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3715,7 +3715,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -3888,7 +3888,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -4028,7 +4028,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -4109,7 +4109,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -4373,7 +4373,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -4482,7 +4482,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -4564,7 +4564,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrAttribType InstrAttribType
+                public QuickFix.Fields.InstrAttribType InstrAttribType
                 { 
                     get 
                     {
@@ -4644,7 +4644,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -6892,7 +6892,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -6972,7 +6972,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -7052,7 +7052,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -7192,7 +7192,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {
@@ -7274,7 +7274,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -8964,7 +8964,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP2/SecurityListUpdateReport.cs
+++ b/QuickFIXn/Message/FIX50SP2/SecurityListUpdateReport.cs
@@ -775,7 +775,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Symbol Symbol
+                public QuickFix.Fields.Symbol Symbol
                 { 
                     get 
                     {
@@ -5193,7 +5193,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -5273,7 +5273,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -5446,7 +5446,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                     { 
                         get 
                         {
@@ -5586,7 +5586,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                        public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                         { 
                             get 
                             {
@@ -5667,7 +5667,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventType ComplexEventType
+                    public QuickFix.Fields.ComplexEventType ComplexEventType
                     { 
                         get 
                         {
@@ -5931,7 +5931,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                        public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                         { 
                             get 
                             {
@@ -6040,7 +6040,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                             { 
                                 get 
                                 {
@@ -6122,7 +6122,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrAttribType InstrAttribType
+                    public QuickFix.Fields.InstrAttribType InstrAttribType
                     { 
                         get 
                         {
@@ -6202,7 +6202,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSymbol LegSymbol
+                    public QuickFix.Fields.LegSymbol LegSymbol
                     { 
                         get 
                         {
@@ -8140,7 +8140,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                        public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                         { 
                             get 
                             {
@@ -8220,7 +8220,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.LegStipulationType LegStipulationType
+                        public QuickFix.Fields.LegStipulationType LegStipulationType
                         { 
                             get 
                             {
@@ -8301,7 +8301,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                    public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                     { 
                         get 
                         {
@@ -10549,7 +10549,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                        public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                         { 
                             get 
                             {
@@ -10629,7 +10629,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                        public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                         { 
                             get 
                             {
@@ -10709,7 +10709,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                        public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                         { 
                             get 
                             {
@@ -10849,7 +10849,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                             { 
                                 get 
                                 {
@@ -10931,7 +10931,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StipulationType StipulationType
+                    public QuickFix.Fields.StipulationType StipulationType
                     { 
                         get 
                         {
@@ -11011,7 +11011,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StartTickPriceRange StartTickPriceRange
+                    public QuickFix.Fields.StartTickPriceRange StartTickPriceRange
                     { 
                         get 
                         {
@@ -11153,7 +11153,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LotType LotType
+                    public QuickFix.Fields.LotType LotType
                     { 
                         get 
                         {
@@ -11233,7 +11233,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.TradingSessionID TradingSessionID
+                    public QuickFix.Fields.TradingSessionID TradingSessionID
                     { 
                         get 
                         {
@@ -11466,7 +11466,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.OrdType OrdType
+                        public QuickFix.Fields.OrdType OrdType
                         { 
                             get 
                             {
@@ -11515,7 +11515,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.TimeInForce TimeInForce
+                        public QuickFix.Fields.TimeInForce TimeInForce
                         { 
                             get 
                             {
@@ -11564,7 +11564,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ExecInstValue ExecInstValue
+                        public QuickFix.Fields.ExecInstValue ExecInstValue
                         { 
                             get 
                             {
@@ -11613,7 +11613,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.MatchAlgorithm MatchAlgorithm
+                        public QuickFix.Fields.MatchAlgorithm MatchAlgorithm
                         { 
                             get 
                             {
@@ -11693,7 +11693,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.MDFeedType MDFeedType
+                        public QuickFix.Fields.MDFeedType MDFeedType
                         { 
                             get 
                             {
@@ -11805,7 +11805,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedInstrAttribType NestedInstrAttribType
+                    public QuickFix.Fields.NestedInstrAttribType NestedInstrAttribType
                     { 
                         get 
                         {
@@ -11885,7 +11885,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StrikeRuleID StrikeRuleID
+                    public QuickFix.Fields.StrikeRuleID StrikeRuleID
                     { 
                         get 
                         {
@@ -12087,7 +12087,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.MaturityRuleID MaturityRuleID
+                        public QuickFix.Fields.MaturityRuleID MaturityRuleID
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50SP2/SecurityStatus.cs
+++ b/QuickFIXn/Message/FIX50SP2/SecurityStatus.cs
@@ -3875,7 +3875,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3955,7 +3955,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -4128,7 +4128,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -4268,7 +4268,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -4349,7 +4349,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -4613,7 +4613,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -4722,7 +4722,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -4804,7 +4804,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrAttribType InstrAttribType
+                public QuickFix.Fields.InstrAttribType InstrAttribType
                 { 
                     get 
                     {
@@ -4884,7 +4884,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -7132,7 +7132,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -7212,7 +7212,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -7292,7 +7292,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -7432,7 +7432,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {
@@ -7514,7 +7514,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -9204,7 +9204,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP2/SecurityStatusRequest.cs
+++ b/QuickFIXn/Message/FIX50SP2/SecurityStatusRequest.cs
@@ -3139,7 +3139,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3219,7 +3219,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -3392,7 +3392,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -3532,7 +3532,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -3613,7 +3613,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -3877,7 +3877,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -3986,7 +3986,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -4068,7 +4068,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrAttribType InstrAttribType
+                public QuickFix.Fields.InstrAttribType InstrAttribType
                 { 
                     get 
                     {
@@ -4148,7 +4148,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -6396,7 +6396,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -6476,7 +6476,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -6556,7 +6556,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -6696,7 +6696,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {
@@ -6778,7 +6778,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -8468,7 +8468,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP2/SecurityTypeRequest.cs
+++ b/QuickFIXn/Message/FIX50SP2/SecurityTypeRequest.cs
@@ -362,7 +362,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.MarketSegmentID);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX50SP2/SecurityTypes.cs
+++ b/QuickFIXn/Message/FIX50SP2/SecurityTypes.cs
@@ -599,7 +599,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityType SecurityType
+                public QuickFix.Fields.SecurityType SecurityType
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP2/SettlementInstructionRequest.cs
+++ b/QuickFIXn/Message/FIX50SP2/SettlementInstructionRequest.cs
@@ -535,7 +535,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -675,7 +675,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP2/SettlementInstructions.cs
+++ b/QuickFIXn/Message/FIX50SP2/SettlementInstructions.cs
@@ -351,7 +351,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SettlInstID SettlInstID
+                public QuickFix.Fields.SettlInstID SettlInstID
                 { 
                     get 
                     {
@@ -1173,7 +1173,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -1313,7 +1313,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.PartySubID PartySubID
+                        public QuickFix.Fields.PartySubID PartySubID
                         { 
                             get 
                             {
@@ -1394,7 +1394,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SettlInstSource SettlInstSource
+                    public QuickFix.Fields.SettlInstSource SettlInstSource
                     { 
                         get 
                         {
@@ -1503,7 +1503,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SettlPartyID SettlPartyID
+                        public QuickFix.Fields.SettlPartyID SettlPartyID
                         { 
                             get 
                             {
@@ -1643,7 +1643,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.SettlPartySubID SettlPartySubID
+                            public QuickFix.Fields.SettlPartySubID SettlPartySubID
                             { 
                                 get 
                                 {

--- a/QuickFIXn/Message/FIX50SP2/SettlementObligationReport.cs
+++ b/QuickFIXn/Message/FIX50SP2/SettlementObligationReport.cs
@@ -442,7 +442,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.NetGrossInd NetGrossInd
+                public QuickFix.Fields.NetGrossInd NetGrossInd
                 { 
                     get 
                     {
@@ -3651,7 +3651,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SecurityAltID SecurityAltID
+                    public QuickFix.Fields.SecurityAltID SecurityAltID
                     { 
                         get 
                         {
@@ -3731,7 +3731,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.EventType EventType
+                    public QuickFix.Fields.EventType EventType
                     { 
                         get 
                         {
@@ -3904,7 +3904,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                    public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                     { 
                         get 
                         {
@@ -4044,7 +4044,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                        public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                         { 
                             get 
                             {
@@ -4125,7 +4125,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventType ComplexEventType
+                    public QuickFix.Fields.ComplexEventType ComplexEventType
                     { 
                         get 
                         {
@@ -4389,7 +4389,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                        public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                         { 
                             get 
                             {
@@ -4498,7 +4498,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                             { 
                                 get 
                                 {
@@ -4580,7 +4580,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -4720,7 +4720,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.PartySubID PartySubID
+                        public QuickFix.Fields.PartySubID PartySubID
                         { 
                             get 
                             {
@@ -4801,7 +4801,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SettlObligSource SettlObligSource
+                    public QuickFix.Fields.SettlObligSource SettlObligSource
                     { 
                         get 
                         {
@@ -4879,7 +4879,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SettlPartyID SettlPartyID
+                        public QuickFix.Fields.SettlPartyID SettlPartyID
                         { 
                             get 
                             {
@@ -5019,7 +5019,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.SettlPartySubID SettlPartySubID
+                            public QuickFix.Fields.SettlPartySubID SettlPartySubID
                             { 
                                 get 
                                 {

--- a/QuickFIXn/Message/FIX50SP2/StreamAssignmentReport.cs
+++ b/QuickFIXn/Message/FIX50SP2/StreamAssignmentReport.cs
@@ -161,7 +161,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.NoPartyIDs NoPartyIDs
+                public QuickFix.Fields.NoPartyIDs NoPartyIDs
                 { 
                     get 
                     {
@@ -239,7 +239,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -379,7 +379,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.PartySubID PartySubID
+                        public QuickFix.Fields.PartySubID PartySubID
                         { 
                             get 
                             {
@@ -460,7 +460,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.Symbol Symbol
+                    public QuickFix.Fields.Symbol Symbol
                     { 
                         get 
                         {
@@ -3421,7 +3421,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                        public QuickFix.Fields.SecurityAltID SecurityAltID
                         { 
                             get 
                             {
@@ -3501,7 +3501,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.EventType EventType
+                        public QuickFix.Fields.EventType EventType
                         { 
                             get 
                             {
@@ -3674,7 +3674,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                        public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                         { 
                             get 
                             {
@@ -3814,7 +3814,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                             { 
                                 get 
                                 {
@@ -3895,7 +3895,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                        public QuickFix.Fields.ComplexEventType ComplexEventType
                         { 
                             get 
                             {
@@ -4159,7 +4159,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                            public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                             { 
                                 get 
                                 {
@@ -4268,7 +4268,7 @@ namespace QuickFix
                                     return clone;
                                 }
                             
-                                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                                public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                                 { 
                                     get 
                                     {

--- a/QuickFIXn/Message/FIX50SP2/StreamAssignmentReportACK.cs
+++ b/QuickFIXn/Message/FIX50SP2/StreamAssignmentReportACK.cs
@@ -209,7 +209,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EncodedText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX50SP2/StreamAssignmentRequest.cs
+++ b/QuickFIXn/Message/FIX50SP2/StreamAssignmentRequest.cs
@@ -132,7 +132,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.NoPartyIDs NoPartyIDs
+                public QuickFix.Fields.NoPartyIDs NoPartyIDs
                 { 
                     get 
                     {
@@ -210,7 +210,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -350,7 +350,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.PartySubID PartySubID
+                        public QuickFix.Fields.PartySubID PartySubID
                         { 
                             get 
                             {
@@ -431,7 +431,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.Symbol Symbol
+                    public QuickFix.Fields.Symbol Symbol
                     { 
                         get 
                         {
@@ -3268,7 +3268,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                        public QuickFix.Fields.SecurityAltID SecurityAltID
                         { 
                             get 
                             {
@@ -3348,7 +3348,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.EventType EventType
+                        public QuickFix.Fields.EventType EventType
                         { 
                             get 
                             {
@@ -3521,7 +3521,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                        public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                         { 
                             get 
                             {
@@ -3661,7 +3661,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                            public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                             { 
                                 get 
                                 {
@@ -3742,7 +3742,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                        public QuickFix.Fields.ComplexEventType ComplexEventType
                         { 
                             get 
                             {
@@ -4006,7 +4006,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                            public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                             { 
                                 get 
                                 {
@@ -4115,7 +4115,7 @@ namespace QuickFix
                                     return clone;
                                 }
                             
-                                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                                public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                                 { 
                                     get 
                                     {

--- a/QuickFIXn/Message/FIX50SP2/TradeCaptureReport.cs
+++ b/QuickFIXn/Message/FIX50SP2/TradeCaptureReport.cs
@@ -6332,7 +6332,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -6412,7 +6412,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -6585,7 +6585,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -6725,7 +6725,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -6806,7 +6806,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -7070,7 +7070,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -7179,7 +7179,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -7261,7 +7261,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -9509,7 +9509,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -9589,7 +9589,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -9669,7 +9669,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -9809,7 +9809,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {
@@ -9891,7 +9891,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosAmtType PosAmtType
+                public QuickFix.Fields.PosAmtType PosAmtType
                 { 
                     get 
                     {
@@ -10002,7 +10002,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -12374,7 +12374,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -12454,7 +12454,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegStipulationType LegStipulationType
+                    public QuickFix.Fields.LegStipulationType LegStipulationType
                     { 
                         get 
                         {
@@ -12534,7 +12534,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -12674,7 +12674,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -12755,7 +12755,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingLegSymbol UnderlyingLegSymbol
+                    public QuickFix.Fields.UnderlyingLegSymbol UnderlyingLegSymbol
                     { 
                         get 
                         {
@@ -13267,7 +13267,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingLegSecurityAltID UnderlyingLegSecurityAltID
+                        public QuickFix.Fields.UnderlyingLegSecurityAltID UnderlyingLegSecurityAltID
                         { 
                             get 
                             {
@@ -13349,7 +13349,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
+                public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
                 { 
                     get 
                     {
@@ -13553,7 +13553,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Side Side
+                public QuickFix.Fields.Side Side
                 { 
                     get 
                     {
@@ -16793,7 +16793,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -16933,7 +16933,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.PartySubID PartySubID
+                        public QuickFix.Fields.PartySubID PartySubID
                         { 
                             get 
                             {
@@ -17014,7 +17014,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ClearingInstruction ClearingInstruction
+                    public QuickFix.Fields.ClearingInstruction ClearingInstruction
                     { 
                         get 
                         {
@@ -17063,7 +17063,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ContAmtType ContAmtType
+                    public QuickFix.Fields.ContAmtType ContAmtType
                     { 
                         get 
                         {
@@ -17174,7 +17174,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StipulationType StipulationType
+                    public QuickFix.Fields.StipulationType StipulationType
                     { 
                         get 
                         {
@@ -17254,7 +17254,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
+                    public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
                     { 
                         get 
                         {
@@ -17396,7 +17396,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.AllocAccount AllocAccount
+                    public QuickFix.Fields.AllocAccount AllocAccount
                     { 
                         get 
                         {
@@ -17722,7 +17722,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested2PartyID Nested2PartyID
+                        public QuickFix.Fields.Nested2PartyID Nested2PartyID
                         { 
                             get 
                             {
@@ -17862,7 +17862,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
+                            public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
                             { 
                                 get 
                                 {
@@ -17944,7 +17944,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SideTrdRegTimestamp SideTrdRegTimestamp
+                    public QuickFix.Fields.SideTrdRegTimestamp SideTrdRegTimestamp
                     { 
                         get 
                         {
@@ -18055,7 +18055,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SettlObligSource SettlObligSource
+                    public QuickFix.Fields.SettlObligSource SettlObligSource
                     { 
                         get 
                         {
@@ -18133,7 +18133,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SettlPartyID SettlPartyID
+                        public QuickFix.Fields.SettlPartyID SettlPartyID
                         { 
                             get 
                             {
@@ -18273,7 +18273,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.SettlPartySubID SettlPartySubID
+                            public QuickFix.Fields.SettlPartySubID SettlPartySubID
                             { 
                                 get 
                                 {
@@ -18356,7 +18356,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RootPartyID RootPartyID
+                public QuickFix.Fields.RootPartyID RootPartyID
                 { 
                     get 
                     {
@@ -18496,7 +18496,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.RootPartySubID RootPartySubID
+                    public QuickFix.Fields.RootPartySubID RootPartySubID
                     { 
                         get 
                         {
@@ -18577,7 +18577,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TrdRepPartyRole TrdRepPartyRole
+                public QuickFix.Fields.TrdRepPartyRole TrdRepPartyRole
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP2/TradeCaptureReportAck.cs
+++ b/QuickFIXn/Message/FIX50SP2/TradeCaptureReportAck.cs
@@ -5363,7 +5363,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -5443,7 +5443,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -5616,7 +5616,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -5756,7 +5756,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -5837,7 +5837,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -6101,7 +6101,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -6210,7 +6210,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -6292,7 +6292,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
+                public QuickFix.Fields.TrdRegTimestamp TrdRegTimestamp
                 { 
                     get 
                     {
@@ -6496,7 +6496,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -8868,7 +8868,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -8948,7 +8948,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegStipulationType LegStipulationType
+                    public QuickFix.Fields.LegStipulationType LegStipulationType
                     { 
                         get 
                         {
@@ -9028,7 +9028,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.NestedPartyID NestedPartyID
+                    public QuickFix.Fields.NestedPartyID NestedPartyID
                     { 
                         get 
                         {
@@ -9168,7 +9168,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.NestedPartySubID NestedPartySubID
+                        public QuickFix.Fields.NestedPartySubID NestedPartySubID
                         { 
                             get 
                             {
@@ -9249,7 +9249,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingLegSymbol UnderlyingLegSymbol
+                    public QuickFix.Fields.UnderlyingLegSymbol UnderlyingLegSymbol
                     { 
                         get 
                         {
@@ -9761,7 +9761,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingLegSecurityAltID UnderlyingLegSecurityAltID
+                        public QuickFix.Fields.UnderlyingLegSecurityAltID UnderlyingLegSecurityAltID
                         { 
                             get 
                             {
@@ -9843,7 +9843,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PosAmtType PosAmtType
+                public QuickFix.Fields.PosAmtType PosAmtType
                 { 
                     get 
                     {
@@ -9954,7 +9954,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.Side Side
+                public QuickFix.Fields.Side Side
                 { 
                     get 
                     {
@@ -13039,7 +13039,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartyID PartyID
+                    public QuickFix.Fields.PartyID PartyID
                     { 
                         get 
                         {
@@ -13179,7 +13179,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.PartySubID PartySubID
+                        public QuickFix.Fields.PartySubID PartySubID
                         { 
                             get 
                             {
@@ -13260,7 +13260,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ClearingInstruction ClearingInstruction
+                    public QuickFix.Fields.ClearingInstruction ClearingInstruction
                     { 
                         get 
                         {
@@ -13309,7 +13309,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ContAmtType ContAmtType
+                    public QuickFix.Fields.ContAmtType ContAmtType
                     { 
                         get 
                         {
@@ -13420,7 +13420,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.StipulationType StipulationType
+                    public QuickFix.Fields.StipulationType StipulationType
                     { 
                         get 
                         {
@@ -13500,7 +13500,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
+                    public QuickFix.Fields.MiscFeeAmt MiscFeeAmt
                     { 
                         get 
                         {
@@ -13642,7 +13642,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.AllocAccount AllocAccount
+                    public QuickFix.Fields.AllocAccount AllocAccount
                     { 
                         get 
                         {
@@ -13968,7 +13968,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.Nested2PartyID Nested2PartyID
+                        public QuickFix.Fields.Nested2PartyID Nested2PartyID
                         { 
                             get 
                             {
@@ -14108,7 +14108,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
+                            public QuickFix.Fields.Nested2PartySubID Nested2PartySubID
                             { 
                                 get 
                                 {
@@ -14190,7 +14190,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SideTrdRegTimestamp SideTrdRegTimestamp
+                    public QuickFix.Fields.SideTrdRegTimestamp SideTrdRegTimestamp
                     { 
                         get 
                         {
@@ -14301,7 +14301,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.SettlObligSource SettlObligSource
+                    public QuickFix.Fields.SettlObligSource SettlObligSource
                     { 
                         get 
                         {
@@ -14379,7 +14379,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.SettlPartyID SettlPartyID
+                        public QuickFix.Fields.SettlPartyID SettlPartyID
                         { 
                             get 
                             {
@@ -14519,7 +14519,7 @@ namespace QuickFix
                                 return clone;
                             }
                         
-                                                    public QuickFix.Fields.SettlPartySubID SettlPartySubID
+                            public QuickFix.Fields.SettlPartySubID SettlPartySubID
                             { 
                                 get 
                                 {
@@ -14602,7 +14602,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.RootPartyID RootPartyID
+                public QuickFix.Fields.RootPartyID RootPartyID
                 { 
                     get 
                     {
@@ -14742,7 +14742,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.RootPartySubID RootPartySubID
+                    public QuickFix.Fields.RootPartySubID RootPartySubID
                     { 
                         get 
                         {
@@ -14823,7 +14823,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -17071,7 +17071,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -17151,7 +17151,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -17231,7 +17231,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -17371,7 +17371,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {
@@ -17453,7 +17453,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TrdRepPartyRole TrdRepPartyRole
+                public QuickFix.Fields.TrdRepPartyRole TrdRepPartyRole
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP2/TradeCaptureReportRequest.cs
+++ b/QuickFIXn/Message/FIX50SP2/TradeCaptureReportRequest.cs
@@ -4348,7 +4348,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.PartyID PartyID
+                public QuickFix.Fields.PartyID PartyID
                 { 
                     get 
                     {
@@ -4488,7 +4488,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.PartySubID PartySubID
+                    public QuickFix.Fields.PartySubID PartySubID
                     { 
                         get 
                         {
@@ -4569,7 +4569,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -4649,7 +4649,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -4822,7 +4822,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -4962,7 +4962,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -5043,7 +5043,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -5307,7 +5307,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -5416,7 +5416,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -5498,7 +5498,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrAttribType InstrAttribType
+                public QuickFix.Fields.InstrAttribType InstrAttribType
                 { 
                     get 
                     {
@@ -5578,7 +5578,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -7826,7 +7826,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -7906,7 +7906,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -7986,7 +7986,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -8126,7 +8126,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {
@@ -8208,7 +8208,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -9898,7 +9898,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {
@@ -9979,7 +9979,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradeDate TradeDate
+                public QuickFix.Fields.TradeDate TradeDate
                 { 
                     get 
                     {

--- a/QuickFIXn/Message/FIX50SP2/TradeCaptureReportRequestAck.cs
+++ b/QuickFIXn/Message/FIX50SP2/TradeCaptureReportRequestAck.cs
@@ -3360,7 +3360,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3440,7 +3440,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -3613,7 +3613,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -3753,7 +3753,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -3834,7 +3834,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -4098,7 +4098,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -4207,7 +4207,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {
@@ -4289,7 +4289,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
+                public QuickFix.Fields.UnderlyingSymbol UnderlyingSymbol
                 { 
                     get 
                     {
@@ -6537,7 +6537,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
+                    public QuickFix.Fields.UnderlyingSecurityAltID UnderlyingSecurityAltID
                     { 
                         get 
                         {
@@ -6617,7 +6617,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
+                    public QuickFix.Fields.UnderlyingStipType UnderlyingStipType
                     { 
                         get 
                         {
@@ -6697,7 +6697,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
+                    public QuickFix.Fields.UnderlyingInstrumentPartyID UnderlyingInstrumentPartyID
                     { 
                         get 
                         {
@@ -6837,7 +6837,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
+                        public QuickFix.Fields.UnderlyingInstrumentPartySubID UnderlyingInstrumentPartySubID
                         { 
                             get 
                             {
@@ -6919,7 +6919,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.LegSymbol LegSymbol
+                public QuickFix.Fields.LegSymbol LegSymbol
                 { 
                     get 
                     {
@@ -8609,7 +8609,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
+                    public QuickFix.Fields.LegSecurityAltID LegSecurityAltID
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP2/TradingSessionList.cs
+++ b/QuickFIXn/Message/FIX50SP2/TradingSessionList.cs
@@ -217,7 +217,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {
@@ -1070,7 +1070,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.OrdType OrdType
+                    public QuickFix.Fields.OrdType OrdType
                     { 
                         get 
                         {
@@ -1119,7 +1119,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.TimeInForce TimeInForce
+                    public QuickFix.Fields.TimeInForce TimeInForce
                     { 
                         get 
                         {
@@ -1168,7 +1168,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ExecInstValue ExecInstValue
+                    public QuickFix.Fields.ExecInstValue ExecInstValue
                     { 
                         get 
                         {
@@ -1217,7 +1217,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.MatchAlgorithm MatchAlgorithm
+                    public QuickFix.Fields.MatchAlgorithm MatchAlgorithm
                     { 
                         get 
                         {
@@ -1297,7 +1297,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.MDFeedType MDFeedType
+                    public QuickFix.Fields.MDFeedType MDFeedType
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP2/TradingSessionListRequest.cs
+++ b/QuickFIXn/Message/FIX50SP2/TradingSessionListRequest.cs
@@ -302,7 +302,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.MarketSegmentID);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX50SP2/TradingSessionListUpdateReport.cs
+++ b/QuickFIXn/Message/FIX50SP2/TradingSessionListUpdateReport.cs
@@ -217,7 +217,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.TradingSessionID TradingSessionID
+                public QuickFix.Fields.TradingSessionID TradingSessionID
                 { 
                     get 
                     {
@@ -1070,7 +1070,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.OrdType OrdType
+                    public QuickFix.Fields.OrdType OrdType
                     { 
                         get 
                         {
@@ -1119,7 +1119,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.TimeInForce TimeInForce
+                    public QuickFix.Fields.TimeInForce TimeInForce
                     { 
                         get 
                         {
@@ -1168,7 +1168,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ExecInstValue ExecInstValue
+                    public QuickFix.Fields.ExecInstValue ExecInstValue
                     { 
                         get 
                         {
@@ -1217,7 +1217,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.MatchAlgorithm MatchAlgorithm
+                    public QuickFix.Fields.MatchAlgorithm MatchAlgorithm
                     { 
                         get 
                         {
@@ -1297,7 +1297,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.MDFeedType MDFeedType
+                    public QuickFix.Fields.MDFeedType MDFeedType
                     { 
                         get 
                         {

--- a/QuickFIXn/Message/FIX50SP2/TradingSessionStatus.cs
+++ b/QuickFIXn/Message/FIX50SP2/TradingSessionStatus.cs
@@ -3511,7 +3511,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.SecurityAltID SecurityAltID
+                public QuickFix.Fields.SecurityAltID SecurityAltID
                 { 
                     get 
                     {
@@ -3591,7 +3591,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.EventType EventType
+                public QuickFix.Fields.EventType EventType
                 { 
                     get 
                     {
@@ -3764,7 +3764,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
+                public QuickFix.Fields.InstrumentPartyID InstrumentPartyID
                 { 
                     get 
                     {
@@ -3904,7 +3904,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
+                    public QuickFix.Fields.InstrumentPartySubID InstrumentPartySubID
                     { 
                         get 
                         {
@@ -3985,7 +3985,7 @@ namespace QuickFix
                     return clone;
                 }
             
-                            public QuickFix.Fields.ComplexEventType ComplexEventType
+                public QuickFix.Fields.ComplexEventType ComplexEventType
                 { 
                     get 
                     {
@@ -4249,7 +4249,7 @@ namespace QuickFix
                         return clone;
                     }
                 
-                                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
+                    public QuickFix.Fields.ComplexEventStartDate ComplexEventStartDate
                     { 
                         get 
                         {
@@ -4358,7 +4358,7 @@ namespace QuickFix
                             return clone;
                         }
                     
-                                            public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
+                        public QuickFix.Fields.ComplexEventStartTime ComplexEventStartTime
                         { 
                             get 
                             {

--- a/QuickFIXn/Message/FIX50SP2/TradingSessionStatusRequest.cs
+++ b/QuickFIXn/Message/FIX50SP2/TradingSessionStatusRequest.cs
@@ -302,7 +302,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.MarketSegmentID);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX50SP2/UserNotification.cs
+++ b/QuickFIXn/Message/FIX50SP2/UserNotification.cs
@@ -176,7 +176,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EncodedText);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX50SP2/UserRequest.cs
+++ b/QuickFIXn/Message/FIX50SP2/UserRequest.cs
@@ -397,7 +397,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.EncryptedNewPassword);
             }
-
         }
     }
 }

--- a/QuickFIXn/Message/FIX50SP2/UserResponse.cs
+++ b/QuickFIXn/Message/FIX50SP2/UserResponse.cs
@@ -147,7 +147,6 @@ namespace QuickFix
             { 
                 return IsSetField(Tags.UserStatusText);
             }
-
         }
     }
 }

--- a/generator/messages_gen.rb
+++ b/generator/messages_gen.rb
@@ -46,7 +46,7 @@ HERE
   end
 
   def self.gen_msg msg, fixver 
-<<HERE
+    s = <<HERE
 // This is a generated file.  Don't edit it directly!
 
 using QuickFix.Fields;
@@ -60,11 +60,19 @@ namespace QuickFix
 #{ctor(msg)}
 #{ctor_req(msg)}
 #{gen_msg_fields(msg[:fields], 12)}
-#{gen_msg_groups(msg[:groups], 12)}
+HERE
+
+    if msg[:groups].length > 0
+      s << gen_msg_groups(msg[:groups], 12)
+      s << "\n"
+    end
+
+    s += <<HERE2
         }
     }
 }
-HERE
+HERE2
+    s
   end
 
   def self.msgtype msg

--- a/generator/messages_gen.rb
+++ b/generator/messages_gen.rb
@@ -166,6 +166,7 @@ HERE
     str << "    }"
     str << ""
     str << gen_msg_fields(grp[:fields], prepend_spaces+4)
+    str.last.lstrip!.prepend(' '*4) # hack to remove accidental extra whitespace on first line of that string
     str << gen_msg_groups(grp[:groups], prepend_spaces+4)
     str << "}"
     str.map {|s| ' '*prepend_spaces + s}.join("\n")


### PR DESCRIPTION
Remove:

1) extra leading whitespace from message field declarations that are within repeating groups.  (The generator was double-applying some indentation on the first line of a fields code section.)

2) a superfluous newlines that appear at the end of message classes message types that don't contain any repeating groups.