### PR TITLE
Fix "cannot convert from 'QuickFix.Fields.Converters.TimeStampPrecision' to bool" error

### DIFF
--- a/QuickFIXn/Fields/Fields.cs
+++ b/QuickFIXn/Fields/Fields.cs
@@ -1,7 +1,6 @@
 // This is a generated file.  Don't edit it directly!
-
-using System;
 using QuickFix.Fields.Converters;
+using System;
 
 namespace QuickFix.Fields
 {
@@ -954,7 +953,9 @@ namespace QuickFix.Fields
         public OrigTime(DateTime val)
             :base(Tags.OrigTime, val) {}
         public OrigTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.OrigTime, val, showMilliseconds) {}
+			:base(Tags.OrigTime, val, showMilliseconds) {}
+        public OrigTime(DateTime val, TimeStampPrecision timeStampPrecision)
+			:base(Tags.OrigTime, val, timeStampPrecision) {}
 
     }
 
@@ -1131,9 +1132,9 @@ namespace QuickFix.Fields
         public SendingTime(DateTime val)
             :base(Tags.SendingTime, val) {}
         public SendingTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.SendingTime, val, showMilliseconds) {}
-
-        public SendingTime( DateTime val, TimeStampPrecision timestampPrecision) : base( Tags.SendingTime, val, timestampPrecision) { }
+			:base(Tags.SendingTime, val, showMilliseconds) {}
+        public SendingTime(DateTime val, TimeStampPrecision timeStampPrecision)
+			:base(Tags.SendingTime, val, timeStampPrecision) {}
 
     }
 
@@ -1271,7 +1272,9 @@ namespace QuickFix.Fields
         public TransactTime(DateTime val)
             :base(Tags.TransactTime, val) {}
         public TransactTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.TransactTime, val, showMilliseconds) {}
+			:base(Tags.TransactTime, val, showMilliseconds) {}
+        public TransactTime(DateTime val, TimeStampPrecision timeStampPrecision)
+			:base(Tags.TransactTime, val, timeStampPrecision) {}
 
     }
 
@@ -1304,7 +1307,9 @@ namespace QuickFix.Fields
         public ValidUntilTime(DateTime val)
             :base(Tags.ValidUntilTime, val) {}
         public ValidUntilTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.ValidUntilTime, val, showMilliseconds) {}
+			:base(Tags.ValidUntilTime, val, showMilliseconds) {}
+        public ValidUntilTime(DateTime val, TimeStampPrecision timeStampPrecision)
+			:base(Tags.ValidUntilTime, val, timeStampPrecision) {}
 
     }
 
@@ -2268,10 +2273,10 @@ namespace QuickFix.Fields
         public OrigSendingTime(DateTime val)
             :base(Tags.OrigSendingTime, val) {}
         public OrigSendingTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.OrigSendingTime, val, showMilliseconds) {}
+			:base(Tags.OrigSendingTime, val, showMilliseconds) {}
+        public OrigSendingTime(DateTime val, TimeStampPrecision timeStampPrecision)
+			:base(Tags.OrigSendingTime, val, timeStampPrecision) {}
 
-        public OrigSendingTime(DateTime val, TimeStampPrecision timeStampPrecision )
-            : base(Tags.OrigSendingTime, val, timeStampPrecision) { }
     }
 
 
@@ -2334,7 +2339,9 @@ namespace QuickFix.Fields
         public ExpireTime(DateTime val)
             :base(Tags.ExpireTime, val) {}
         public ExpireTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.ExpireTime, val, showMilliseconds) {}
+			:base(Tags.ExpireTime, val, showMilliseconds) {}
+        public ExpireTime(DateTime val, TimeStampPrecision timeStampPrecision)
+			:base(Tags.ExpireTime, val, timeStampPrecision) {}
 
     }
 
@@ -3130,7 +3137,9 @@ namespace QuickFix.Fields
         public EffectiveTime(DateTime val)
             :base(Tags.EffectiveTime, val) {}
         public EffectiveTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.EffectiveTime, val, showMilliseconds) {}
