### PR TITLE
Added check if key exists in SessionState MessageQueue dictionary, before adding new element

### DIFF
--- a/QuickFIXn/SessionState.cs
+++ b/QuickFIXn/SessionState.cs
@@ -300,7 +300,10 @@ namespace QuickFix
 
         public void Queue(int msgSeqNum, Message msg)
         {
-            MsgQueue.Add(msgSeqNum, msg);
+            if (!MsgQueue.ContainsKey(msgSeqNum))
+            {
+                MsgQueue.Add(msgSeqNum, msg);
+            }
         }
 
         public void ClearQueue()


### PR DESCRIPTION
This is a situation I ran into.
Upon reconnection, after Logon handshake, these messages are exchanged

(A => B) RESENDREQUEST 34-0
**(B => A) RESENDREQUEST 87-0
(B => A) EXECUTIONREPORT (MsgSeqNum: 37)**
(A => B) SEQUENCERESET (NewSeqNo: 91)
**(B => A) SEQUENCERESET (NewSeqNo: 37)
(B => A) EXECUTIONREPORT (MsgSeqNum: 37, PossDupFlag: Y)**

This last message results with an exception "_Verify failed: An item with the same key has already been added._" The fix service restarts after that.
The reason is that message with sequence number 37 is already in MessageQueue dictionary when the second EXECUTIONREPORT arrives (as a response to RESENDREQUEST) so the attempt to add a new message with the same sequence number causes an exception.
I simply added a check if key is already in dictionary, before adding new message to it.