### PR TITLE
Correct ordering in message trailer

### DIFF
--- a/QuickFIXn/Message/Message.cs
+++ b/QuickFIXn/Message/Message.cs
@@ -32,6 +32,8 @@ namespace QuickFix
 
     public class Trailer : FieldMap
     {
+        public int[] TRAILER_FIELD_ORDER = { Tags.SignatureLength, Tags.Signature, Tags.CheckSum };
+
         public Trailer()
             : base()
         { }
@@ -39,6 +41,16 @@ namespace QuickFix
         public Trailer(Trailer src)
             : base(src)
         { }
+
+        public override string CalculateString()
+        {
+            return base.CalculateString(new StringBuilder(), TRAILER_FIELD_ORDER);
+        }
+
+        public override string CalculateString(StringBuilder sb, int[] preFields)
+        {
+            return base.CalculateString(sb, TRAILER_FIELD_ORDER);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
I was using this package to connect to an RMS that required a signature to be filled. When I filled both Signature and SignatureLength, the message trailer fields became out of order, the checksum was not being sent as the last field of the message, as it should be.