### PR TITLE
Nanosecond support for QuickFIX timestamp fields

### DIFF
--- a/QuickFIXn/Fields/Converters/TimeStampPrecision.cs
+++ b/QuickFIXn/Fields/Converters/TimeStampPrecision.cs
@@ -8,6 +8,7 @@ namespace QuickFix.Fields.Converters
     {
         Second,
         Millisecond,
-        Microsecond
+        Microsecond,
+        Nanosecond
     }
 }

--- a/QuickFIXn/Fields/DateTimeField.cs
+++ b/QuickFIXn/Fields/DateTimeField.cs
@@ -16,7 +16,7 @@ namespace QuickFix.Fields
             : this(tag, dt, showMilliseconds ? TimeStampPrecision.Millisecond : TimeStampPrecision.Second ) { }
 
         public DateTimeField(int tag, DateTime dt, TimeStampPrecision timeFormatPrecision)
-    : base(tag, dt )
+            : base(tag, dt )
         {
             timePrecision = timeFormatPrecision;
         }

--- a/QuickFIXn/Fields/Fields.cs
+++ b/QuickFIXn/Fields/Fields.cs
@@ -1,7 +1,6 @@
 // This is a generated file.  Don't edit it directly!
 
 using System;
-using QuickFix.Fields.Converters;
 
 namespace QuickFix.Fields
 {
@@ -954,7 +953,9 @@ namespace QuickFix.Fields
         public OrigTime(DateTime val)
             :base(Tags.OrigTime, val) {}
         public OrigTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.OrigTime, val, showMilliseconds) {}
+            :base(Tags.OrigTime, val, showMilliseconds) {}
+		public OrigTime(DateTime val, Converters.TimeStampPrecision precision)
+            :base(Tags.OrigTime, val, precision) {}
 
     }
 
@@ -1131,9 +1132,9 @@ namespace QuickFix.Fields
         public SendingTime(DateTime val)
             :base(Tags.SendingTime, val) {}
         public SendingTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.SendingTime, val, showMilliseconds) {}
-
-        public SendingTime( DateTime val, TimeStampPrecision timestampPrecision) : base( Tags.SendingTime, val, timestampPrecision) { }
+            :base(Tags.SendingTime, val, showMilliseconds) {}
+		public SendingTime(DateTime val, Converters.TimeStampPrecision precision)
+            :base(Tags.SendingTime, val, precision) {}
 
     }
 
@@ -1271,7 +1272,9 @@ namespace QuickFix.Fields
         public TransactTime(DateTime val)
             :base(Tags.TransactTime, val) {}
         public TransactTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.TransactTime, val, showMilliseconds) {}
+            :base(Tags.TransactTime, val, showMilliseconds) {}
+		public TransactTime(DateTime val, Converters.TimeStampPrecision precision)
+            :base(Tags.TransactTime, val, precision) {}
 
     }
 
@@ -1304,7 +1307,9 @@ namespace QuickFix.Fields
         public ValidUntilTime(DateTime val)
             :base(Tags.ValidUntilTime, val) {}
         public ValidUntilTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.ValidUntilTime, val, showMilliseconds) {}
+            :base(Tags.ValidUntilTime, val, showMilliseconds) {}
+		public ValidUntilTime(DateTime val, Converters.TimeStampPrecision precision)
+            :base(Tags.ValidUntilTime, val, precision) {}
 
     }
 
@@ -2268,10 +2273,10 @@ namespace QuickFix.Fields
         public OrigSendingTime(DateTime val)
             :base(Tags.OrigSendingTime, val) {}
         public OrigSendingTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.OrigSendingTime, val, showMilliseconds) {}
+            :base(Tags.OrigSendingTime, val, showMilliseconds) {}
+		public OrigSendingTime(DateTime val, Converters.TimeStampPrecision precision)
+            :base(Tags.OrigSendingTime, val, precision) {}
 
-        public OrigSendingTime(DateTime val, TimeStampPrecision timeStampPrecision )
-            : base(Tags.OrigSendingTime, val, timeStampPrecision) { }
     }
 
 
