### PR TITLE
upmerged #296 and finish -- FieldMap.GetField now obsolete, use .GetString instead

### DIFF
--- a/AcceptanceTest/ATApplication.cs
+++ b/AcceptanceTest/ATApplication.cs
@@ -104,7 +104,7 @@ namespace AcceptanceTest
             if (message.Header.IsSetField(QuickFix.Fields.Tags.PossResend))
                 possResend = message.Header.GetBoolean(QuickFix.Fields.Tags.PossResend);
 
-            KeyValuePair<string, SessionID> pair = new KeyValuePair<string, SessionID>(message.GetField(QuickFix.Fields.Tags.ClOrdID), sessionID);
+            KeyValuePair<string, SessionID> pair = new KeyValuePair<string, SessionID>(message.GetString(QuickFix.Fields.Tags.ClOrdID), sessionID);
             if (possResend && clOrdIDs_.Contains(pair))
                 return;
             clOrdIDs_.Add(pair);
@@ -160,9 +160,10 @@ namespace AcceptanceTest
         {
             try
             {
-                string msgType = message.Header.GetField(QuickFix.Fields.Tags.MsgType);
+                string msgType = message.Header.GetString(QuickFix.Fields.Tags.MsgType);
                 // log_.OnEvent("Got message " + msgType);
                 // System.Console.WriteLine("===got message " + msgType);
+
                 Crack(message, sessionID);
             }
             catch (QuickFix.UnsupportedMessageType)

--- a/Examples/TradeClient/TradeClientApp.cs
+++ b/Examples/TradeClient/TradeClientApp.cs
@@ -48,7 +48,7 @@ namespace TradeClient
                 if (message.Header.IsSetField(QuickFix.Fields.Tags.PossDupFlag))
                 {
                     possDupFlag = QuickFix.Fields.Converters.BoolConverter.Convert(
-                        message.Header.GetField(QuickFix.Fields.Tags.PossDupFlag)); /// FIXME
+                        message.Header.GetString(QuickFix.Fields.Tags.PossDupFlag)); /// FIXME
                 }
                 if (possDupFlag)
                     throw new DoNotSend();
@@ -162,7 +162,7 @@ namespace TradeClient
 
             if (m != null && QueryConfirm("Send order"))
             {
-                m.Header.GetField(Tags.BeginString);
+                m.Header.GetString(Tags.BeginString);
 
                 SendMessage(m);
             }

--- a/QuickFIXn/Message/FieldMap.cs
+++ b/QuickFIXn/Message/FieldMap.cs
@@ -523,6 +523,7 @@ namespace QuickFix
         /// getField without a type defaults to returning a string
         /// </summary>
         /// <param name="tag">fix tag</param>
