### PR TITLE
Fix Nanosecond config throw

### DIFF
--- a/QuickFIXn/Dictionary.cs
+++ b/QuickFIXn/Dictionary.cs
@@ -166,6 +166,9 @@ namespace QuickFix
                 case "MICROSECOND":
                 case "MICRO":
                     return TimeStampPrecision.Microsecond;
+                case "NANOSECOND":
+                case "NANO":
+                    return TimeStampPrecision.Nanosecond;
                 default: throw new ConfigError( "Illegal value " + GetString( key ) + " for " + key );
             }
         }

--- a/QuickFIXn/Fields/Converters/DateTimeConverter.cs
+++ b/QuickFIXn/Fields/Converters/DateTimeConverter.cs
@@ -213,14 +213,26 @@ namespace QuickFix.Fields.Converters
         {
             return includeMilliseconds ? Convert(dt, TimeStampPrecision.Millisecond): Convert( dt, TimeStampPrecision.Second );
         }
-
-
-        private static long Nanoseconds(this System.DateTime dt)
+        
+        //
+        // Summary:
+        //     Gets the nanoseconds component of the date represented by this instance truncated to 100 nanosecond resolution
+        //
+        // Returns:
+        //     The nanoseconds component, expressed as a value between 0 and 99900.
+        public static int Nanosecond(this System.DateTime dt)
         {
             int ns = (int)(dt.Ticks % System.TimeSpan.TicksPerMillisecond % (double)TicksPerMicrosecond) * NanosecondsPerTick;
             int us = (int)System.Math.Floor((dt.Ticks % System.TimeSpan.TicksPerMillisecond) / (double)TicksPerMicrosecond);
+            return (us * NanosPerMicro) + ns;
+        }
+
+        private static long SubsecondAsNanoseconds(this System.DateTime dt)
+        {
+            int ns = dt.Nanosecond();
             int ms = dt.Millisecond;
             return (ms * NanosPerMicro * MicrosPerMillis) + (us * NanosPerMicro) + ns;
+            return (ms * NanosPerMicro * MicrosPerMillis) + ns;
         }
 
         /// <summary>