+			:base(Tags.EffectiveTime, val, showMilliseconds) {}
+        public EffectiveTime(DateTime val, TimeStampPrecision timeStampPrecision)
+			:base(Tags.EffectiveTime, val, timeStampPrecision) {}
 
     }
 
@@ -4110,7 +4119,9 @@ namespace QuickFix.Fields
         public MDEntryTime(DateTime val)
             :base(Tags.MDEntryTime, val) {}
         public MDEntryTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.MDEntryTime, val, showMilliseconds) {}
+			:base(Tags.MDEntryTime, val, showMilliseconds) {}
+        public MDEntryTime(DateTime val, TimeStampPrecision timeStampPrecision)
+			:base(Tags.MDEntryTime, val, timeStampPrecision) {}
 
     }
 
@@ -5386,7 +5397,9 @@ namespace QuickFix.Fields
         public TradSesStartTime(DateTime val)
             :base(Tags.TradSesStartTime, val) {}
         public TradSesStartTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.TradSesStartTime, val, showMilliseconds) {}
+			:base(Tags.TradSesStartTime, val, showMilliseconds) {}
+        public TradSesStartTime(DateTime val, TimeStampPrecision timeStampPrecision)
+			:base(Tags.TradSesStartTime, val, timeStampPrecision) {}
 
     }
 
@@ -5401,7 +5414,9 @@ namespace QuickFix.Fields
         public TradSesOpenTime(DateTime val)
             :base(Tags.TradSesOpenTime, val) {}
         public TradSesOpenTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.TradSesOpenTime, val, showMilliseconds) {}
+			:base(Tags.TradSesOpenTime, val, showMilliseconds) {}
+        public TradSesOpenTime(DateTime val, TimeStampPrecision timeStampPrecision)
+			:base(Tags.TradSesOpenTime, val, timeStampPrecision) {}
 
     }
 
@@ -5416,7 +5431,9 @@ namespace QuickFix.Fields
         public TradSesPreCloseTime(DateTime val)
             :base(Tags.TradSesPreCloseTime, val) {}
         public TradSesPreCloseTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.TradSesPreCloseTime, val, showMilliseconds) {}
+			:base(Tags.TradSesPreCloseTime, val, showMilliseconds) {}
+        public TradSesPreCloseTime(DateTime val, TimeStampPrecision timeStampPrecision)
+			:base(Tags.TradSesPreCloseTime, val, timeStampPrecision) {}
 
     }
 
@@ -5431,7 +5448,9 @@ namespace QuickFix.Fields
         public TradSesCloseTime(DateTime val)
             :base(Tags.TradSesCloseTime, val) {}
         public TradSesCloseTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.TradSesCloseTime, val, showMilliseconds) {}
+			:base(Tags.TradSesCloseTime, val, showMilliseconds) {}
+        public TradSesCloseTime(DateTime val, TimeStampPrecision timeStampPrecision)
+			:base(Tags.TradSesCloseTime, val, timeStampPrecision) {}
 
     }
 
@@ -5446,7 +5465,9 @@ namespace QuickFix.Fields
         public TradSesEndTime(DateTime val)
             :base(Tags.TradSesEndTime, val) {}
         public TradSesEndTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.TradSesEndTime, val, showMilliseconds) {}
+			:base(Tags.TradSesEndTime, val, showMilliseconds) {}
+        public TradSesEndTime(DateTime val, TimeStampPrecision timeStampPrecision)
+			:base(Tags.TradSesEndTime, val, timeStampPrecision) {}
 
     }
 
@@ -5740,7 +5761,9 @@ namespace QuickFix.Fields
         public QuoteSetValidUntilTime(DateTime val)
             :base(Tags.QuoteSetValidUntilTime, val) {}
         public QuoteSetValidUntilTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.QuoteSetValidUntilTime, val, showMilliseconds) {}
+			:base(Tags.QuoteSetValidUntilTime, val, showMilliseconds) {}
+        public QuoteSetValidUntilTime(DateTime val, TimeStampPrecision timeStampPrecision)
+			:base(Tags.QuoteSetValidUntilTime, val, timeStampPrecision) {}
 
     }
 
@@ -5797,7 +5820,9 @@ namespace QuickFix.Fields
         public OnBehalfOfSendingTime(DateTime val)
             :base(Tags.OnBehalfOfSendingTime, val) {}
         public OnBehalfOfSendingTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.OnBehalfOfSendingTime, val, showMilliseconds) {}