+        [Obsolete("Use GetString instead.")]
         public string GetField(int tag)
         {
             if (_fields.ContainsKey(tag))
@@ -622,7 +623,7 @@ namespace QuickFix
             {
                 if (IsSetField(preField))
                 {
-                    sb.Append(preField + "=" + GetField(preField)).Append(Message.SOH);
+                    sb.Append(preField + "=" + GetString(preField)).Append(Message.SOH);
                     if (groupCounterTags.Contains(preField))
                     {
                         List<Group> glist = _groups[preField];

--- a/QuickFIXn/Message/Message.cs
+++ b/QuickFIXn/Message/Message.cs
@@ -251,7 +251,7 @@ namespace QuickFix
 
             try
             {
-                return fields.GetField(tag);
+                return fields.GetString(tag);
             }
             catch (FieldNotFoundException)
             {
@@ -592,7 +592,7 @@ namespace QuickFix
 
             if (header.IsSetField(Tags.BeginString))
             {
-                string beginString = header.GetField(Tags.BeginString);
+                string beginString = header.GetString(Tags.BeginString);
                 if (beginString.Length > 0)
                     this.Header.SetField(new BeginString(beginString));
 
@@ -603,14 +603,14 @@ namespace QuickFix
                 {
                     if (header.IsSetField(Tags.OnBehalfOfLocationID))
                     {
-                        string onBehalfOfLocationID = header.GetField(Tags.OnBehalfOfLocationID);
+                        string onBehalfOfLocationID = header.GetString(Tags.OnBehalfOfLocationID);
                         if (onBehalfOfLocationID.Length > 0)
                             this.Header.SetField(new DeliverToLocationID(onBehalfOfLocationID));
                     }
 
                     if (header.IsSetField(Tags.DeliverToLocationID))
                     {
-                        string deliverToLocationID = header.GetField(Tags.DeliverToLocationID);
+                        string deliverToLocationID = header.GetString(Tags.DeliverToLocationID);
                         if (deliverToLocationID.Length > 0)
                             this.Header.SetField(new OnBehalfOfLocationID(deliverToLocationID));
                     }
@@ -673,28 +673,28 @@ namespace QuickFix
 
             if(header.IsSetField(Tags.OnBehalfOfCompID))
             {
-                string onBehalfOfCompID = header.GetField(Tags.OnBehalfOfCompID);
+                string onBehalfOfCompID = header.GetString(Tags.OnBehalfOfCompID);
                 if(onBehalfOfCompID.Length > 0)
                     this.Header.SetField(new DeliverToCompID(onBehalfOfCompID));
             }
 
             if(header.IsSetField(Tags.OnBehalfOfSubID))
             {
-                string onBehalfOfSubID = header.GetField(  Tags.OnBehalfOfSubID);
+                string onBehalfOfSubID = header.GetString(  Tags.OnBehalfOfSubID);
                 if(onBehalfOfSubID.Length > 0)
                     this.Header.SetField(new DeliverToSubID(onBehalfOfSubID));
             }
 
             if(header.IsSetField(Tags.DeliverToCompID))
             {
-                string deliverToCompID = header.GetField(Tags.DeliverToCompID);
+                string deliverToCompID = header.GetString(Tags.DeliverToCompID);
                 if(deliverToCompID.Length > 0)
                     this.Header.SetField(new OnBehalfOfCompID(deliverToCompID));
             }
 
             if(header.IsSetField(Tags.DeliverToSubID))
             {
-                string deliverToSubID = header.GetField(Tags.DeliverToSubID);
+                string deliverToSubID = header.GetString(Tags.DeliverToSubID);
                 if(deliverToSubID.Length > 0)
                     this.Header.SetField(new OnBehalfOfSubID(deliverToSubID));
             }
@@ -710,12 +710,12 @@ namespace QuickFix
 
         public bool IsAdmin()
         {
-            return this.Header.IsSetField(Tags.MsgType) && IsAdminMsgType(this.Header.GetField(Tags.MsgType));
+            return this.Header.IsSetField(Tags.MsgType) && IsAdminMsgType(this.Header.GetString(Tags.MsgType));
         }
 
         public bool IsApp()
         {
-            return this.Header.IsSetField(Tags.MsgType) && !IsAdminMsgType(this.Header.GetField(Tags.MsgType));
+            return this.Header.IsSetField(Tags.MsgType) && !IsAdminMsgType(this.Header.GetString(Tags.MsgType));
         }
 
         /// <summary>
@@ -745,18 +745,18 @@ namespace QuickFix
             bool targetLocationIDSet = m.Header.IsSetField(Tags.TargetLocationID);
 
             if (senderSubIDSet && senderLocationIDSet && targetSubIDSet && targetLocationIDSet)
-                return new SessionID(m.Header.GetField(Tags.BeginString),
-                    m.Header.GetField(Tags.SenderCompID), m.Header.GetField(Tags.SenderSubID), m.Header.GetField(Tags.SenderLocationID),
-                    m.Header.GetField(Tags.TargetCompID), m.Header.GetField(Tags.TargetSubID), m.Header.GetField(Tags.TargetLocationID));
+                return new SessionID(m.Header.GetString(Tags.BeginString),
+                    m.Header.GetString(Tags.SenderCompID), m.Header.GetString(Tags.SenderSubID), m.Header.GetString(Tags.SenderLocationID),
+                    m.Header.GetString(Tags.TargetCompID), m.Header.GetString(Tags.TargetSubID), m.Header.GetString(Tags.TargetLocationID));
             else if (senderSubIDSet && targetSubIDSet)
-                return new SessionID(m.Header.GetField(Tags.BeginString),
-                    m.Header.GetField(Tags.SenderCompID), m.Header.GetField(Tags.SenderSubID),
-                    m.Header.GetField(Tags.TargetCompID), m.Header.GetField(Tags.TargetSubID));
+                return new SessionID(m.Header.GetString(Tags.BeginString),
+                    m.Header.GetString(Tags.SenderCompID), m.Header.GetString(Tags.SenderSubID),
+                    m.Header.GetString(Tags.TargetCompID), m.Header.GetString(Tags.TargetSubID));
             else
                 return new SessionID(
-                    m.Header.GetField(Tags.BeginString),
-                    m.Header.GetField(Tags.SenderCompID),
-                    m.Header.GetField(Tags.TargetCompID));
+                    m.Header.GetString(Tags.BeginString),
+                    m.Header.GetString(Tags.SenderCompID),
+                    m.Header.GetString(Tags.TargetCompID));
         }
 
         public override void Clear()

--- a/QuickFIXn/Session.cs
+++ b/QuickFIXn/Session.cs
@@ -952,9 +952,9 @@ namespace QuickFix
 
             try
             {
-                msgType = msg.Header.GetField(Fields.Tags.MsgType);
-                string senderCompID = msg.Header.GetField(Fields.Tags.SenderCompID);
-                string targetCompID = msg.Header.GetField(Fields.Tags.TargetCompID);
+                msgType = msg.Header.GetString(Fields.Tags.MsgType);
+                string senderCompID = msg.Header.GetString(Fields.Tags.SenderCompID);
+                string targetCompID = msg.Header.GetString(Fields.Tags.TargetCompID);
 
                 if (!IsCorrectCompID(senderCompID, targetCompID))
                 {
@@ -989,7 +989,7 @@ namespace QuickFix
                     {
                         this.Log.OnEvent("Chunked ResendRequest for messages FROM: " + range.BeginSeqNo + " TO: " + range.ChunkEndSeqNo + " has been satisfied.");
                         int newChunkEndSeqNo = Math.Min(range.EndSeqNo, range.ChunkEndSeqNo + this.MaxMessagesInResendRequest);
-                        GenerateResendRequestRange(msg.Header.GetField(Fields.Tags.BeginString), range.ChunkEndSeqNo + 1, newChunkEndSeqNo);
+                        GenerateResendRequestRange(msg.Header.GetString(Fields.Tags.BeginString), range.ChunkEndSeqNo + 1, newChunkEndSeqNo);
                         range.ChunkEndSeqNo = newChunkEndSeqNo;
                     }
                 }
@@ -1107,7 +1107,7 @@ namespace QuickFix
 
         protected void DoTargetTooHigh(Message msg, int msgSeqNum)
         {
-            string beginString = msg.Header.GetField(Fields.Tags.BeginString);
+            string beginString = msg.Header.GetString(Fields.Tags.BeginString);
 
             this.Log.OnEvent("MsgSeqNum too high, expecting " + state_.GetNextTargetMsgSeqNum() + " but received " + msgSeqNum);
             state_.Queue(msgSeqNum, msg);
@@ -1150,7 +1150,7 @@ namespace QuickFix
         {
             // If config RequiresOrigSendingTime=N, then tolerate SequenceReset messages that lack OrigSendingTime (issue #102).
             // (This field doesn't really make sense in this message, so some parties omit it, even though spec requires it.)
-            string msgType = msg.Header.GetField(Fields.Tags.MsgType); 
+            string msgType = msg.Header.GetString(Fields.Tags.MsgType); 
             if (msgType == Fields.MsgType.SEQUENCE_RESET && RequiresOrigSendingTime == false)
                 return;
 
@@ -1372,7 +1372,7 @@ namespace QuickFix
             InitializeHeader(heartbeat);
             try
             {
-                heartbeat.SetField(new Fields.TestReqID(testRequest.GetField(Fields.Tags.TestReqID)));
+                heartbeat.SetField(new Fields.TestReqID(testRequest.GetString(Fields.Tags.TestReqID)));
                 if (this.EnableLastMsgSeqNumProcessed)
                 {
                     heartbeat.Header.SetField(new Fields.LastMsgSeqNumProcessed(testRequest.Header.GetInt(Tags.MsgSeqNum)));
@@ -1409,7 +1409,7 @@ namespace QuickFix
 
             string msgType;
             if (message.Header.IsSetField(Fields.Tags.MsgType))
-                msgType = message.Header.GetField(Fields.Tags.MsgType);
+                msgType = message.Header.GetString(Fields.Tags.MsgType);
             else
                 msgType = "";
 
@@ -1637,7 +1637,7 @@ namespace QuickFix
         {
             lock (sync_)
             {
-                string msgType = message.Header.GetField(Fields.Tags.MsgType);
+                string msgType = message.Header.GetString(Fields.Tags.MsgType);
 
                 InitializeHeader(message, seqNum);
 

--- a/UnitTests/FieldMapTests.cs
+++ b/UnitTests/FieldMapTests.cs
@@ -236,7 +236,7 @@ namespace UnitTests
         {
             DecimalField field = new DecimalField(200, new Decimal(101.0001));
             fieldmap.SetField(field);
-            string refield = fieldmap.GetField(200);
+            string refield = fieldmap.GetString(200);
             Assert.That("101.0001", Is.EqualTo(refield));
         }
 
@@ -263,7 +263,7 @@ namespace UnitTests
         public void FieldNotFoundTest()
         {
             Assert.Throws(typeof(FieldNotFoundException),
-                delegate { fieldmap.GetField(99900); });
+                delegate { fieldmap.GetString(99900); });
             Assert.Throws(typeof(FieldNotFoundException),
                 delegate { fieldmap.GetField(new DateTimeField(1002030)); });
             Assert.Throws(typeof(FieldNotFoundException),

--- a/UnitTests/MessageTests.cs
+++ b/UnitTests/MessageTests.cs
@@ -922,10 +922,10 @@ namespace UnitTests
             message.SetFields(new IField[] { allocAccount, allocAccountType, allocId });
 
             Assert.AreEqual(true, message.IsSetField(Tags.AllocID));
-            Assert.AreEqual("123456", message.GetField(Tags.AllocID));
+            Assert.AreEqual("123456", message.GetString(Tags.AllocID));
 
             Assert.AreEqual(true, message.IsSetField(Tags.AllocAccount));
-            Assert.AreEqual("QuickFixAccount", message.GetField(Tags.AllocAccount));
+            Assert.AreEqual("QuickFixAccount", message.GetString(Tags.AllocAccount));
 
             Assert.AreEqual(true, message.IsSetField(Tags.AllocAccountType));
             Assert.AreEqual(AllocAccountType.HOUSE_TRADER, message.GetInt(Tags.AllocAccountType));

--- a/UnitTests/SessionDynamicTest.cs
+++ b/UnitTests/SessionDynamicTest.cs
@@ -195,8 +195,8 @@ namespace UnitTests
                 {
                     Message message = new Message(socketState._messageFragment);
                     socketState._messageFragment = string.Empty;
-                    string targetCompID = message.Header.GetField(QuickFix.Fields.Tags.TargetCompID);
-                    if (message.Header.GetField(QuickFix.Fields.Tags.MsgType) == QuickFix.Fields.MsgType.LOGON)
+                    string targetCompID = message.Header.GetString(QuickFix.Fields.Tags.TargetCompID);
+                    if (message.Header.GetString(QuickFix.Fields.Tags.MsgType) == QuickFix.Fields.MsgType.LOGON)
                         lock (_sessions)
                         {
                             _sessions[targetCompID] = socketState;

--- a/UnitTests/SessionTest.cs
+++ b/UnitTests/SessionTest.cs
@@ -491,7 +491,7 @@ namespace UnitTests
             int count = -1;
             foreach (QuickFix.Message sequenceResestMsg in responder.msgLookup[QuickFix.Fields.MsgType.SEQUENCE_RESET])
             {
-                Assert.AreEqual(sequenceResestMsg.GetField(QuickFix.Fields.Tags.GapFillFlag), "Y");
+                Assert.AreEqual(sequenceResestMsg.GetString(QuickFix.Fields.Tags.GapFillFlag), "Y");
                 Assert.AreEqual(sequenceResestMsg.Header.GetInt(QuickFix.Fields.Tags.MsgSeqNum), gapStarts[++count]);
                 Assert.AreEqual(sequenceResestMsg.GetInt(QuickFix.Fields.Tags.NewSeqNo), gapEnds[count]);
             }
@@ -524,7 +524,7 @@ namespace UnitTests
         public void AssertMsInTag(string msgType, int tag, bool shouldHaveMs)
         {
             QuickFix.Message msg = responder.msgLookup[msgType].Last();
-            string sendingTime = msg.Header.GetField(tag);
+            string sendingTime = msg.Header.GetString(tag);
             Match m = msRegex.Match(sendingTime);
             Assert.That(m.Success == shouldHaveMs);
         }
@@ -532,7 +532,7 @@ namespace UnitTests
         public void AssertMicrosecondsInTag(string msgType, int tag, bool shouldHaveMicrosecond)
         {
             QuickFix.Message msg = responder.msgLookup[msgType].Last();
-            string sendingTime = msg.Header.GetField(tag);
+            string sendingTime = msg.Header.GetString(tag);
             Match m = microsecondRegex.Match(sendingTime);
             Assert.That(m.Success == shouldHaveMicrosecond);
         }


### PR DESCRIPTION
#296 was great, just really old.  Pulled it into my own branch and updated it to be finished according to latest.