@@ -2334,7 +2339,9 @@ namespace QuickFix.Fields
         public ExpireTime(DateTime val)
             :base(Tags.ExpireTime, val) {}
         public ExpireTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.ExpireTime, val, showMilliseconds) {}
+            :base(Tags.ExpireTime, val, showMilliseconds) {}
+		public ExpireTime(DateTime val, Converters.TimeStampPrecision precision)
+            :base(Tags.ExpireTime, val, precision) {}
 
     }
 
@@ -3130,7 +3137,9 @@ namespace QuickFix.Fields
         public EffectiveTime(DateTime val)
             :base(Tags.EffectiveTime, val) {}
         public EffectiveTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.EffectiveTime, val, showMilliseconds) {}
+            :base(Tags.EffectiveTime, val, showMilliseconds) {}
+		public EffectiveTime(DateTime val, Converters.TimeStampPrecision precision)
+            :base(Tags.EffectiveTime, val, precision) {}
 
     }
 
@@ -4110,7 +4119,9 @@ namespace QuickFix.Fields
         public MDEntryTime(DateTime val)
             :base(Tags.MDEntryTime, val) {}
         public MDEntryTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.MDEntryTime, val, showMilliseconds) {}
+            :base(Tags.MDEntryTime, val, showMilliseconds) {}
+		public MDEntryTime(DateTime val, Converters.TimeStampPrecision precision)
+            :base(Tags.MDEntryTime, val, precision) {}
 
     }
 
@@ -5386,7 +5397,9 @@ namespace QuickFix.Fields
         public TradSesStartTime(DateTime val)
             :base(Tags.TradSesStartTime, val) {}
         public TradSesStartTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.TradSesStartTime, val, showMilliseconds) {}
+            :base(Tags.TradSesStartTime, val, showMilliseconds) {}
+		public TradSesStartTime(DateTime val, Converters.TimeStampPrecision precision)
+            :base(Tags.TradSesStartTime, val, precision) {}
 
     }
 
@@ -5401,7 +5414,9 @@ namespace QuickFix.Fields
         public TradSesOpenTime(DateTime val)
             :base(Tags.TradSesOpenTime, val) {}
         public TradSesOpenTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.TradSesOpenTime, val, showMilliseconds) {}
+            :base(Tags.TradSesOpenTime, val, showMilliseconds) {}
+		public TradSesOpenTime(DateTime val, Converters.TimeStampPrecision precision)
+            :base(Tags.TradSesOpenTime, val, precision) {}
 
     }
 
@@ -5416,7 +5431,9 @@ namespace QuickFix.Fields
         public TradSesPreCloseTime(DateTime val)
             :base(Tags.TradSesPreCloseTime, val) {}
         public TradSesPreCloseTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.TradSesPreCloseTime, val, showMilliseconds) {}
+            :base(Tags.TradSesPreCloseTime, val, showMilliseconds) {}
+		public TradSesPreCloseTime(DateTime val, Converters.TimeStampPrecision precision)
+            :base(Tags.TradSesPreCloseTime, val, precision) {}
 
     }
 
@@ -5431,7 +5448,9 @@ namespace QuickFix.Fields
         public TradSesCloseTime(DateTime val)
             :base(Tags.TradSesCloseTime, val) {}
         public TradSesCloseTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.TradSesCloseTime, val, showMilliseconds) {}
+            :base(Tags.TradSesCloseTime, val, showMilliseconds) {}
+		public TradSesCloseTime(DateTime val, Converters.TimeStampPrecision precision)
+            :base(Tags.TradSesCloseTime, val, precision) {}
 
     }
 
@@ -5446,7 +5465,9 @@ namespace QuickFix.Fields
         public TradSesEndTime(DateTime val)
             :base(Tags.TradSesEndTime, val) {}
         public TradSesEndTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.TradSesEndTime, val, showMilliseconds) {}
+            :base(Tags.TradSesEndTime, val, showMilliseconds) {}
+		public TradSesEndTime(DateTime val, Converters.TimeStampPrecision precision)
+            :base(Tags.TradSesEndTime, val, precision) {}
 
     }
 
