### PR TITLE
Fix ObjectDisposedException  when SocketInitiator is stopped before connection attempt fails

### DIFF
--- a/QuickFIXn/Session.cs
+++ b/QuickFIXn/Session.cs
@@ -25,6 +25,7 @@ namespace QuickFix
         private IMessageFactory msgFactory_;
         private bool appDoesEarlyIntercept_;
         private static readonly HashSet<string> AdminMsgTypes = new HashSet<string>() { "0", "A", "1", "2", "3", "4", "5" };
+        private bool disposed_;
 
         #endregion
 
@@ -1678,12 +1679,20 @@ namespace QuickFix
 
         public void Dispose()
         {
-            if (state_ != null) { state_.Dispose(); }
-            lock (sessions_)
+            if (!disposed_)
             {
-                sessions_.Remove(this.SessionID);
+                if (state_ != null) { state_.Dispose(); }
+                lock (sessions_)
+                {
+                    sessions_.Remove(this.SessionID);
+                }
+                disposed_ = true;
             }
+        }
 
+        public bool Disposed
+        {
+            get { return disposed_; }
         }
     }
 }

--- a/QuickFIXn/Transport/SocketInitiator.cs
+++ b/QuickFIXn/Transport/SocketInitiator.cs
@@ -55,60 +55,54 @@ namespace QuickFix.Transport
         {
             SocketInitiatorThread t = socketInitiatorThread as SocketInitiatorThread;
             if (t == null) return;
+
+            string exceptionEvent = null;
             try
             {
-                t.Connect();
-                t.Initiator.SetConnected(t.Session.SessionID);
-                t.Session.Log.OnEvent("Connection succeeded");
-                t.Session.Next();
-                while (t.Read())
-                {
-                }
-
-                if (t.Initiator.IsStopped)
-                    t.Initiator.RemoveThread(t);
-                t.Initiator.SetDisconnected(t.Session.SessionID);
-            }
-            catch (IOException ex) // Can be exception when connecting, during ssl authentication or when reading
-            {
-                t.Session.Log.OnEvent("Connection failed: " + ex.Message);
-            }
-            catch (SocketException e)
-            {
-                t.Session.Log.OnEvent("Connection failed: " + e.Message);
-            }
-            catch (System.Security.Authentication.AuthenticationException ex) // some certificate problems
-            {
-                t.Session.Log.OnEvent("Connection failed (AuthenticationException): " + ex.Message);
-            }
-            catch (ObjectDisposedException ex)
-            {
-                // There's a chance that the logger is the thing that got disposed,
-                // so let's make sure we're not going to throw a repeat exception
-                // by hitting that logger again.
-
                 try
                 {
-                    t.Session.Log.OnEvent(ex.ToString());
+                    t.Connect();
+                    t.Initiator.SetConnected(t.Session.SessionID);
+                    t.Session.Log.OnEvent("Connection succeeded");
+                    t.Session.Next();
+                    while (t.Read())
+                    {
+                    }
+
+                    if (t.Initiator.IsStopped)
+                        t.Initiator.RemoveThread(t);
+                    t.Initiator.SetDisconnected(t.Session.SessionID);
                 }
-                catch (ObjectDisposedException ode)
+                catch (IOException ex) // Can be exception when connecting, during ssl authentication or when reading
                 {
-                    // Can't use the logger, so write a different file.
-                    System.IO.StreamWriter sw = System.IO.File.AppendText("ObjectDisposedException.log");
-                    try
+                    exceptionEvent = $"Connection failed: {ex.Message}";
+                }
+                catch (SocketException e)
+                {
+                    exceptionEvent = $"Connection failed: {e.Message}";
+                }
+                catch (System.Security.Authentication.AuthenticationException ex) // some certificate problems
+                {
+                    exceptionEvent = $"Connection failed (AuthenticationException): {ex.Message}";
+                }
+                catch (Exception ex)
+                {
+                    exceptionEvent = $"Unexpected exception: {ex}";
+                }
+
+                if (exceptionEvent != null)
+                {
+                    if (t.Session.Disposed)
                     {
-                        string logLine = $"{System.DateTime.Now:G}: {ode}";
-                        sw.WriteLine(logLine);
+                        // The session is disposed, and so is its log. We cannot use it to log the event,
+                        // so we resort to storing it in a local file.
+                        File.AppendAllText("DisposedSessionEvents.log", $"{System.DateTime.Now:G}: {exceptionEvent}{Environment.NewLine}");
                     }
-                    finally
+                    else
                     {
-                        sw.Close();
+                        t.Session.Log.OnEvent(exceptionEvent);
                     }
                 }
-            }
-            catch (Exception ex)
-            {
-                t.Session.Log.OnEvent("Unexpected exception: " + ex);
             }
             finally
             {

--- a/QuickFIXn/Transport/SocketInitiator.cs
+++ b/QuickFIXn/Transport/SocketInitiator.cs
@@ -96,7 +96,14 @@ namespace QuickFix.Transport
                     {
                         // The session is disposed, and so is its log. We cannot use it to log the event,
                         // so we resort to storing it in a local file.
-                        File.AppendAllText("DisposedSessionEvents.log", $"{System.DateTime.Now:G}: {exceptionEvent}{Environment.NewLine}");
+                        try
+                        {
+                            File.AppendAllText("DisposedSessionEvents.log", $"{System.DateTime.Now:G}: {exceptionEvent}{Environment.NewLine}");
+                        }
+                        catch (IOException)
+                        {
+                            // Prevent IO exceptions from crashing the application
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
I have encountered a problem when invoking the Stop() method of a SocketInitiator after a connection attempt has been initiated, but before it fails with a connection error. This leads to an ObjectDisposedException being thrown when attempting to log the connection error in the session's Log, which has already been disposed at that point as part of the Stop() invocation.

The current try/catch implementation does not manage to handle this correctly, because control has already flowed to another catch branch, and the ObjectDisposedException is triggered there. Furthermore, a naive fix that extracts the handling of an ObjectDisposedException handler in an outer try/catch block also fails in certain multi-threaded situations because the file "ObjectDisposedException.log" is kept exclusively locked for too long.

The proposed change does the following:
1) Introduces a way for the SocketInitiator to determine whether the session has already been disposed;
2) Only attempts to log an error to the session's log if it has not already been disposed;
3) Appends the error to the local file "DisposedSessionEvents.log" if the session has already been disposed; doing this through File.AppendAllText(...) seems to mitigate the problem with exclusive locking of the file in multi-threaded situations.

