### PR TITLE
Implement Refresh() method in FileStore

### DIFF
--- a/QuickFIXn/FileStore.cs
+++ b/QuickFIXn/FileStore.cs
@@ -71,12 +71,21 @@ namespace QuickFix
 
         private void open()
         {
+            close();
+
             ConstructFromFileCache();
             InitializeSessionCreateTime();
 
             seqNumsFile_ = new System.IO.FileStream(seqNumsFileName_, System.IO.FileMode.OpenOrCreate, System.IO.FileAccess.ReadWrite);
             msgFile_ = new System.IO.FileStream(msgFileName_, System.IO.FileMode.OpenOrCreate, System.IO.FileAccess.ReadWrite);
             headerFile_ = new System.IO.StreamWriter(headerFileName_, true);
+        }
+
+        private void close()
+        {
+            seqNumsFile_?.Dispose();
+            msgFile_?.Dispose();
+            headerFile_?.Dispose();
         }
 
         private void PurgeSingleFile(System.IO.Stream stream, string filename)
@@ -270,7 +279,7 @@ namespace QuickFix
         [System.Obsolete("Use CreationTime instead")]
         public DateTime GetCreationTime()
         {
-            throw new NotImplementedException();
+            return CreationTime.GetValueOrDefault();
         }
 
         public void Reset()
@@ -282,7 +291,8 @@ namespace QuickFix
 
         public void Refresh()
         {
-            throw new NotImplementedException();
+            cache_.Reset();
+            open();
         }
 
         #endregion
@@ -291,9 +301,7 @@ namespace QuickFix
 
         public void Dispose()
         {
-            seqNumsFile_.Dispose();
-            msgFile_.Dispose();
-            headerFile_.Dispose();
+            close();
         }
 
         #endregion


### PR DESCRIPTION
This not being implemented actually breaks the 1.8 release when the FileStore is used. This was never implemented, but at least in version 1.5 it was never called.