+			:base(Tags.OnBehalfOfSendingTime, val, showMilliseconds) {}
+        public OnBehalfOfSendingTime(DateTime val, TimeStampPrecision timeStampPrecision)
+			:base(Tags.OnBehalfOfSendingTime, val, timeStampPrecision) {}
 
     }
 
@@ -6891,7 +6916,9 @@ namespace QuickFix.Fields
         public ContraTradeTime(DateTime val)
             :base(Tags.ContraTradeTime, val) {}
         public ContraTradeTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.ContraTradeTime, val, showMilliseconds) {}
+			:base(Tags.ContraTradeTime, val, showMilliseconds) {}
+        public ContraTradeTime(DateTime val, TimeStampPrecision timeStampPrecision)
+			:base(Tags.ContraTradeTime, val, timeStampPrecision) {}
 
     }
 
@@ -6964,7 +6991,9 @@ namespace QuickFix.Fields
         public StrikeTime(DateTime val)
             :base(Tags.StrikeTime, val) {}
         public StrikeTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.StrikeTime, val, showMilliseconds) {}
+			:base(Tags.StrikeTime, val, showMilliseconds) {}
+        public StrikeTime(DateTime val, TimeStampPrecision timeStampPrecision)
+			:base(Tags.StrikeTime, val, timeStampPrecision) {}
 
     }
 
@@ -7948,7 +7977,9 @@ namespace QuickFix.Fields
         public TotalVolumeTradedTime(DateTime val)
             :base(Tags.TotalVolumeTradedTime, val) {}
         public TotalVolumeTradedTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.TotalVolumeTradedTime, val, showMilliseconds) {}
+			:base(Tags.TotalVolumeTradedTime, val, showMilliseconds) {}
+        public TotalVolumeTradedTime(DateTime val, TimeStampPrecision timeStampPrecision)
+			:base(Tags.TotalVolumeTradedTime, val, timeStampPrecision) {}
 
     }
 
@@ -8536,7 +8567,9 @@ namespace QuickFix.Fields
         public TransBkdTime(DateTime val)
             :base(Tags.TransBkdTime, val) {}
         public TransBkdTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.TransBkdTime, val, showMilliseconds) {}
+			:base(Tags.TransBkdTime, val, showMilliseconds) {}
+        public TransBkdTime(DateTime val, TimeStampPrecision timeStampPrecision)
+			:base(Tags.TransBkdTime, val, timeStampPrecision) {}
 
     }
 
@@ -9067,7 +9100,9 @@ namespace QuickFix.Fields
         public ExecValuationPoint(DateTime val)
             :base(Tags.ExecValuationPoint, val) {}
         public ExecValuationPoint(DateTime val, bool showMilliseconds)
-	    :base(Tags.ExecValuationPoint, val, showMilliseconds) {}
+			:base(Tags.ExecValuationPoint, val, showMilliseconds) {}
+        public ExecValuationPoint(DateTime val, TimeStampPrecision timeStampPrecision)
+			:base(Tags.ExecValuationPoint, val, timeStampPrecision) {}
 
     }
 
@@ -10295,7 +10330,9 @@ namespace QuickFix.Fields
         public OrigOrdModTime(DateTime val)
             :base(Tags.OrigOrdModTime, val) {}
         public OrigOrdModTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.OrigOrdModTime, val, showMilliseconds) {}
+			:base(Tags.OrigOrdModTime, val, showMilliseconds) {}
+        public OrigOrdModTime(DateTime val, TimeStampPrecision timeStampPrecision)
+			:base(Tags.OrigOrdModTime, val, timeStampPrecision) {}
 
     }
 
@@ -10900,7 +10937,9 @@ namespace QuickFix.Fields
         public HopSendingTime(DateTime val)
             :base(Tags.HopSendingTime, val) {}
         public HopSendingTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.HopSendingTime, val, showMilliseconds) {}
+			:base(Tags.HopSendingTime, val, showMilliseconds) {}
+        public HopSendingTime(DateTime val, TimeStampPrecision timeStampPrecision)
+			:base(Tags.HopSendingTime, val, timeStampPrecision) {}
 
     }
 
