### PR TITLE
correct ordering of fields in message trailer - #473

### DIFF
--- a/QuickFIXn/Message/Message.cs
+++ b/QuickFIXn/Message/Message.cs
@@ -30,6 +30,8 @@ namespace QuickFix
 
     public class Trailer : FieldMap
     {
+        public int[] TRAILER_FIELD_ORDER = { Tags.SignatureLength, Tags.Signature, Tags.CheckSum };
+
         public Trailer()
             : base()
         { }
@@ -37,6 +39,16 @@ namespace QuickFix
         public Trailer(Trailer src)
             : base(src)
         { }
+
+        public override string CalculateString()
+        {
+            return base.CalculateString(new StringBuilder(), TRAILER_FIELD_ORDER);
+        }
+
+        public override string CalculateString(StringBuilder sb, int[] preFields)
+        {
+            return base.CalculateString(sb, TRAILER_FIELD_ORDER);
+        }
     }
 
     /// <summary>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -29,6 +29,7 @@ What's New
 * (patch) #509 - Consistent sessionID argument name in IApplication (eugbaranov)
 * (patch) #296 - make FieldMap.GetField obsolete; favor .GetString instead (staffanu)
 * (patch) #478 - eliminate unnecessary string/byte flip-flop (gbirchmeier)
+* (patch) #473 - correct ordering of fields in message trailer (Ieshaj/gbirchmeier)
 
 ### v1.8.0:
 * (patch) #402 - Multithreading fix to please NUnit 2.6.3 and above (arkadiuszwojcik)

--- a/UnitTests/MessageTests.cs
+++ b/UnitTests/MessageTests.cs
@@ -930,5 +930,19 @@ namespace UnitTests
             Assert.AreEqual(true, message.IsSetField(Tags.AllocAccountType));
             Assert.AreEqual(AllocAccountType.HOUSE_TRADER, message.GetInt(Tags.AllocAccountType));
         }
+
+        [Test]
+        public void ChecksumIsLastFieldOfTrailer()
+        {
+            // issue 473
+            QuickFix.FIX42.News msg = new QuickFix.FIX42.News(new Headline("foobar"));
+            msg.LinesOfText = new LinesOfText(0);
+
+            msg.Trailer.SetField(new Signature("woot"));
+            msg.Trailer.SetField(new SignatureLength(4));
+
+            string foo = msg.ToString().Replace(Message.SOH, "|");
+            StringAssert.EndsWith("|10=099|", foo);
+        }
     }
 }


### PR DESCRIPTION
#473 