@@ -233,7 +245,7 @@ namespace QuickFix.Fields.Converters
         {
             if (precision == TimeStampPrecision.Nanosecond)
             {
-                return string.Format(DATE_TIME_FORMAT_WITH_NANOSECONDS, dt, dt.Nanoseconds());
+                return string.Format(DATE_TIME_FORMAT_WITH_NANOSECONDS, dt, dt.SubsecondAsNanoseconds());
             }
             else
             {

--- a/QuickFIXn/Fields/Converters/DateTimeConverter.cs
+++ b/QuickFIXn/Fields/Converters/DateTimeConverter.cs
@@ -22,7 +22,10 @@ namespace QuickFix.Fields.Converters
         public const string TIME_ONLY_FORMAT_WITH_MICROSECONDS = "{0:HH:mm:ss.ffffff}";
         public const string TIME_ONLY_FORMAT_WITH_MILLISECONDS = "{0:HH:mm:ss.fff}";
         public const string TIME_ONLY_FORMAT_WITHOUT_MILLISECONDS = "{0:HH:mm:ss}";
-        public static string[] DATE_TIME_FORMATS = { "yyyyMMdd-HH:mm:ss.ffffff", "yyyyMMdd-HH:mm:ss.fff", "yyyyMMdd-HH:mm:ss" };
+        
+        public const string DATE_TIME_WITH_MICROSECONDS = "yyyyMMdd-HH:mm:ss.ffffff";
+        public static int DATETIME_MAXLENGTH_WITHOUT_NANOSECONDS = DATE_TIME_WITH_MICROSECONDS.Length;
+        public static string[] DATE_TIME_FORMATS = { DATE_TIME_WITH_MICROSECONDS, "yyyyMMdd-HH:mm:ss.fff", "yyyyMMdd-HH:mm:ss" };
         public static string[] DATE_ONLY_FORMATS = { "yyyyMMdd" };
         public static string[] TIME_ONLY_FORMATS = { "HH:mm:ss.ffffff", "HH:mm:ss.fff", "HH:mm:ss" };
         public static DateTimeStyles DATE_TIME_STYLES = DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal;
@@ -97,7 +100,7 @@ namespace QuickFix.Fields.Converters
         /// <exception cref="FieldConvertError"/>
         public static System.DateTime ConvertToDateTime(string str)
         {
-            return ConvertToDateTime(str, TimeStampPrecision.Millisecond);
+            return ConvertToDateTime(str, TimeStampPrecision.Nanosecond);
         }
 
         /// <summary>
@@ -108,7 +111,8 @@ namespace QuickFix.Fields.Converters
         {
             try
             {
-                if (precision == TimeStampPrecision.Nanosecond)
+                //Avoid NanoString Path parsing if not possible from string length
+                if (str.Length > DATETIME_MAXLENGTH_WITHOUT_NANOSECONDS && precision == TimeStampPrecision.Nanosecond)
                 {
                     return DateTimeFromNanoString(str);
                 }

--- a/QuickFIXn/Fields/Converters/DateTimeConverter.cs
+++ b/QuickFIXn/Fields/Converters/DateTimeConverter.cs
@@ -100,7 +100,7 @@ namespace QuickFix.Fields.Converters
         /// <exception cref="FieldConvertError"/>
         public static System.DateTime ConvertToDateTime(string str)
         {
-            return ConvertToDateTime(str, TimeStampPrecision.Nanosecond);
+            return ConvertToDateTime(str, TimeStampPrecision.Millisecond);
         }
 
         /// <summary>

--- a/QuickFIXn/Fields/Converters/DateTimeConverter.cs
+++ b/QuickFIXn/Fields/Converters/DateTimeConverter.cs
@@ -231,7 +231,6 @@ namespace QuickFix.Fields.Converters
         {
             int ns = dt.Nanosecond();
             int ms = dt.Millisecond;
-            return (ms * NanosPerMicro * MicrosPerMillis) + (us * NanosPerMicro) + ns;
             return (ms * NanosPerMicro * MicrosPerMillis) + ns;
         }
 

--- a/QuickFIXn/Fields/Converters/DateTimeConverter.cs
+++ b/QuickFIXn/Fields/Converters/DateTimeConverter.cs
@@ -283,7 +283,7 @@ namespace QuickFix.Fields.Converters
         {
             if (precision == TimeStampPrecision.Nanosecond)
             {
-                return string.Format(TIME_ONLY_FORMAT_WITH_NANOSECONDS, dt, dt.Nanoseconds());
+                return string.Format(TIME_ONLY_FORMAT_WITH_NANOSECONDS, dt, dt.SubsecondAsNanoseconds());
             }
             else
             {

--- a/QuickFIXn/Fields/Converters/DateTimeConverter.cs
+++ b/QuickFIXn/Fields/Converters/DateTimeConverter.cs
@@ -24,7 +24,7 @@ namespace QuickFix.Fields.Converters
         public const string TIME_ONLY_FORMAT_WITHOUT_MILLISECONDS = "{0:HH:mm:ss}";
         
         public const string DATE_TIME_WITH_MICROSECONDS = "yyyyMMdd-HH:mm:ss.ffffff";
-        public static int DATETIME_MAXLENGTH_WITHOUT_NANOSECONDS = DATE_TIME_WITH_MICROSECONDS.Length;
+        public static int DATE_TIME_MAXLENGTH_WITHOUT_NANOSECONDS = DATE_TIME_WITH_MICROSECONDS.Length;
         public static string[] DATE_TIME_FORMATS = { DATE_TIME_WITH_MICROSECONDS, "yyyyMMdd-HH:mm:ss.fff", "yyyyMMdd-HH:mm:ss" };
         public static string[] DATE_ONLY_FORMATS = { "yyyyMMdd" };
         public static string[] TIME_ONLY_FORMATS = { "HH:mm:ss.ffffff", "HH:mm:ss.fff", "HH:mm:ss" };
@@ -112,7 +112,7 @@ namespace QuickFix.Fields.Converters
             try
             {
                 //Avoid NanoString Path parsing if not possible from string length
-                if (str.Length > DATETIME_MAXLENGTH_WITHOUT_NANOSECONDS && precision == TimeStampPrecision.Nanosecond)
+                if (str.Length > DATE_TIME_MAXLENGTH_WITHOUT_NANOSECONDS && precision == TimeStampPrecision.Nanosecond)
                 {
                     return DateTimeFromNanoString(str);
                 }

--- a/UnitTests/Fields/Converters/DateTimeConverterMicrosecondTests.cs
+++ b/UnitTests/Fields/Converters/DateTimeConverterMicrosecondTests.cs
@@ -8,6 +8,28 @@ namespace UnitTests.Fields.Converters
     public class DateTimeConverterMicrosecondTests
     {
         [Test]
+        public void CanConvertFromDateTimeStringWithNanosecondsToValidDateTimeObject()
+        {
+            //GIVEN - a datetime string with nanoseconds
+            var dateTimeStringWithNanoseconds = "20170305-13:22:12.123456789";
+            var dateTimeStringWithNanosecondsTruncated = "20170305-13:22:12.123456700";
+
+            //WHEN - it is converted to a date time
+            var convertedDateTime = DateTimeConverter.ConvertToDateTime(dateTimeStringWithNanoseconds, TimeStampPrecision.Nanosecond);
+
+            //THEN - the date time object is setup correctly
+            Assert.AreEqual(2017, convertedDateTime.Year);
+            Assert.AreEqual(3, convertedDateTime.Month);
+            Assert.AreEqual(5, convertedDateTime.Day);
+            Assert.AreEqual(13, convertedDateTime.Hour);
+            Assert.AreEqual(22, convertedDateTime.Minute);
+            Assert.AreEqual(12, convertedDateTime.Second);
+            Assert.AreEqual(123, convertedDateTime.Millisecond);
+            Assert.AreEqual(456700, convertedDateTime.Nanosecond()); //100 Nanosecond Truncated Resolution
+            Assert.AreEqual(dateTimeStringWithNanosecondsTruncated, DateTimeConverter.Convert(convertedDateTime, TimeStampPrecision.Nanosecond));
+        }
+        
+        [Test]
         public void CanConvertFromDateTimeStringWithMicrosecondsToValidDateTimeObject()
         {
             //GIVEN - a datetime string with microseconds

--- a/UnitTests/SessionFactoryTest.cs
+++ b/UnitTests/SessionFactoryTest.cs
@@ -145,6 +145,14 @@ namespace UnitTests
             session = factory.Create(sessionID, settings);
             Assert.That(session.TimeStampPrecision == QuickFix.Fields.Converters.TimeStampPrecision.Millisecond);
 
+            settings.SetString(SessionSettings.TIMESTAMP_PRECISION, "Nanosecond");
+            session = factory.Create(sessionID, settings);
+            Assert.That(session.TimeStampPrecision == QuickFix.Fields.Converters.TimeStampPrecision.Nanosecond);
+
+            settings.SetString(SessionSettings.TIMESTAMP_PRECISION, "Nano");
+            session = factory.Create(sessionID, settings);
+            Assert.That(session.TimeStampPrecision == QuickFix.Fields.Converters.TimeStampPrecision.Nanosecond);
+            
             settings.SetString(SessionSettings.TIMESTAMP_PRECISION, "Second");
             session = factory.Create(sessionID, settings);
             Assert.That(session.TimeStampPrecision == QuickFix.Fields.Converters.TimeStampPrecision.Second);


### PR DESCRIPTION
Related to Issue #352.

The nanosecond precision seems to be functionally complete but attempting to use the setting causes a throw. This resolves the throw ~~but doesn't fix DateTimeConverter being a global static~~ and DateTimeConverter overload used by the strongly typed FIX classes.

Update: Avoiding NanoString parse when unnecessary seems like a reasonable fix.
Update 2: Static assumption of Millisecond will be a much more involved all around fix as a result of fix50sp1/2o_SendingTimeValueOutOfRange.def Acceptance Test