@@ -13221,7 +13260,9 @@ namespace QuickFix.Fields
         public TrdRegTimestamp(DateTime val)
             :base(Tags.TrdRegTimestamp, val) {}
         public TrdRegTimestamp(DateTime val, bool showMilliseconds)
-	    :base(Tags.TrdRegTimestamp, val, showMilliseconds) {}
+			:base(Tags.TrdRegTimestamp, val, showMilliseconds) {}
+        public TrdRegTimestamp(DateTime val, TimeStampPrecision timeStampPrecision)
+			:base(Tags.TrdRegTimestamp, val, timeStampPrecision) {}
 
     }
 
@@ -13377,7 +13418,9 @@ namespace QuickFix.Fields
         public LastUpdateTime(DateTime val)
             :base(Tags.LastUpdateTime, val) {}
         public LastUpdateTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.LastUpdateTime, val, showMilliseconds) {}
+			:base(Tags.LastUpdateTime, val, showMilliseconds) {}
+        public LastUpdateTime(DateTime val, TimeStampPrecision timeStampPrecision)
+			:base(Tags.LastUpdateTime, val, timeStampPrecision) {}
 
     }
 
@@ -16363,7 +16406,9 @@ namespace QuickFix.Fields
         public SideTimeInForce(DateTime val)
             :base(Tags.SideTimeInForce, val) {}
         public SideTimeInForce(DateTime val, bool showMilliseconds)
-	    :base(Tags.SideTimeInForce, val, showMilliseconds) {}
+			:base(Tags.SideTimeInForce, val, showMilliseconds) {}
+        public SideTimeInForce(DateTime val, TimeStampPrecision timeStampPrecision)
+			:base(Tags.SideTimeInForce, val, timeStampPrecision) {}
 
     }
 
@@ -17047,7 +17092,9 @@ namespace QuickFix.Fields
         public SideTrdRegTimestamp(DateTime val)
             :base(Tags.SideTrdRegTimestamp, val) {}
         public SideTrdRegTimestamp(DateTime val, bool showMilliseconds)
-	    :base(Tags.SideTrdRegTimestamp, val, showMilliseconds) {}
+			:base(Tags.SideTrdRegTimestamp, val, showMilliseconds) {}
+        public SideTrdRegTimestamp(DateTime val, TimeStampPrecision timeStampPrecision)
+			:base(Tags.SideTrdRegTimestamp, val, timeStampPrecision) {}
 
     }
 
@@ -18798,7 +18845,9 @@ namespace QuickFix.Fields
         public TZTransactTime(DateTime val)
             :base(Tags.TZTransactTime, val) {}
         public TZTransactTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.TZTransactTime, val, showMilliseconds) {}
+			:base(Tags.TZTransactTime, val, showMilliseconds) {}
+        public TZTransactTime(DateTime val, TimeStampPrecision timeStampPrecision)
+			:base(Tags.TZTransactTime, val, timeStampPrecision) {}
 
     }
 
@@ -19019,7 +19068,9 @@ namespace QuickFix.Fields
         public EventTime(DateTime val)
             :base(Tags.EventTime, val) {}
         public EventTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.EventTime, val, showMilliseconds) {}
+			:base(Tags.EventTime, val, showMilliseconds) {}
+        public EventTime(DateTime val, TimeStampPrecision timeStampPrecision)
+			:base(Tags.EventTime, val, timeStampPrecision) {}
 
     }
 
@@ -20950,7 +21001,9 @@ namespace QuickFix.Fields
         public DerivativeEventTime(DateTime val)
             :base(Tags.DerivativeEventTime, val) {}
         public DerivativeEventTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.DerivativeEventTime, val, showMilliseconds) {}
+			:base(Tags.DerivativeEventTime, val, showMilliseconds) {}
+        public DerivativeEventTime(DateTime val, TimeStampPrecision timeStampPrecision)
+			:base(Tags.DerivativeEventTime, val, timeStampPrecision) {}
 
     }
 