@@ -5740,7 +5761,9 @@ namespace QuickFix.Fields
         public QuoteSetValidUntilTime(DateTime val)
             :base(Tags.QuoteSetValidUntilTime, val) {}
         public QuoteSetValidUntilTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.QuoteSetValidUntilTime, val, showMilliseconds) {}
+            :base(Tags.QuoteSetValidUntilTime, val, showMilliseconds) {}
+		public QuoteSetValidUntilTime(DateTime val, Converters.TimeStampPrecision precision)
+            :base(Tags.QuoteSetValidUntilTime, val, precision) {}
 
     }
 
@@ -5797,7 +5820,9 @@ namespace QuickFix.Fields
         public OnBehalfOfSendingTime(DateTime val)
             :base(Tags.OnBehalfOfSendingTime, val) {}
         public OnBehalfOfSendingTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.OnBehalfOfSendingTime, val, showMilliseconds) {}
+            :base(Tags.OnBehalfOfSendingTime, val, showMilliseconds) {}
+		public OnBehalfOfSendingTime(DateTime val, Converters.TimeStampPrecision precision)
+            :base(Tags.OnBehalfOfSendingTime, val, precision) {}
 
     }
 
@@ -6891,7 +6916,9 @@ namespace QuickFix.Fields
         public ContraTradeTime(DateTime val)
             :base(Tags.ContraTradeTime, val) {}
         public ContraTradeTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.ContraTradeTime, val, showMilliseconds) {}
+            :base(Tags.ContraTradeTime, val, showMilliseconds) {}
+		public ContraTradeTime(DateTime val, Converters.TimeStampPrecision precision)
+            :base(Tags.ContraTradeTime, val, precision) {}
 
     }
 
@@ -6964,7 +6991,9 @@ namespace QuickFix.Fields
         public StrikeTime(DateTime val)
             :base(Tags.StrikeTime, val) {}
         public StrikeTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.StrikeTime, val, showMilliseconds) {}
+            :base(Tags.StrikeTime, val, showMilliseconds) {}
+		public StrikeTime(DateTime val, Converters.TimeStampPrecision precision)
+            :base(Tags.StrikeTime, val, precision) {}
 
     }
 
@@ -7948,7 +7977,9 @@ namespace QuickFix.Fields
         public TotalVolumeTradedTime(DateTime val)
             :base(Tags.TotalVolumeTradedTime, val) {}
         public TotalVolumeTradedTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.TotalVolumeTradedTime, val, showMilliseconds) {}
+            :base(Tags.TotalVolumeTradedTime, val, showMilliseconds) {}
+		public TotalVolumeTradedTime(DateTime val, Converters.TimeStampPrecision precision)
+            :base(Tags.TotalVolumeTradedTime, val, precision) {}
 
     }
 
@@ -8536,7 +8567,9 @@ namespace QuickFix.Fields
         public TransBkdTime(DateTime val)
             :base(Tags.TransBkdTime, val) {}
         public TransBkdTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.TransBkdTime, val, showMilliseconds) {}
+            :base(Tags.TransBkdTime, val, showMilliseconds) {}
+		public TransBkdTime(DateTime val, Converters.TimeStampPrecision precision)
+            :base(Tags.TransBkdTime, val, precision) {}
 
     }
 
@@ -9067,7 +9100,9 @@ namespace QuickFix.Fields
         public ExecValuationPoint(DateTime val)
             :base(Tags.ExecValuationPoint, val) {}
         public ExecValuationPoint(DateTime val, bool showMilliseconds)
-	    :base(Tags.ExecValuationPoint, val, showMilliseconds) {}
+            :base(Tags.ExecValuationPoint, val, showMilliseconds) {}
+		public ExecValuationPoint(DateTime val, Converters.TimeStampPrecision precision)
+            :base(Tags.ExecValuationPoint, val, precision) {}
 
     }
 
