### PR TITLE
fix FIX50 group creation bug; add NullLogFactory

### DIFF
--- a/QuickFIXn/AbstractInitiator.cs
+++ b/QuickFIXn/AbstractInitiator.cs
@@ -46,8 +46,8 @@ namespace QuickFix
             _app = app;
             _storeFactory = storeFactory;
             _settings = settings;
-            _logFactory = logFactory;
-            _msgFactory = messageFactory;
+            _logFactory = logFactory ?? new NullLogFactory();
+            _msgFactory = messageFactory ?? new DefaultMessageFactory();
 
             HashSet<SessionID> definedSessions = _settings.GetSessions();
             if (0 == definedSessions.Count)

--- a/QuickFIXn/DefaultMessageFactory.cs
+++ b/QuickFIXn/DefaultMessageFactory.cs
@@ -95,12 +95,11 @@ namespace QuickFix
 
         public Group Create(string beginString, string msgType, int groupCounterTag)
         {
-            // FIXME: This is a hack.  FIXT11 could mean 50 or 50sp1 or 50sp2.
-            // We need some way to choose which 50 version it is.
-            // Choosing 50 here is not adequate.
-            var key = beginString.Equals(FixValues.BeginString.FIXT11)
-                ? FixValues.BeginString.FIX50
-                : beginString;
+            string key = beginString;
+            if(beginString.Equals(FixValues.BeginString.FIXT11))
+            {
+                key = QuickFix.FixValues.ApplVerID.ToBeginString(_defaultApplVerId.getValue());
+            }
 
             if (_factories.TryGetValue(key, out var factory))
             {

--- a/QuickFIXn/NullLogFactory.cs
+++ b/QuickFIXn/NullLogFactory.cs
@@ -1,0 +1,12 @@
+﻿namespace QuickFix
+{
+    public class NullLogFactory : ILogFactory
+    {
+        public NullLogFactory() { }
+
+        public ILog Create(SessionID _x)
+        {
+            return new NullLog();
+        }
+    }
+}

--- a/QuickFIXn/SessionFactory.cs
+++ b/QuickFIXn/SessionFactory.cs
@@ -23,10 +23,18 @@ namespace QuickFix
 
         public SessionFactory(IApplication app, IMessageStoreFactory storeFactory, ILogFactory logFactory, IMessageFactory messageFactory)
         {
+            // TODO: for V2, consider ONLY instantiating MessageFactory in the Create() method,
+            //   and removing instance var messageFactory_ altogether.
+            //   This makes sense because we can't distinguish FIX50 versions here in this constructor,
+            //   and thus can't create the right FIX-Version factory because we don't know what
+            //   session to use to look up the BeginString and DefaultApplVerID.
+
             application_ = app;
             messageStoreFactory_ = storeFactory;
-            logFactory_ = logFactory;
+            logFactory_ = logFactory ?? new NullLogFactory();
             messageFactory_ = messageFactory ?? new DefaultMessageFactory();
+
+            System.Console.WriteLine("[SessionFactory] " + messageFactory_.GetType().FullName);
         }
 
         public Session Create(SessionID sessionID, QuickFix.Dictionary settings)
@@ -43,14 +51,26 @@ namespace QuickFix
                 useDataDictionary = settings.GetBool(SessionSettings.USE_DATA_DICTIONARY);
 
             QuickFix.Fields.ApplVerID defaultApplVerID = null;
+            IMessageFactory sessionMsgFactory = messageFactory_;
             if (sessionID.IsFIXT)
             {
                 if (!settings.Has(SessionSettings.DEFAULT_APPLVERID))
                 {
                     throw new ConfigError("ApplVerID is required for FIXT transport");
                 }
-                defaultApplVerID = Message.GetApplVerID(settings.GetString(SessionSettings.DEFAULT_APPLVERID));
-                
+                string rawDefaultApplVerIdSetting = settings.GetString(SessionSettings.DEFAULT_APPLVERID);
+
+                defaultApplVerID = Message.GetApplVerID(rawDefaultApplVerIdSetting);
+
+                // DefaultMessageFactory as created in the SessionFactory ctor cannot
+                // tell the difference between FIX50 versions (same BeginString, unknown defaultApplVerId).
+                // But we have the real session settings here, so we can fix that.
+                // This is, of course, kind of a hack, and it should be reworked in V2 (TODO!).
+                if (messageFactory_ is DefaultMessageFactory)
+                {
+                    sessionMsgFactory = new DefaultMessageFactory(
+                        FixValues.ApplVerID.FromBeginString(rawDefaultApplVerIdSetting));
+                }
             }
 
             DataDictionaryProvider dd = new DataDictionaryProvider();
@@ -81,7 +101,7 @@ namespace QuickFix
                 new SessionSchedule(settings),
                 heartBtInt,
                 logFactory_,
-                messageFactory_,
+                sessionMsgFactory,
                 senderDefaultApplVerId);
 
             if (settings.Has(SessionSettings.SEND_REDUNDANT_RESENDREQUESTS))

--- a/QuickFIXn/ThreadedSocketAcceptor.cs
+++ b/QuickFIXn/ThreadedSocketAcceptor.cs
@@ -5,8 +5,6 @@ using System;
 
 namespace QuickFix
 {
-    // TODO v2.0 - consider changing to internal
-
     /// <summary>
     /// Acceptor implementation - with threads
     /// Creates a ThreadedSocketReactor for every listening endpoint.
@@ -74,18 +72,57 @@ namespace QuickFix
 
         #region Constructors
 
+        /// <summary>
+        /// Create a ThreadedSocketAcceptor with a NullLogFactory and DefaultMessageFactory
+        /// </summary>
+        /// <param name="application"></param>
+        /// <param name="storeFactory"></param>
+        /// <param name="settings"></param>
         public ThreadedSocketAcceptor(IApplication application, IMessageStoreFactory storeFactory, SessionSettings settings)
-            : this(new SessionFactory(application, storeFactory), settings)
+            : this(application, storeFactory, settings, null, null)
         { }
 
+        /// <summary>
+        /// Create a ThreadedSocketAcceptor with a DefaultMessageFactory
+        /// </summary>
+        /// <param name="application"></param>
+        /// <param name="storeFactory"></param>
+        /// <param name="settings"></param>
+        /// <param name="logFactory"></param>
         public ThreadedSocketAcceptor(IApplication application, IMessageStoreFactory storeFactory, SessionSettings settings, ILogFactory logFactory)
-            : this(new SessionFactory(application, storeFactory, logFactory), settings)
+            : this(application, storeFactory, settings, logFactory, null)
         { }
 
-        public ThreadedSocketAcceptor(IApplication application, IMessageStoreFactory storeFactory, SessionSettings settings, ILogFactory logFactory, IMessageFactory messageFactory)
-            : this(new SessionFactory(application, storeFactory, logFactory, messageFactory), settings)
-        { }
+        /// <summary>
+        /// Create a ThreadedSocketAcceptor
+        /// </summary>
+        /// <param name="application"></param>
+        /// <param name="storeFactory"></param>
+        /// <param name="settings"></param>
+        /// <param name="logFactory">If null, a NullFactory will be used.</param>
+        /// <param name="messageFactory">If null, a DefaultMessageFactory will be created (using settings parameters)</param>
+        public ThreadedSocketAcceptor(
+            IApplication application,
+            IMessageStoreFactory storeFactory,
+            SessionSettings settings,
+            ILogFactory logFactory,
+            IMessageFactory messageFactory)
+        {
+            logFactory = logFactory ?? new NullLogFactory();
+            messageFactory = messageFactory ?? new DefaultMessageFactory();
+            SessionFactory sf = new SessionFactory(application, storeFactory, logFactory, messageFactory);
 
+            try
+            {
+                CreateSessions(settings, sf);
+            }
+            catch (System.Exception e)
+            {
+                throw new ConfigError(e.Message, e);
+            }
+        }
+
+        [Obsolete("Will be removed in a future release.")]
         public ThreadedSocketAcceptor(SessionFactory sessionFactory, SessionSettings settings)
         {
             try

--- a/UnitTests/DefaultMessageFactoryTests.cs
+++ b/UnitTests/DefaultMessageFactoryTests.cs
@@ -11,15 +11,30 @@ namespace UnitTests
     public class DefaultMessageFactoryTests
     {
         [Test]
-        public void GroupCreateTest()
+        public void GroupCreateTest_Fix50()
         {
-            DefaultMessageFactory dmf = new DefaultMessageFactory();
+            DefaultMessageFactory dmf = new DefaultMessageFactory(QuickFix.FixValues.ApplVerID.FIX50);
 
             Group g44 = dmf.Create("FIX.4.4", "B", 33);
             Assert.IsInstanceOf<QuickFix.FIX44.News.LinesOfTextGroup>(g44);
 
             Group g50 = dmf.Create("FIXT.1.1", "B", 33);
             Assert.IsInstanceOf<QuickFix.FIX50.News.NoLinesOfTextGroup>(g50);
+
+            Group g50sp2 = dmf.Create("FIXT.1.1", "CD", QuickFix.Fields.Tags.NoAsgnReqs);
+            Assert.IsNull(g50sp2);
+        }
+
+        [Test]
+        public void GroupCreateTest_DefaultFix50Sp2()
+        {
+            DefaultMessageFactory dmf = new DefaultMessageFactory();
+
+            Group g44 = dmf.Create("FIX.4.4", "B", 33);
+            Assert.IsInstanceOf<QuickFix.FIX44.News.LinesOfTextGroup>(g44);
+
+            Group g50sp2 = dmf.Create("FIXT.1.1", "CD", QuickFix.Fields.Tags.NoAsgnReqs);
+            Assert.IsInstanceOf<QuickFix.FIX50SP2.StreamAssignmentReport.NoAsgnReqsGroup>(g50sp2);
         }
     }
 }

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -21,9 +21,12 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Messages\FIX40\QuickFix.FIX40.csproj" />
+    <ProjectReference Include="..\Messages\FIX41\QuickFix.FIX41.csproj" />
     <ProjectReference Include="..\Messages\FIX42\QuickFix.FIX42.csproj" />
     <ProjectReference Include="..\Messages\FIX43\QuickFix.FIX43.csproj" />
     <ProjectReference Include="..\Messages\FIX44\QuickFix.FIX44.csproj" />
+    <ProjectReference Include="..\Messages\FIX50SP1\QuickFix.FIX50SP1.csproj" />
+    <ProjectReference Include="..\Messages\FIX50SP2\QuickFix.FIX50SP2.csproj" />
     <ProjectReference Include="..\Messages\FIX50\QuickFix.FIX50.csproj" />
     <ProjectReference Include="..\QuickFIXn\QuickFix.csproj" />
   </ItemGroup>


### PR DESCRIPTION
In case of FIX5, SessionFactory.Create now creates a more-appropriate DefaultMessageFactory.

Also add NullLogFactory.

Also refactor some constructors.