@@ -24022,7 +24075,9 @@ namespace QuickFix.Fields
         public ComplexEventStartDate(DateTime val)
             :base(Tags.ComplexEventStartDate, val) {}
         public ComplexEventStartDate(DateTime val, bool showMilliseconds)
-	    :base(Tags.ComplexEventStartDate, val, showMilliseconds) {}
+			:base(Tags.ComplexEventStartDate, val, showMilliseconds) {}
+        public ComplexEventStartDate(DateTime val, TimeStampPrecision timeStampPrecision)
+			:base(Tags.ComplexEventStartDate, val, timeStampPrecision) {}
 
     }
 
@@ -24037,7 +24092,9 @@ namespace QuickFix.Fields
         public ComplexEventEndDate(DateTime val)
             :base(Tags.ComplexEventEndDate, val) {}
         public ComplexEventEndDate(DateTime val, bool showMilliseconds)
-	    :base(Tags.ComplexEventEndDate, val, showMilliseconds) {}
+			:base(Tags.ComplexEventEndDate, val, showMilliseconds) {}
+        public ComplexEventEndDate(DateTime val, TimeStampPrecision timeStampPrecision)
+			:base(Tags.ComplexEventEndDate, val, timeStampPrecision) {}
 
     }
 
@@ -24065,7 +24122,9 @@ namespace QuickFix.Fields
         public ComplexEventStartTime(DateTime val)
             :base(Tags.ComplexEventStartTime, val) {}
         public ComplexEventStartTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.ComplexEventStartTime, val, showMilliseconds) {}
+			:base(Tags.ComplexEventStartTime, val, showMilliseconds) {}
+        public ComplexEventStartTime(DateTime val, TimeStampPrecision timeStampPrecision)
+			:base(Tags.ComplexEventStartTime, val, timeStampPrecision) {}
 
     }
 
@@ -24080,7 +24139,9 @@ namespace QuickFix.Fields
         public ComplexEventEndTime(DateTime val)
             :base(Tags.ComplexEventEndTime, val) {}
         public ComplexEventEndTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.ComplexEventEndTime, val, showMilliseconds) {}
+			:base(Tags.ComplexEventEndTime, val, showMilliseconds) {}
+        public ComplexEventEndTime(DateTime val, TimeStampPrecision timeStampPrecision)
+			:base(Tags.ComplexEventEndTime, val, timeStampPrecision) {}
 
     }
 
@@ -24201,7 +24262,9 @@ namespace QuickFix.Fields
         public RelSymTransactTime(DateTime val)
             :base(Tags.RelSymTransactTime, val) {}
         public RelSymTransactTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.RelSymTransactTime, val, showMilliseconds) {}
+			:base(Tags.RelSymTransactTime, val, showMilliseconds) {}
+        public RelSymTransactTime(DateTime val, TimeStampPrecision timeStampPrecision)
+			:base(Tags.RelSymTransactTime, val, timeStampPrecision) {}
 
     }
 

--- a/generator/fields_gen.rb
+++ b/generator/fields_gen.rb
@@ -38,7 +38,7 @@ class FieldGen
   def self.fields_str fields
 <<HERE
 // This is a generated file.  Don't edit it directly!
-
+using QuickFix.Fields.Converters;
 using System;
 
 namespace QuickFix.Fields
@@ -108,7 +108,9 @@ HERE
         public #{field[:name]}(#{field[:base_type]} val)
             :base(Tags.#{field[:name]}, val) {}
         public #{field[:name]}(#{field[:base_type]} val, bool showMilliseconds)
-	    :base(Tags.#{field[:name]}, val, showMilliseconds) {}
+			:base(Tags.#{field[:name]}, val, showMilliseconds) {}
+        public #{field[:name]}(#{field[:base_type]} val, TimeStampPrecision timeStampPrecision)
+			:base(Tags.#{field[:name]}, val, timeStampPrecision) {}
 #{fix_values(field)}
     }
 


### PR DESCRIPTION
Pull #425 added support for microsecond precision in datetime fields, however, the codegen was not updated to cater for the new precision. Therefore new builds were failing with "Cannot convert from 'QuickFix.Fields.Converters.TimeStampPrecision' to bool"  wherever the field constructors were being called because of a missing overload.

This PR adds the new overload.