@@ -10295,7 +10330,9 @@ namespace QuickFix.Fields
         public OrigOrdModTime(DateTime val)
             :base(Tags.OrigOrdModTime, val) {}
         public OrigOrdModTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.OrigOrdModTime, val, showMilliseconds) {}
+            :base(Tags.OrigOrdModTime, val, showMilliseconds) {}
+		public OrigOrdModTime(DateTime val, Converters.TimeStampPrecision precision)
+            :base(Tags.OrigOrdModTime, val, precision) {}
 
     }
 
@@ -10900,7 +10937,9 @@ namespace QuickFix.Fields
         public HopSendingTime(DateTime val)
             :base(Tags.HopSendingTime, val) {}
         public HopSendingTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.HopSendingTime, val, showMilliseconds) {}
+            :base(Tags.HopSendingTime, val, showMilliseconds) {}
+		public HopSendingTime(DateTime val, Converters.TimeStampPrecision precision)
+            :base(Tags.HopSendingTime, val, precision) {}
 
     }
 
@@ -13221,7 +13260,9 @@ namespace QuickFix.Fields
         public TrdRegTimestamp(DateTime val)
             :base(Tags.TrdRegTimestamp, val) {}
         public TrdRegTimestamp(DateTime val, bool showMilliseconds)
-	    :base(Tags.TrdRegTimestamp, val, showMilliseconds) {}
+            :base(Tags.TrdRegTimestamp, val, showMilliseconds) {}
+		public TrdRegTimestamp(DateTime val, Converters.TimeStampPrecision precision)
+            :base(Tags.TrdRegTimestamp, val, precision) {}
 
     }
 
@@ -13377,7 +13418,9 @@ namespace QuickFix.Fields
         public LastUpdateTime(DateTime val)
             :base(Tags.LastUpdateTime, val) {}
         public LastUpdateTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.LastUpdateTime, val, showMilliseconds) {}
+            :base(Tags.LastUpdateTime, val, showMilliseconds) {}
+		public LastUpdateTime(DateTime val, Converters.TimeStampPrecision precision)
+            :base(Tags.LastUpdateTime, val, precision) {}
 
     }
 
@@ -16363,7 +16406,9 @@ namespace QuickFix.Fields
         public SideTimeInForce(DateTime val)
             :base(Tags.SideTimeInForce, val) {}
         public SideTimeInForce(DateTime val, bool showMilliseconds)
-	    :base(Tags.SideTimeInForce, val, showMilliseconds) {}
+            :base(Tags.SideTimeInForce, val, showMilliseconds) {}
+		public SideTimeInForce(DateTime val, Converters.TimeStampPrecision precision)
+            :base(Tags.SideTimeInForce, val, precision) {}
 
     }
 
@@ -17047,7 +17092,9 @@ namespace QuickFix.Fields
         public SideTrdRegTimestamp(DateTime val)
             :base(Tags.SideTrdRegTimestamp, val) {}
         public SideTrdRegTimestamp(DateTime val, bool showMilliseconds)
-	    :base(Tags.SideTrdRegTimestamp, val, showMilliseconds) {}
+            :base(Tags.SideTrdRegTimestamp, val, showMilliseconds) {}
+		public SideTrdRegTimestamp(DateTime val, Converters.TimeStampPrecision precision)
+            :base(Tags.SideTrdRegTimestamp, val, precision) {}
 
     }
 
@@ -18798,7 +18845,9 @@ namespace QuickFix.Fields
         public TZTransactTime(DateTime val)
             :base(Tags.TZTransactTime, val) {}
         public TZTransactTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.TZTransactTime, val, showMilliseconds) {}
+            :base(Tags.TZTransactTime, val, showMilliseconds) {}
+		public TZTransactTime(DateTime val, Converters.TimeStampPrecision precision)
+            :base(Tags.TZTransactTime, val, precision) {}
 
     }
 
@@ -19019,7 +19068,9 @@ namespace QuickFix.Fields
         public EventTime(DateTime val)
             :base(Tags.EventTime, val) {}
         public EventTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.EventTime, val, showMilliseconds) {}
