### PR TITLE
Allow groups where the first entry is a group

### DIFF
--- a/QuickFIXn/DataDictionary/DataDictionary.cs
+++ b/QuickFIXn/DataDictionary/DataDictionary.cs
@@ -608,6 +608,12 @@ namespace QuickFix.DataDictionary
 					grp.NumFld = fld.Tag; 
 					ParseMsgEl(childNode, grp);
 					ddmap.Groups.Add(fld.Tag, grp);
+					
+					// if first field in group, make it the DELIM
+					if ((ddmap.GetType() == typeof(DDGrp) && ((DDGrp)ddmap).Delim == 0))
+					{
+						((DDGrp)ddmap).Delim = fld.Tag;
+					}
 				}
                 else if (childNode.Name == "component")
                 {


### PR DESCRIPTION
rather than a field.

Currently, this results in the GroupDelimiterTagException "Group 123's first entry does not start with delimiter 0"

N.B. I have tested this only very lightly so far, and it addresses the problem