### PR TITLE
fix multibyte charachters error

### DIFF
--- a/QuickFIXn/SocketInitiatorThread.cs
+++ b/QuickFIXn/SocketInitiatorThread.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 
 namespace QuickFix
 {
+    /// TEST
     /// <summary>
     /// Handles a connection with an acceptor.
     /// </summary>

--- a/QuickFIXn/SocketInitiatorThread.cs
+++ b/QuickFIXn/SocketInitiatorThread.cs
@@ -7,7 +7,7 @@ using System.Diagnostics;
 
 namespace QuickFix
 {
-    /// TEST
+
     /// <summary>
     /// Handles a connection with an acceptor.
     /// </summary>

--- a/QuickFIXn/SocketInitiatorThread.cs
+++ b/QuickFIXn/SocketInitiatorThread.cs
@@ -81,7 +81,7 @@ namespace QuickFix
             {
                 int bytesRead = ReadSome(readBuffer_, 1000);
                 if (bytesRead > 0)
-                    parser_.AddToStream(System.Text.Encoding.UTF8.GetString(readBuffer_, 0, bytesRead));
+                    parser_.AddToStream(ref readBuffer_, bytesRead);
                 else if (null != session_)
                 {
                     session_.Next();

--- a/QuickFIXn/SocketReader.cs
+++ b/QuickFIXn/SocketReader.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace QuickFix
 {
-    /// TEST
+    
     /// <summary>
     /// TODO merge with SocketInitiatorThread
     /// </summary>

--- a/QuickFIXn/SocketReader.cs
+++ b/QuickFIXn/SocketReader.cs
@@ -4,6 +4,8 @@ using System;
 
 namespace QuickFix
 {
+
+    
     /// <summary>
     /// TODO merge with SocketInitiatorThread
     /// </summary>

--- a/QuickFIXn/SocketReader.cs
+++ b/QuickFIXn/SocketReader.cs
@@ -4,8 +4,6 @@ using System;
 
 namespace QuickFix
 {
-
-    
     /// <summary>
     /// TODO merge with SocketInitiatorThread
     /// </summary>

--- a/QuickFIXn/SocketReader.cs
+++ b/QuickFIXn/SocketReader.cs
@@ -4,7 +4,6 @@ using System;
 
 namespace QuickFix
 {
-
     /// <summary>
     /// TODO merge with SocketInitiatorThread
     /// </summary>

--- a/QuickFIXn/SocketReader.cs
+++ b/QuickFIXn/SocketReader.cs
@@ -43,7 +43,7 @@ namespace QuickFix
             {
                 int bytesRead = ReadSome(readBuffer_, 1000);
                 if (bytesRead > 0)
-                    parser_.AddToStream(System.Text.Encoding.UTF8.GetString(readBuffer_, 0, bytesRead));
+                    parser_.AddToStream(ref readBuffer_, bytesRead);
                 else if (null != qfSession_)
                 {
                     qfSession_.Next();

--- a/QuickFIXn/SocketReader.cs
+++ b/QuickFIXn/SocketReader.cs
@@ -4,6 +4,7 @@ using System;
 
 namespace QuickFix
 {
+    /// TEST
     /// <summary>
     /// TODO merge with SocketInitiatorThread
     /// </summary>

--- a/UnitTests/MultibyteCharTests.cs
+++ b/UnitTests/MultibyteCharTests.cs
@@ -1,0 +1,52 @@
+﻿using NUnit.Framework;
+using QuickFix;
+using System.IO;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace UnitTests {
+  [TestFixture]
+  public class MultibyteCharTests {
+    [Test]
+    public void SocketInitiatorTest() {
+
+      var sit = new SocketInitiatorThread(null, null, null, null);
+      string str = 'a' + new string((char)0x0430, 260); // Error
+      //string str = new string((char)0x0430, 260);     // OK
+
+      byte[] buf = Encoding.UTF8.GetBytes(str);
+      MemoryStream ms = new MemoryStream(buf);
+      sit.GetType().GetField("stream_", BindingFlags.NonPublic | BindingFlags.SetField | BindingFlags.Instance).SetValue(sit, ms);
+      sit.Read();
+      sit.Read();
+
+      var parser = sit.GetType().GetField("parser_", BindingFlags.NonPublic | BindingFlags.GetField | BindingFlags.Instance).GetValue(sit);
+      var usedBufferLength = parser.GetType().GetField("usedBufferLength", BindingFlags.NonPublic | BindingFlags.GetField | BindingFlags.Instance).GetValue(parser);
+      Assert.That((int)usedBufferLength == buf.Length);
+    }
+
+    [Test]
+    public void SocketReaderTest() {
+
+      SocketReader sr = FormatterServices.GetUninitializedObject(typeof(SocketReader)) as SocketReader;
+
+      string str = 'a' + new string((char)0x0430, 260); // Error
+      //string str = new string((char)0x0430, 260);     // OK
+
+      byte[] buf = Encoding.UTF8.GetBytes(str);
+      MemoryStream ms = new MemoryStream(buf);
+      byte[] readBuffer = new byte[512];
+      Parser parser = new Parser();
+      sr.GetType().GetField("readBuffer_", BindingFlags.NonPublic | BindingFlags.SetField | BindingFlags.Instance).SetValue(sr, readBuffer);
+      sr.GetType().GetField("parser_", BindingFlags.NonPublic | BindingFlags.SetField | BindingFlags.Instance).SetValue(sr, parser);
+      sr.GetType().GetField("stream_", BindingFlags.NonPublic | BindingFlags.SetField | BindingFlags.Instance).SetValue(sr, ms);
+      sr.Read();
+      sr.Read();
+
+      var usedBufferLength = parser.GetType().GetField("usedBufferLength", BindingFlags.NonPublic | BindingFlags.GetField | BindingFlags.Instance).GetValue(parser);
+      Assert.That((int)usedBufferLength == buf.Length);
+
+    }
+  }
+}


### PR DESCRIPTION
The error occurs when one byte of a multibyte character is the last in the buffer and the other byte is at the beginning of the next buffer.