+            :base(Tags.EventTime, val, showMilliseconds) {}
+		public EventTime(DateTime val, Converters.TimeStampPrecision precision)
+            :base(Tags.EventTime, val, precision) {}
 
     }
 
@@ -20950,7 +21001,9 @@ namespace QuickFix.Fields
         public DerivativeEventTime(DateTime val)
             :base(Tags.DerivativeEventTime, val) {}
         public DerivativeEventTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.DerivativeEventTime, val, showMilliseconds) {}
+            :base(Tags.DerivativeEventTime, val, showMilliseconds) {}
+		public DerivativeEventTime(DateTime val, Converters.TimeStampPrecision precision)
+            :base(Tags.DerivativeEventTime, val, precision) {}
 
     }
 
@@ -24022,7 +24075,9 @@ namespace QuickFix.Fields
         public ComplexEventStartDate(DateTime val)
             :base(Tags.ComplexEventStartDate, val) {}
         public ComplexEventStartDate(DateTime val, bool showMilliseconds)
-	    :base(Tags.ComplexEventStartDate, val, showMilliseconds) {}
+            :base(Tags.ComplexEventStartDate, val, showMilliseconds) {}
+		public ComplexEventStartDate(DateTime val, Converters.TimeStampPrecision precision)
+            :base(Tags.ComplexEventStartDate, val, precision) {}
 
     }
 
@@ -24037,7 +24092,9 @@ namespace QuickFix.Fields
         public ComplexEventEndDate(DateTime val)
             :base(Tags.ComplexEventEndDate, val) {}
         public ComplexEventEndDate(DateTime val, bool showMilliseconds)
-	    :base(Tags.ComplexEventEndDate, val, showMilliseconds) {}
+            :base(Tags.ComplexEventEndDate, val, showMilliseconds) {}
+		public ComplexEventEndDate(DateTime val, Converters.TimeStampPrecision precision)
+            :base(Tags.ComplexEventEndDate, val, precision) {}
 
     }
 
@@ -24065,7 +24122,9 @@ namespace QuickFix.Fields
         public ComplexEventStartTime(DateTime val)
             :base(Tags.ComplexEventStartTime, val) {}
         public ComplexEventStartTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.ComplexEventStartTime, val, showMilliseconds) {}
+            :base(Tags.ComplexEventStartTime, val, showMilliseconds) {}
+		public ComplexEventStartTime(DateTime val, Converters.TimeStampPrecision precision)
+            :base(Tags.ComplexEventStartTime, val, precision) {}
 
     }
 
@@ -24080,7 +24139,9 @@ namespace QuickFix.Fields
         public ComplexEventEndTime(DateTime val)
             :base(Tags.ComplexEventEndTime, val) {}
         public ComplexEventEndTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.ComplexEventEndTime, val, showMilliseconds) {}
+            :base(Tags.ComplexEventEndTime, val, showMilliseconds) {}
+		public ComplexEventEndTime(DateTime val, Converters.TimeStampPrecision precision)
+            :base(Tags.ComplexEventEndTime, val, precision) {}
 
     }
 
@@ -24201,7 +24262,9 @@ namespace QuickFix.Fields
         public RelSymTransactTime(DateTime val)
             :base(Tags.RelSymTransactTime, val) {}
         public RelSymTransactTime(DateTime val, bool showMilliseconds)
-	    :base(Tags.RelSymTransactTime, val, showMilliseconds) {}
+            :base(Tags.RelSymTransactTime, val, showMilliseconds) {}
+		public RelSymTransactTime(DateTime val, Converters.TimeStampPrecision precision)
+            :base(Tags.RelSymTransactTime, val, precision) {}
 
     }
 

--- a/UnitTests/ConverterTests.cs
+++ b/UnitTests/ConverterTests.cs
@@ -85,6 +85,20 @@ namespace UnitTests
             Assert.That(DecimalConverter.Convert("-.23"), Is.EqualTo(new Decimal(-0.23)));
         }
 
