### PR TITLE
Do not ignore MsgSeqNum on ResendRequest when no persistence

### DIFF
--- a/QuickFIXn/Session.cs
+++ b/QuickFIXn/Session.cs
@@ -795,6 +795,11 @@ namespace QuickFix
                         if (endSeqNo > next)
                             endSeqNo = next;
                         GenerateSequenceReset(resendReq, begSeqNo, endSeqNo);
+                        msgSeqNum = resendReq.Header.GetInt(Tags.MsgSeqNum);
+                        if (!IsTargetTooHigh(msgSeqNum) && !IsTargetTooLow(msgSeqNum))
+                        {
+                            state_.IncrNextTargetMsgSeqNum();
+                        }
                         return;
                     }
 


### PR DESCRIPTION
MsgSeqNum on ResendRequest messages is currently ignored when message persistence is disabled. Hence, when a new message is received following a ResendRequest its validation fails as the expected target sequence number is one down from the actual (since the one on ResendRequest was ignored). This should be fixed.