### PR TITLE
don't attempt proxy access on .NET Core

### DIFF
--- a/QuickFIXn/Transport/StreamFactory.cs
+++ b/QuickFIXn/Transport/StreamFactory.cs
@@ -24,8 +24,17 @@ namespace QuickFix.Transport
             Uri destUri = uriBuilder.Uri;
             IWebProxy webProxy = WebRequest.GetSystemWebProxy();
 
-            if (webProxy.IsBypassed(destUri))
+            try
+            {
+                if (webProxy.IsBypassed(destUri))
+                    return null;
+            }
+            catch (PlatformNotSupportedException)
+            {
+                // .NET Core doesn't support IWebProxy.IsBypassed
+                // (because .NET Core doesn't have access to Windows-specific services, of course)
                 return null;
+            }
 
             Uri proxyUri = webProxy.GetProxy(destUri);
             IPAddress[] proxyEntry = Dns.GetHostAddresses(proxyUri.Host);

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -24,6 +24,7 @@ What's New
 * (minor) #521 - fix misspelled session reject reason (vpfau)
 * (minor) #524 - add tunnel support; expand cert store search to include LocalMachine (nileshwagel/gbirchmeier)
 * (minor) #531 - change encoding to iso-8859-1 (aka latin1) (amibar/gbirchmeier)
+* (patch) #532 - bug in #524: don't attempt non-.NET-Core-supported functionality (gbirchmeier)
 
 ### v1.8.0:
 * (patch) #402 - Multithreading fix to please NUnit 2.6.3 and above (arkadiuszwojcik)


### PR DESCRIPTION
This feature is not supported on .NET Core.
This bug was introduced in #524.