+        public static DateTime makeDateTime(int y, int m, int d, int h, int min, int s, int ms, int us, int ns)
+        {
+            // already includes ms
+            DateTime dt = new DateTime(y, m, d, h, min, s, ms);
+            long nanos = (us * DateTimeConverter.NanosPerMicro) + ns;
+            long ticks = nanos / DateTimeConverter.NanosecondsPerTick;
+            return dt.AddTicks(ticks);
+        }
+
+        public static DateTime makeTimeOnly(int h, int m, int s, int ms, int us, int ns)
+        {
+            return makeDateTime(1980, 1, 1, h, m, s, ms, us, ns);
+        }
+
         [Test]
         public void DateTimeConverterTest()
         {
@@ -134,6 +148,30 @@ namespace UnitTests
             // invalid string-to-DateTime formats
             Assert.Throws(typeof(FieldConvertError), delegate { DateTimeConverter.ConvertToTimeOnly(""); });
             Assert.Throws(typeof(FieldConvertError), delegate { DateTimeConverter.ConvertToTimeOnly("20021201-11:03:00"); });
+        }
+
+        private const int MinutesPerHour = 60;
+        private const int SecondsPerMinute = 60;
+        private const int MillisPerSecond = 1000;
+
+        [Test]
+        public void TestNanosecondPrecision()
+        {
+            // seeded DateTime
+            DateTime dt = makeDateTime(2002, 12, 01, 11, 03, 05, 231, 116, 500);
+
+            // convert nanosecond DateTime to string with option
+            Assert.That(DateTimeConverter.Convert(dt, TimeStampPrecision.Nanosecond), Is.EqualTo("20021201-11:03:05.231116500"));
+
+            // convert nanosecond DateTime to time-only string
+            Assert.That(DateTimeConverter.ConvertTimeOnly(dt, TimeStampPrecision.Nanosecond), Is.EqualTo("11:03:05.231116500"));
+
+            // convert nanosecond time string to DateTime time portion only
+            DateTime timeOnly = makeTimeOnly(11, 03, 05, 231, 116, 500);
+            Assert.That(DateTimeConverter.ConvertToTimeOnly("11:03:05.231116500", TimeStampPrecision.Nanosecond), Is.EqualTo(timeOnly));
+
+            // convert nanosecond time string to full DateTime
+            Assert.That(DateTimeConverter.ConvertToDateTime("20021201-11:03:05.231116500", TimeStampPrecision.Nanosecond), Is.EqualTo(dt));
         }
     }
 }

--- a/UnitTests/ConverterTests.cs
+++ b/UnitTests/ConverterTests.cs
@@ -158,7 +158,7 @@ namespace UnitTests
         public void TestNanosecondPrecision()
         {
             // seeded DateTime
-            DateTime dt = makeDateTime(2002, 12, 01, 11, 03, 05, 231, 116, 500);
+            DateTime dt = DateTime.SpecifyKind(makeDateTime(2002, 12, 01, 11, 03, 05, 231, 116, 500), DateTimeKind.Utc);
 
             // convert nanosecond DateTime to string with option
             Assert.That(DateTimeConverter.Convert(dt, TimeStampPrecision.Nanosecond), Is.EqualTo("20021201-11:03:05.231116500"));
@@ -172,6 +172,19 @@ namespace UnitTests
 
             // convert nanosecond time string to full DateTime
             Assert.That(DateTimeConverter.ConvertToDateTime("20021201-11:03:05.231116500", TimeStampPrecision.Nanosecond), Is.EqualTo(dt));
+
+            // convert nanosecond time with UTC time zone to full DateTime
+            Assert.That(DateTimeConverter.ConvertToDateTime("20021201-11:03:05.231116500Z", TimeStampPrecision.Nanosecond), Is.EqualTo(dt));
+
+            // convert nanosecond time with non-UTC positive offset time zone to full DateTime
+            Assert.That(DateTimeConverter.ConvertToDateTime("20021201-06:03:05.231116500+05", TimeStampPrecision.Nanosecond), Is.EqualTo(dt));
+
+            // convert nanosecond time with non-UTC negative offset time zone to full DateTime
+            Assert.That(DateTimeConverter.ConvertToDateTime("20021201-08:03:05.231116500-03", TimeStampPrecision.Nanosecond), Is.EqualTo(dt));
+
+            // convert nanosecond time in local time (no time zone) to full DateTime
+            DateTime local = DateTime.SpecifyKind(makeDateTime(2002, 12, 01, 11, 03, 05, 231, 116, 500), DateTimeKind.Local);
+            Assert.That(DateTimeConverter.ConvertToDateTime("20021201-11:03:05.231116500", TimeStampPrecision.Nanosecond), Is.EqualTo(local));
         }
     }
 }

