### PR TITLE
Fix Message load error within a Linux-based Docker container

### DIFF
--- a/QuickFIXn/Message/Message.cs
+++ b/QuickFIXn/Message/Message.cs
@@ -126,7 +126,7 @@ namespace QuickFix
                 int tagend = msgstr.IndexOf("=", pos);
                 int tag = Convert.ToInt32(msgstr.Substring(pos, tagend - pos));
                 pos = tagend + 1;
-                int fieldvalend = msgstr.IndexOf("\u0001", pos);
+                int fieldvalend = msgstr.IndexOf((char)1, pos);
                 StringField field =  new StringField(tag, msgstr.Substring(pos, fieldvalend - pos));
 
                 /** TODO data dict stuff


### PR DESCRIPTION
Fix for FormatException: "Input string was not in a correct format error" in ExtractField when loading a Message within a Linux-based Docker container.