--- a/UnitTests/FieldTests.cs
+++ b/UnitTests/FieldTests.cs
@@ -80,8 +80,21 @@ namespace UnitTests
             Assert.That(field.Obj, Is.EqualTo(newval));
             Assert.That(field.ToString(), Is.EqualTo("20090904-03:44:01.000"));
         }
-
-
+        
+        [Test]
+        public void DateTimeFieldNanoTest()
+        {
+            DateTime val = ConverterTests.makeDateTime(2009, 9, 4, 3, 44, 1, 100, 310, 300);
+            DateTime newval = ConverterTests.makeDateTime(2009, 9, 4, 3, 44, 1, 100, 310, 300);
+            DateTimeField field = new DateTimeField(200, val, QuickFix.Fields.Converters.TimeStampPrecision.Nanosecond);
+            Assert.That(field.Obj, Is.EqualTo(val));
+            Assert.That(field.getValue(), Is.EqualTo(val));
+            Assert.That(field.Tag, Is.EqualTo(200));
+            field.Obj = newval;
+            Assert.That(field.Obj, Is.EqualTo(newval));
+            Assert.That(field.ToString(), Is.EqualTo("20090904-03:44:01.100310300"));
+        }
+        
         [Test]
         public void StringFieldTest_TotalAndLength()
         {

--- a/generator/fields_gen.rb
+++ b/generator/fields_gen.rb
@@ -108,7 +108,9 @@ HERE
         public #{field[:name]}(#{field[:base_type]} val)
             :base(Tags.#{field[:name]}, val) {}
         public #{field[:name]}(#{field[:base_type]} val, bool showMilliseconds)
-	    :base(Tags.#{field[:name]}, val, showMilliseconds) {}
+            :base(Tags.#{field[:name]}, val, showMilliseconds) {}
+		public #{field[:name]}(#{field[:base_type]} val, Converters.TimeStampPrecision precision)
+            :base(Tags.#{field[:name]}, val, precision) {}
 #{fix_values(field)}
     }
 


### PR DESCRIPTION
This pull request provides limited nanosecond support for ISO 8601 formats.  String parsing into nanosecond DateTime objects using the QuickFIX/n Converter library support the Z UTC suffix, GMT offset suffixes, and local time.

A note on usage: the `DateTimeField`'s most precise constructor accepts a `DateTime` object and a `TimeStampPrecision` flag.  This flag must be `TimeStampPrecision.Nanosecond` to support string conversions with nanosecond precision.  A QuickFIX/n `DateTimeField` will preserve nanosecond fractional precision according to the `DateTime` ticks passed into the `DateTimeField` constructor.

A note on limited nanosecond support: the Windows system operates its system clock in the concept of 'ticks', of which the smallest resolution is 100 nanoseconds.  This library is limited by the Windows API's tick resolution, and can only support a maximum resolution of 100 nanosecond intervals.  Time conversions with more precision than the Windows API supports will be truncated to the lowest 100ns boundary.

For usage information manipulating nanosecond `DateTime` objects, see the [nanosecond Converter unit tests](https://github.com/brobits/quickfixn/blob/nanos/UnitTests/ConverterTests.cs#L158).

For usage information manipulating nanosecond `DateTimeField` QuickFIX/n objects, see the [nanosecond DateTimeField unit tests](https://github.com/brobits/quickfixn/blob/nanos/UnitTests/FieldTests.cs#L85).