### PR TITLE
support for AllowUnknownMsgFields

### DIFF
--- a/QuickFIXn/DataDictionary/DataDictionary.cs
+++ b/QuickFIXn/DataDictionary/DataDictionary.cs
@@ -7,449 +7,450 @@ using QuickFix.Fields;
 
 namespace QuickFix.DataDictionary
 {
-	/// <summary>
-	/// Provide the message metadata for various versions of FIX
-	/// </summary>
-	public class DataDictionary
-	{
-		public string MajorVersion { get; private set; }
-		public string MinorVersion { get; private set; }
-		public string Version { get; private set; }
-		public Dictionary<int, DDField> FieldsByTag = new Dictionary<int, DDField>();
-		public Dictionary<String, DDField> FieldsByName = new Dictionary<string, DDField>();
-		public Dictionary<String, DDMap> Messages = new Dictionary<string, DDMap>();
-		private XmlDocument RootDoc;
+    /// <summary>
+    /// Provide the message metadata for various versions of FIX
+    /// </summary>
+    public class DataDictionary
+    {
+        public string MajorVersion { get; private set; }
+        public string MinorVersion { get; private set; }
+        public string Version { get; private set; }
+        public Dictionary<int, DDField> FieldsByTag = new Dictionary<int, DDField>();
+        public Dictionary<String, DDField> FieldsByName = new Dictionary<string, DDField>();
+        public Dictionary<String, DDMap> Messages = new Dictionary<string, DDMap>();
+        private XmlDocument RootDoc;
 
-		public bool CheckFieldsOutOfOrder { get; set; }
-		public bool CheckFieldsHaveValues { get; set; }
-		public bool CheckUserDefinedFields { get; set; }
-		public bool AllowUnknownFieldValues { get; set; }
-		public bool AllowUnknownMessageFields { get; set; }
+        public bool CheckFieldsOutOfOrder { get; set; }
+        public bool CheckFieldsHaveValues { get; set; }
+        public bool CheckUserDefinedFields { get; set; }
+        public bool AllowUnknownFieldValues { get; set; }
+        public bool AllowUnknownMessageFields { get; set; }
 
-		public DDMap Header = new DDMap();
-		public DDMap Trailer = new DDMap();
+        public DDMap Header = new DDMap();
+        public DDMap Trailer = new DDMap();
 
-		public DataDictionary()
-		{
-			CheckFieldsHaveValues = true;
-			CheckFieldsOutOfOrder = true;
-			CheckUserDefinedFields = true;
-		}
+        public DataDictionary()
+        {
+            CheckFieldsHaveValues = true;
+            CheckFieldsOutOfOrder = true;
+            CheckUserDefinedFields = true;
+        }
 
-		/// <summary>
-		/// Initialize a data dictionary from a file path
-		/// </summary>
-		/// <param name="path"></param>
-		public DataDictionary(String path)
-			:this()
-		{
-			Load(path);
-		}
+        /// <summary>
+        /// Initialize a data dictionary from a file path
+        /// </summary>
+        /// <param name="path"></param>
+        public DataDictionary(String path)
+            : this()
+        {
+            Load(path);
+        }
 
         /// <summary>
         /// Initialize a data dictionary from a stream
         /// </summary>
         /// <param name="stream"></param>
         public DataDictionary(Stream stream)
-            :this()
+            : this()
         {
             Load(stream);
         }
 
-		/// <summary>
-		/// Copy a data dictionary
-		/// </summary>
-		/// <param name="src">the source dictionary that will be copied into this dictionary</param>
-		public DataDictionary(DataDictionary src)
-			:this()
-		{
-			this.Messages = src.Messages;
-			this.FieldsByName = src.FieldsByName;
-			this.FieldsByTag = src.FieldsByTag;
-			if (null != src.MajorVersion)
-				this.MajorVersion = string.Copy(src.MajorVersion);
-			if (null != src.MinorVersion)
-				this.MinorVersion = string.Copy(src.MinorVersion);
-			if (null != src.Version)
-				this.Version = string.Copy(src.Version);
-			this.CheckFieldsHaveValues = src.CheckFieldsHaveValues;
-			this.CheckFieldsOutOfOrder = src.CheckFieldsOutOfOrder;
-			this.CheckUserDefinedFields = src.CheckUserDefinedFields;
-			this.Header = src.Header;
-			this.Trailer = src.Trailer;
-		}
+        /// <summary>
+        /// Copy a data dictionary
+        /// </summary>
+        /// <param name="src">the source dictionary that will be copied into this dictionary</param>
+        public DataDictionary(DataDictionary src)
+            : this()
+        {
+            this.Messages = src.Messages;
+            this.FieldsByName = src.FieldsByName;
+            this.FieldsByTag = src.FieldsByTag;
+            if (null != src.MajorVersion)
+                this.MajorVersion = string.Copy(src.MajorVersion);
+            if (null != src.MinorVersion)
+                this.MinorVersion = string.Copy(src.MinorVersion);
+            if (null != src.Version)
+                this.Version = string.Copy(src.Version);
+            this.CheckFieldsHaveValues = src.CheckFieldsHaveValues;
+            this.CheckFieldsOutOfOrder = src.CheckFieldsOutOfOrder;
+            this.CheckUserDefinedFields = src.CheckUserDefinedFields;
+            this.Header = src.Header;
+            this.Trailer = src.Trailer;
+        }
 
-		public static void Validate(Message message, DataDictionary sessionDataDict, DataDictionary appDataDict, string beginString, string msgType)
-		{
-			bool bodyOnly = (null == sessionDataDict);
+        public static void Validate(Message message, DataDictionary sessionDataDict, DataDictionary appDataDict, string beginString, string msgType)
+        {
+            bool bodyOnly = (null == sessionDataDict);
 
-			if ((null != sessionDataDict) && (null != sessionDataDict.Version))
-				if (!sessionDataDict.Version.Equals(beginString))
-					throw new UnsupportedVersion(beginString);
+            if ((null != sessionDataDict) && (null != sessionDataDict.Version))
+                if (!sessionDataDict.Version.Equals(beginString))
+                    throw new UnsupportedVersion(beginString);
 
-			if (((null != sessionDataDict) && sessionDataDict.CheckFieldsOutOfOrder) || ((null != appDataDict) && appDataDict.CheckFieldsOutOfOrder))
-			{
-				int field;
-				if (!message.HasValidStructure(out field))
-					throw new TagOutOfOrder(field);
-			}
+            if (((null != sessionDataDict) && sessionDataDict.CheckFieldsOutOfOrder) || ((null != appDataDict) && appDataDict.CheckFieldsOutOfOrder))
+            {
+                int field;
+                if (!message.HasValidStructure(out field))
+                    throw new TagOutOfOrder(field);
+            }
 
-			if ((null != appDataDict) && (null != appDataDict.Version))
-			{
-				appDataDict.CheckMsgType(msgType);
-				appDataDict.CheckHasRequired(message, msgType);
-			}
-			
-			if (!bodyOnly)
-			{
-				sessionDataDict.Iterate(message.Header, msgType);
-				sessionDataDict.Iterate(message.Trailer, msgType);
-			}
+            if ((null != appDataDict) && (null != appDataDict.Version))
+            {
+                appDataDict.CheckMsgType(msgType);
+                appDataDict.CheckHasRequired(message, msgType);
+            }
 
-			appDataDict.Iterate(message, msgType);
-		}
+            if (!bodyOnly)
+            {
+                sessionDataDict.Iterate(message.Header, msgType);
+                sessionDataDict.Iterate(message.Trailer, msgType);
+            }
 
-		public void Validate(Message message, string beginString, string msgType)
-		{
-			Validate(message, false, beginString, msgType);
-		}
+            appDataDict.Iterate(message, msgType);
+        }
 
-		/// <summary>
-		/// Validate the message body, with header and trailer fields being validated conditionally
-		/// </summary>
-		/// <param name="message">the message</param>
-		/// <param name="bodyOnly">whether to validate just the message body, or to validate the header and trailer sections as well</param>
-		/// <param name="beginString"></param>
-		/// <param name="msgType"></param>
-		public void Validate(Message message, bool bodyOnly, string beginString, string msgType)
-		{
-			DataDictionary sessionDataDict = null;
-			if (!bodyOnly)
-				sessionDataDict = this;
-			Validate(message, sessionDataDict, this, beginString, msgType);
-		}
+        public void Validate(Message message, string beginString, string msgType)
+        {
+            Validate(message, false, beginString, msgType);
+        }
 
-		public static void CheckHasNoRepeatedTags(FieldMap map)
-		{
-			if (map.RepeatedTags.Count > 0)
-				throw new RepeatedTag(map.RepeatedTags[0].Tag);
-		}
+        /// <summary>
+        /// Validate the message body, with header and trailer fields being validated conditionally
+        /// </summary>
+        /// <param name="message">the message</param>
+        /// <param name="bodyOnly">whether to validate just the message body, or to validate the header and trailer sections as well</param>
+        /// <param name="beginString"></param>
+        /// <param name="msgType"></param>
+        public void Validate(Message message, bool bodyOnly, string beginString, string msgType)
+        {
+            DataDictionary sessionDataDict = null;
+            if (!bodyOnly)
+                sessionDataDict = this;
+            Validate(message, sessionDataDict, this, beginString, msgType);
+        }
 
-		public DDMap GetMapForMessage(string msgType)
-		{
-			if(Messages.ContainsKey(msgType)) {
-				return Messages[msgType];
-			}
-			return null;
-		}
+        public static void CheckHasNoRepeatedTags(FieldMap map)
+        {
+            if (map.RepeatedTags.Count > 0)
+                throw new RepeatedTag(map.RepeatedTags[0].Tag);
+        }
 
-		public void CheckMsgType(string msgType)
-		{
-			if (!Messages.ContainsKey(msgType))
-				throw new InvalidMessageType();
-		}
+        public DDMap GetMapForMessage(string msgType)
+        {
+            if (Messages.ContainsKey(msgType))
+            {
+                return Messages[msgType];
+            }
+            return null;
+        }
 
-		public void CheckHasRequired(Message message, string msgType)
-		{
-			foreach (int field in Header.ReqFields)
-			{
-				if (!message.Header.IsSetField(field))
-					throw new RequiredTagMissing(field);
-			}
+        public void CheckMsgType(string msgType)
+        {
+            if (!Messages.ContainsKey(msgType))
+                throw new InvalidMessageType();
+        }
 
-			foreach (int field in Trailer.ReqFields)
-			{
-				if (!message.Trailer.IsSetField(field))
-					throw new RequiredTagMissing(field);
-			}
+        public void CheckHasRequired(Message message, string msgType)
+        {
+            foreach (int field in Header.ReqFields)
+            {
+                if (!message.Header.IsSetField(field))
+                    throw new RequiredTagMissing(field);
+            }
 
-			foreach (int field in Messages[msgType].ReqFields)
-			{
-				if (!message.IsSetField(field))
-					throw new RequiredTagMissing(field);
-			}
+            foreach (int field in Trailer.ReqFields)
+            {
+                if (!message.Trailer.IsSetField(field))
+                    throw new RequiredTagMissing(field);
+            }
 
-			/* FIXME TODO group stuff
-			foreach (DDGroup grp in _messages[msgType].Groups.Values)
-				if (_messages[msgType].ReqFields.Contains(grp.Field))
-					ReqFieldsSetInGroups(grp, fields);
-			*/
-		}
+            foreach (int field in Messages[msgType].ReqFields)
+            {
+                if (!message.IsSetField(field))
+                    throw new RequiredTagMissing(field);
+            }
 
-		public void Iterate(FieldMap map, string msgType)
-		{
-			DataDictionary.CheckHasNoRepeatedTags(map);
+            /* FIXME TODO group stuff
+            foreach (DDGroup grp in _messages[msgType].Groups.Values)
+              if (_messages[msgType].ReqFields.Contains(grp.Field))
+                ReqFieldsSetInGroups(grp, fields);
+            */
+        }
 
-			// check non-group fields
-			int lastField = 0;
-			foreach (KeyValuePair<int, Fields.IField> kvp in map)
-			{
-				Fields.IField field = kvp.Value;
-				if (lastField != 0 && field.Tag == lastField)
-					throw new RepeatedTag(lastField);
-				CheckHasValue(field);
+        public void Iterate(FieldMap map, string msgType)
+        {
+            DataDictionary.CheckHasNoRepeatedTags(map);
 
-				if (!string.IsNullOrEmpty(this.Version))
-				{
-					CheckValidFormat(field);
-					
-					if (ShouldCheckTag(field))
-					{
-						CheckValidTagNumber(field.Tag);
-						CheckValue(field);
-						if (!Message.IsHeaderField(field.Tag, this) && !Message.IsTrailerField(field.Tag, this))
-						{
-							CheckIsInMessage(field, msgType);
-							CheckGroupCount(field, map, msgType);
-						}
-					}
-				}
-				lastField = field.Tag;
-			}
+            // check non-group fields
+            int lastField = 0;
+            foreach (KeyValuePair<int, Fields.IField> kvp in map)
+            {
+                Fields.IField field = kvp.Value;
+                if (lastField != 0 && field.Tag == lastField)
+                    throw new RepeatedTag(lastField);
+                CheckHasValue(field);
 
-			// check contents of each group
-			foreach (int groupTag in map.GetGroupTags())
-			{
-				for (int i = 1; i <= map.GroupCount(groupTag); i++)
-				{
-					Group g = map.GetGroup(i, groupTag);
-					DDGrp ddg = this.Messages[msgType].GetGroup(groupTag);
-					IterateGroup(g, ddg, msgType);
-				}
-			}
-		}
+                if (!string.IsNullOrEmpty(this.Version))
+                {
+                    CheckValidFormat(field);
 
-		public void IterateGroup(Group group, DDGrp ddgroup, string msgType)
-		{
-			DataDictionary.CheckHasNoRepeatedTags(group);
+                    if (ShouldCheckTag(field))
+                    {
+                        CheckValidTagNumber(field.Tag);
+                        CheckValue(field);
+                        if (!Message.IsHeaderField(field.Tag, this) && !Message.IsTrailerField(field.Tag, this))
+                        {
+                            CheckIsInMessage(field, msgType);
+                            CheckGroupCount(field, map, msgType);
+                        }
+                    }
+                }
+                lastField = field.Tag;
+            }
 
-			int lastField = 0;
-			foreach(KeyValuePair<int, Fields.IField> kvp in group)
-			{
-				Fields.IField field = kvp.Value;
-				if (lastField != 0 && field.Tag == lastField)
-					throw new RepeatedTag(lastField);
-				CheckHasValue(field);
+            // check contents of each group
+            foreach (int groupTag in map.GetGroupTags())
+            {
+                for (int i = 1; i <= map.GroupCount(groupTag); i++)
+                {
+                    Group g = map.GetGroup(i, groupTag);
+                    DDGrp ddg = this.Messages[msgType].GetGroup(groupTag);
+                    IterateGroup(g, ddg, msgType);
+                }
+            }
+        }
 
-				if (!string.IsNullOrEmpty(this.Version))
-				{
-					CheckValidFormat(field);
+        public void IterateGroup(Group group, DDGrp ddgroup, string msgType)
+        {
+            DataDictionary.CheckHasNoRepeatedTags(group);
 
-					if (ShouldCheckTag(field))
-					{
-						CheckValidTagNumber(field.Tag);
-						CheckValue(field);
+            int lastField = 0;
+            foreach (KeyValuePair<int, Fields.IField> kvp in group)
+            {
+                Fields.IField field = kvp.Value;
+                if (lastField != 0 && field.Tag == lastField)
+                    throw new RepeatedTag(lastField);
+                CheckHasValue(field);
 
-						CheckIsInGroup(field, ddgroup, msgType);
-						CheckGroupCount(field, group, msgType);
-					}
-				}
-				lastField = field.Tag;
-			}
+                if (!string.IsNullOrEmpty(this.Version))
+                {
+                    CheckValidFormat(field);
 
-			// check contents of each nested group
-			foreach (int groupTag in group.GetGroupTags())
-			{
-				for (int i = 1; i <= group.GroupCount(groupTag); i++)
-				{
-					Group g = group.GetGroup(i, groupTag);
-					DDGrp ddg = ddgroup.GetGroup(groupTag);
-					IterateGroup(g, ddg, msgType);
-				}
-			}
-		}
+                    if (ShouldCheckTag(field))
+                    {
+                        CheckValidTagNumber(field.Tag);
+                        CheckValue(field);
 
-		/// <summary>
-		/// Check that the field has a value (i.e. that there's something after the equal sign);
-		/// does nothing if configuration has "ValidateFieldsHaveValues=N".
-		/// </summary>
-		/// <param name="field"></param>
-		public void CheckHasValue(Fields.IField field)
-		{
-			if (this.CheckFieldsHaveValues && (field.ToString().Length < 1))
-				throw new NoTagValue(field.Tag);
-		}
+                        CheckIsInGroup(field, ddgroup, msgType);
+                        CheckGroupCount(field, group, msgType);
+                    }
+                }
+                lastField = field.Tag;
+            }
 
-		/// <summary>
-		/// Check that the field contents match the DataDictionary-defined type
-		/// </summary>
-		/// <param name="field"></param>
-		public void CheckValidFormat(Fields.IField field)
-		{
-			try
-			{
-				Type type;
-				if (!TryGetFieldType(field.Tag, out type))
-					return;
+            // check contents of each nested group
+            foreach (int groupTag in group.GetGroupTags())
+            {
+                for (int i = 1; i <= group.GroupCount(groupTag); i++)
+                {
+                    Group g = group.GetGroup(i, groupTag);
+                    DDGrp ddg = ddgroup.GetGroup(groupTag);
+                    IterateGroup(g, ddg, msgType);
+                }
+            }
+        }
 
-				if (type == typeof(StringField))
-					return;
-				else if (type == typeof(CharField))
-					Fields.Converters.CharConverter.Convert(field.ToString());
-				else if (type == typeof(IntField))
-					Fields.Converters.IntConverter.Convert(field.ToString());
-				else if (type == typeof(DecimalField))
-					Fields.Converters.DecimalConverter.Convert(field.ToString());
-				else if (type == typeof(BooleanField))
-					Fields.Converters.BoolConverter.Convert(field.ToString());
+        /// <summary>
+        /// Check that the field has a value (i.e. that there's something after the equal sign);
+        /// does nothing if configuration has "ValidateFieldsHaveValues=N".
+        /// </summary>
+        /// <param name="field"></param>
+        public void CheckHasValue(Fields.IField field)
+        {
+            if (this.CheckFieldsHaveValues && (field.ToString().Length < 1))
+                throw new NoTagValue(field.Tag);
+        }
 
-				else if (type == typeof(DateTimeField))
-					Fields.Converters.DateTimeConverter.ConvertToDateTime(field.ToString());
-				else if (type == typeof(DateOnlyField))
-					Fields.Converters.DateTimeConverter.ConvertToDateOnly(field.ToString());
-				else if (type == typeof(TimeOnlyField))
-					Fields.Converters.DateTimeConverter.ConvertToTimeOnly(field.ToString());
-				return;
+        /// <summary>
+        /// Check that the field contents match the DataDictionary-defined type
+        /// </summary>
+        /// <param name="field"></param>
+        public void CheckValidFormat(Fields.IField field)
+        {
+            try
+            {
+                Type type;
+                if (!TryGetFieldType(field.Tag, out type))
+                    return;
 
-			}
-			catch (FieldConvertError e)
-			{
-				throw new IncorrectDataFormat(field.Tag, e);
-			}
-		}
+                if (type == typeof(StringField))
+                    return;
+                else if (type == typeof(CharField))
+                    Fields.Converters.CharConverter.Convert(field.ToString());
+                else if (type == typeof(IntField))
+                    Fields.Converters.IntConverter.Convert(field.ToString());
+                else if (type == typeof(DecimalField))
+                    Fields.Converters.DecimalConverter.Convert(field.ToString());
+                else if (type == typeof(BooleanField))
+                    Fields.Converters.BoolConverter.Convert(field.ToString());
 
-		public bool TryGetFieldType(int tag, out Type result)
-		{
-			
-			if (FieldsByTag.ContainsKey(tag))
-			{
-				result = FieldsByTag[tag].FieldType;
-				return true;
-			}
-			result = null;
-			return false;
-		}
+                else if (type == typeof(DateTimeField))
+                    Fields.Converters.DateTimeConverter.ConvertToDateTime(field.ToString());
+                else if (type == typeof(DateOnlyField))
+                    Fields.Converters.DateTimeConverter.ConvertToDateOnly(field.ToString());
+                else if (type == typeof(TimeOnlyField))
+                    Fields.Converters.DateTimeConverter.ConvertToTimeOnly(field.ToString());
+                return;
 
-		/// <summary>
-		/// Check that this tag is defined in the DataDictionary
-		/// </summary>
-		/// <param name="tag"></param>
-		public void CheckValidTagNumber(int tag)
-		{
-			if (AllowUnknownMessageFields)
-				return;
-			if (!FieldsByTag.ContainsKey(tag))
-			{
-				throw new InvalidTagNumber(tag);
-			}
-		}
+            }
+            catch (FieldConvertError e)
+            {
+                throw new IncorrectDataFormat(field.Tag, e);
+            }
+        }
 
-		/// <summary>
-		/// If field is an enum, make sure the value is valid.
-		/// </summary>
-		/// <param name="field"></param>
-		public void CheckValue(Fields.IField field)
-		{
-			if (AllowUnknownFieldValues)
-				return;
-			DDField fld = FieldsByTag[field.Tag];
-			if (fld.HasEnums())
-			{
-				if (fld.IsMultipleValueFieldWithEnums)
-				{
-					string[] splitted = field.ToString().Split(' ');
+        public bool TryGetFieldType(int tag, out Type result)
+        {
 
-					foreach (string value in splitted)
-						if (!fld.EnumDict.ContainsKey(value))
-							throw new IncorrectTagValue(field.Tag);
-				}
-				else if (!fld.EnumDict.ContainsKey(field.ToString()))
-					throw new IncorrectTagValue(field.Tag);
-			}
-		}
+            if (FieldsByTag.ContainsKey(tag))
+            {
+                result = FieldsByTag[tag].FieldType;
+                return true;
+            }
+            result = null;
+            return false;
+        }
 
-		/// <summary>
-		/// Check that <paramref name="field"/> is supposed to be in the message type indicated by <paramref name="msgType"/>.
-		/// </summary>
-		/// <param name="field"></param>
-		/// <param name="msgType"></param>
-		public void CheckIsInMessage(Fields.IField field, string msgType)
-		{
-			if (AllowUnknownMessageFields)
-				return;
-			DDMap dd;
-			if (Messages.TryGetValue(msgType, out dd))
-				if (dd.Fields.ContainsKey(field.Tag))
-					return;
-			throw new TagNotDefinedForMessage(field.Tag, msgType);
-		}
+        /// <summary>
+        /// Check that this tag is defined in the DataDictionary
+        /// </summary>
+        /// <param name="tag"></param>
+        public void CheckValidTagNumber(int tag)
+        {
+            if (AllowUnknownMessageFields)
+                return;
+            if (!FieldsByTag.ContainsKey(tag))
+            {
+                throw new InvalidTagNumber(tag);
+            }
+        }
 
-		/// <summary>
-		/// Check that <paramref name="field"/> is supposed to be in the group defined in <paramref name="ddgrp"/>
-		/// </summary>
-		/// <param name="field"></param>
-		/// <param name="ddgrp"></param>
-		/// <param name="msgType">Message type that contains the group (included in exceptions thrown on failure)</param>
-		public void CheckIsInGroup(Fields.IField field, DDGrp ddgrp, string msgType)
-		{
-			if (AllowUnknownMessageFields)
-				return;
-			if (ddgrp.IsField(field.Tag))
-				return;
-			throw new TagNotDefinedForMessage(field.Tag, msgType);
-		}
+        /// <summary>
+        /// If field is an enum, make sure the value is valid.
+        /// </summary>
+        /// <param name="field"></param>
+        public void CheckValue(Fields.IField field)
+        {
+            if (AllowUnknownFieldValues)
+                return;
+            DDField fld = FieldsByTag[field.Tag];
+            if (fld.HasEnums())
+            {
+                if (fld.IsMultipleValueFieldWithEnums)
+                {
+                    string[] splitted = field.ToString().Split(' ');
 
-		/// <summary>
-		/// If <paramref name="field"/> is a group-counter for <paramref name="msgType"/>, check that it is accurate, else do nothing.
-		/// </summary>
-		/// <param name="field">a group's counter field</param>
-		/// <param name="map">the FieldMap that contains the group being checked</param>
-		/// <param name="msgType">msg type of message that is/contains <paramref name="map"/></param>
-		public void CheckGroupCount(Fields.IField field, FieldMap map, string msgType)
-		{
-			if(IsGroup(msgType, field.Tag))
-			{
-				if (map.GetInt(field.Tag) != map.GroupCount(field.Tag))
-				{
-					throw new RepeatingGroupCountMismatch(field.Tag);
-				}
-			}
-		}
+                    foreach (string value in splitted)
+                        if (!fld.EnumDict.ContainsKey(value))
+                            throw new IncorrectTagValue(field.Tag);
+                }
+                else if (!fld.EnumDict.ContainsKey(field.ToString()))
+                    throw new IncorrectTagValue(field.Tag);
+            }
+        }
 
-		public bool IsGroup(string msgType, int tag)
-		{
-			if (Messages.ContainsKey(msgType))
-			{
-				return Messages[msgType].IsGroup(tag);
-			}
-			return false;
-		}
+        /// <summary>
+        /// Check that <paramref name="field"/> is supposed to be in the message type indicated by <paramref name="msgType"/>.
+        /// </summary>
+        /// <param name="field"></param>
+        /// <param name="msgType"></param>
+        public void CheckIsInMessage(Fields.IField field, string msgType)
+        {
+            if (AllowUnknownMessageFields)
+                return;
+            DDMap dd;
+            if (Messages.TryGetValue(msgType, out dd))
+                if (dd.Fields.ContainsKey(field.Tag))
+                    return;
+            throw new TagNotDefinedForMessage(field.Tag, msgType);
+        }
 
-		/// <summary>
-		/// Determine if this is a field that should be checked for validity according to config
-		/// </summary>
-		/// <param name="field"></param>
-		/// <returns></returns>
-		public bool ShouldCheckTag(Fields.IField field)
-		{
-			if (!this.CheckUserDefinedFields && (field.Tag >= Fields.Limits.USER_MIN))
-				return false;
-			return true;
-		}
+        /// <summary>
+        /// Check that <paramref name="field"/> is supposed to be in the group defined in <paramref name="ddgrp"/>
+        /// </summary>
+        /// <param name="field"></param>
+        /// <param name="ddgrp"></param>
+        /// <param name="msgType">Message type that contains the group (included in exceptions thrown on failure)</param>
+        public void CheckIsInGroup(Fields.IField field, DDGrp ddgrp, string msgType)
+        {
+            if (AllowUnknownMessageFields)
+                return;
+            if (ddgrp.IsField(field.Tag))
+                return;
+            throw new TagNotDefinedForMessage(field.Tag, msgType);
+        }
 
-		public bool IsHeaderField(int tag)
-		{
-			return Header.IsField(tag);
-		}
+        /// <summary>
+        /// If <paramref name="field"/> is a group-counter for <paramref name="msgType"/>, check that it is accurate, else do nothing.
+        /// </summary>
+        /// <param name="field">a group's counter field</param>
+        /// <param name="map">the FieldMap that contains the group being checked</param>
+        /// <param name="msgType">msg type of message that is/contains <paramref name="map"/></param>
+        public void CheckGroupCount(Fields.IField field, FieldMap map, string msgType)
+        {
+            if (IsGroup(msgType, field.Tag))
+            {
+                if (map.GetInt(field.Tag) != map.GroupCount(field.Tag))
+                {
+                    throw new RepeatingGroupCountMismatch(field.Tag);
+                }
+            }
+        }
 
-		public bool IsTrailerField(int tag)
-		{
-			return Trailer.IsField(tag);
-		}
+        public bool IsGroup(string msgType, int tag)
+        {
+            if (Messages.ContainsKey(msgType))
+            {
+                return Messages[msgType].IsGroup(tag);
+            }
+            return false;
+        }
 
-		public void Load(String path)
-		{
-			var stream = new FileStream(path, FileMode.Open, FileAccess.Read);
-			Load(stream);
-		}
+        /// <summary>
+        /// Determine if this is a field that should be checked for validity according to config
+        /// </summary>
+        /// <param name="field"></param>
+        /// <returns></returns>
+        public bool ShouldCheckTag(Fields.IField field)
+        {
+            if (!this.CheckUserDefinedFields && (field.Tag >= Fields.Limits.USER_MIN))
+                return false;
+            return true;
+        }
 
-		public void Load(Stream stream)
-		{
-		    XmlReaderSettings readerSettings = new XmlReaderSettings();
-		    readerSettings.IgnoreComments = true;
+        public bool IsHeaderField(int tag)
+        {
+            return Header.IsField(tag);
+        }
 
-		    using (XmlReader reader = XmlReader.Create(stream, readerSettings))
-		    {
+        public bool IsTrailerField(int tag)
+        {
+            return Trailer.IsField(tag);
+        }
+
+        public void Load(String path)
+        {
+            var stream = new FileStream(path, FileMode.Open, FileAccess.Read);
+            Load(stream);
+        }
+
+        public void Load(Stream stream)
+        {
+            XmlReaderSettings readerSettings = new XmlReaderSettings();
+            readerSettings.IgnoreComments = true;
+
+            using (XmlReader reader = XmlReader.Create(stream, readerSettings))
+            {
                 RootDoc = new XmlDocument();
                 RootDoc.Load(reader);
                 SetVersionInfo(RootDoc);
@@ -457,80 +458,83 @@ namespace QuickFix.DataDictionary
                 ParseMessages(RootDoc);
                 ParseHeader(RootDoc);
                 ParseTrailer(RootDoc);
-		    }
-		}
+            }
+        }
 
-		public Boolean FieldHasValue(int tag, String val) {
-			return FieldsByTag[tag].EnumDict.ContainsKey(val);
-		}
+        public Boolean FieldHasValue(int tag, String val)
+        {
+            return FieldsByTag[tag].EnumDict.ContainsKey(val);
+        }
 
-		private void SetVersionInfo(XmlDocument doc) {
-			MajorVersion = doc.SelectSingleNode("/fix/@major").Value;
-			MinorVersion = doc.SelectSingleNode("/fix/@minor").Value;
-			string type;
-			XmlNode node = doc.SelectSingleNode("/fix/@type");
-			if (node == null)
-				type = "FIX";//FIXME has to be a better way to do this, but for now, only >=5.0 have type
-			else
-				type = node.Value;
-			
-			
-			if (!type.Equals("FIX") && !type.Equals("FIXT"))
-				throw new System.ArgumentException("Type must be FIX of FIXT in cofig");
-			Version = String.Format("{0}.{1}.{2}", type, MajorVersion, MinorVersion);
-		}
+        private void SetVersionInfo(XmlDocument doc)
+        {
+            MajorVersion = doc.SelectSingleNode("/fix/@major").Value;
+            MinorVersion = doc.SelectSingleNode("/fix/@minor").Value;
+            string type;
+            XmlNode node = doc.SelectSingleNode("/fix/@type");
+            if (node == null)
+                type = "FIX";//FIXME has to be a better way to do this, but for now, only >=5.0 have type
+            else
+                type = node.Value;
 
-		private void ParseFields(XmlDocument doc)
-		{
-			XmlNodeList nodeList = doc.SelectNodes("//fields/field");
-			foreach(XmlNode fldEl in nodeList) {
-				DDField fld = NewField(fldEl);
-				FieldsByTag[fld.Tag] = fld;
-				FieldsByName[fld.Name] = fld;
-			}
-		}
 
-		private DDField NewField(XmlNode fldEl)
-		{
-			String tagstr = fldEl.Attributes["number"].Value;
-			String name = fldEl.Attributes["name"].Value;
-			String fldType = fldEl.Attributes["type"].Value;
-			int tag = QuickFix.Fields.Converters.IntConverter.Convert(tagstr);
-			Dictionary<String, String> enums = new Dictionary<String, String>();
-			if (fldEl.HasChildNodes)
-			{
-				foreach (XmlNode enumEl in fldEl.SelectNodes(".//value"))
-				{
-					string description = String.Empty;
-					if (enumEl.Attributes["description"] != null)
-						description = enumEl.Attributes["description"].Value;
-					enums[enumEl.Attributes["enum"].Value] = description;
-				}
-			}
-			return new DDField(tag, name, enums, fldType);
-		}
+            if (!type.Equals("FIX") && !type.Equals("FIXT"))
+                throw new System.ArgumentException("Type must be FIX of FIXT in cofig");
+            Version = String.Format("{0}.{1}.{2}", type, MajorVersion, MinorVersion);
+        }
 
-		private void ParseMessages(XmlDocument doc)
-		{
-			XmlNodeList nodeList = doc.SelectNodes("//messages/message");
-			foreach (XmlNode msgEl in nodeList)
-			{
-				DDMap msg = new DDMap();
-				ParseMsgEl(msgEl, msg);
-				String msgtype = msgEl.Attributes["msgtype"].Value;
-				Messages.Add(msgtype, msg);
-			}
-		}
+        private void ParseFields(XmlDocument doc)
+        {
+            XmlNodeList nodeList = doc.SelectNodes("//fields/field");
+            foreach (XmlNode fldEl in nodeList)
+            {
+                DDField fld = NewField(fldEl);
+                FieldsByTag[fld.Tag] = fld;
+                FieldsByName[fld.Name] = fld;
+            }
+        }
 
-		private void ParseHeader(XmlDocument doc)
-		{
-			ParseMsgEl(doc.SelectSingleNode("//header"), Header);
-		}
+        private DDField NewField(XmlNode fldEl)
+        {
+            String tagstr = fldEl.Attributes["number"].Value;
+            String name = fldEl.Attributes["name"].Value;
+            String fldType = fldEl.Attributes["type"].Value;
+            int tag = QuickFix.Fields.Converters.IntConverter.Convert(tagstr);
+            Dictionary<String, String> enums = new Dictionary<String, String>();
+            if (fldEl.HasChildNodes)
+            {
+                foreach (XmlNode enumEl in fldEl.SelectNodes(".//value"))
+                {
+                    string description = String.Empty;
+                    if (enumEl.Attributes["description"] != null)
+                        description = enumEl.Attributes["description"].Value;
+                    enums[enumEl.Attributes["enum"].Value] = description;
+                }
+            }
+            return new DDField(tag, name, enums, fldType);
+        }
 
-		private void ParseTrailer(XmlDocument doc)
-		{
-			ParseMsgEl(doc.SelectSingleNode("//trailer"), Trailer);
-		}
+        private void ParseMessages(XmlDocument doc)
+        {
+            XmlNodeList nodeList = doc.SelectNodes("//messages/message");
+            foreach (XmlNode msgEl in nodeList)
+            {
+                DDMap msg = new DDMap();
+                ParseMsgEl(msgEl, msg);
+                String msgtype = msgEl.Attributes["msgtype"].Value;
+                Messages.Add(msgtype, msg);
+            }
+        }
+
+        private void ParseHeader(XmlDocument doc)
+        {
+            ParseMsgEl(doc.SelectSingleNode("//header"), Header);
+        }
+
+        private void ParseTrailer(XmlDocument doc)
+        {
+            ParseMsgEl(doc.SelectSingleNode("//trailer"), Trailer);
+        }
 
         /// <summary>
         /// Implied null third componentRequired parameter
@@ -551,8 +555,8 @@ namespace QuickFix.DataDictionary
         /// If non-null, parsing is inside a component that is required (true) or not (false).
         /// If null, parser is not inside a component.
         /// </param>
-		private void ParseMsgEl(XmlNode node, DDMap ddmap, bool? componentRequired)
-		{
+        private void ParseMsgEl(XmlNode node, DDMap ddmap, bool? componentRequired)
+        {
             /* 
             // This code is great for debugging DD parsing issues.
             string s = "+ " + node.Name;  // node.Name is probably "message"
@@ -561,11 +565,11 @@ namespace QuickFix.DataDictionary
             Console.WriteLine(s);
             */
 
-		    string messageTypeName = (node.Attributes["name"] != null) ? node.Attributes["name"].Value : node.Name;
+            string messageTypeName = (node.Attributes["name"] != null) ? node.Attributes["name"].Value : node.Name;
 
-			if (!node.HasChildNodes) { return; }
-			foreach (XmlNode childNode in node.ChildNodes)
-			{
+            if (!node.HasChildNodes) { return; }
+            foreach (XmlNode childNode in node.ChildNodes)
+            {
                 /*
                 // Continuation of code that's great for debugging DD parsing issues.
                 s = "    + " + childNode.Name;  // childNode.Name is probably "field"
@@ -574,59 +578,59 @@ namespace QuickFix.DataDictionary
                 Console.WriteLine(s);
                 */
 
-			    var fieldName = (childNode.Attributes["name"] != null) ? childNode.Attributes["name"].Value : "no-name";
+                var fieldName = (childNode.Attributes["name"] != null) ? childNode.Attributes["name"].Value : "no-name";
 
-                if ( childNode.Name == "field" )
-				{
-				    if (FieldsByName.ContainsKey(fieldName) == false)
-				    {
-				        throw new Exception(
-				            $"Field '{fieldName}' is used in '{messageTypeName}', but is not defined in <fields> set.");
-				    }
+                if (childNode.Name == "field")
+                {
+                    if (FieldsByName.ContainsKey(fieldName) == false)
+                    {
+                        throw new Exception(
+                            $"Field '{fieldName}' is used in '{messageTypeName}', but is not defined in <fields> set.");
+                    }
 
-				    DDField fld = FieldsByName[fieldName];
+                    DDField fld = FieldsByName[fieldName];
                     XmlAttribute req = childNode.Attributes["required"];
                     if (req != null && req.Value == "Y"
                         && (componentRequired == null || componentRequired.Value == true))
                     {
                         ddmap.ReqFields.Add(fld.Tag);
                     }
-					if (!ddmap.IsField(fld.Tag))
-					{
-						ddmap.Fields.Add(fld.Tag, fld);
-					}
+                    if (!ddmap.IsField(fld.Tag))
+                    {
+                        ddmap.Fields.Add(fld.Tag, fld);
+                    }
 
-					// if first field in group, make it the DELIM
-					if ((ddmap.GetType() == typeof(DDGrp) && ((DDGrp)ddmap).Delim == 0))
-					{
-						((DDGrp)ddmap).Delim = fld.Tag;
-					}
-				}
-				else if(childNode.Name == "group")
-				{
-					DDField fld = FieldsByName[fieldName];
-					DDGrp grp = new DDGrp();
+                    // if first field in group, make it the DELIM
+                    if ((ddmap.GetType() == typeof(DDGrp) && ((DDGrp)ddmap).Delim == 0))
+                    {
+                        ((DDGrp)ddmap).Delim = fld.Tag;
+                    }
+                }
+                else if (childNode.Name == "group")
+                {
+                    DDField fld = FieldsByName[fieldName];
+                    DDGrp grp = new DDGrp();
                     XmlAttribute req = childNode.Attributes["required"];
                     if (req != null && req.Value == "Y"
                         && (componentRequired == null || componentRequired.Value == true))
-					{
-						ddmap.ReqFields.Add(fld.Tag);
-						grp.Required = true;
-					}
-					if (!ddmap.IsField(fld.Tag))
-					{
-						ddmap.Fields.Add(fld.Tag, fld);
-					}
-					grp.NumFld = fld.Tag; 
-					ParseMsgEl(childNode, grp);
-					ddmap.Groups.Add(fld.Tag, grp);
-					
-					// if first field in group, make it the DELIM
-					if ((ddmap.GetType() == typeof(DDGrp) && ((DDGrp)ddmap).Delim == 0))
-					{
-						((DDGrp)ddmap).Delim = fld.Tag;
-					}
-				}
+                    {
+                        ddmap.ReqFields.Add(fld.Tag);
+                        grp.Required = true;
+                    }
+                    if (!ddmap.IsField(fld.Tag))
+                    {
+                        ddmap.Fields.Add(fld.Tag, fld);
+                    }
+                    grp.NumFld = fld.Tag;
+                    ParseMsgEl(childNode, grp);
+                    ddmap.Groups.Add(fld.Tag, grp);
+
+                    // if first field in group, make it the DELIM
+                    if ((ddmap.GetType() == typeof(DDGrp) && ((DDGrp)ddmap).Delim == 0))
+                    {
+                        ((DDGrp)ddmap).Delim = fld.Tag;
+                    }
+                }
                 else if (childNode.Name == "component")
                 {
                     XmlNode compNode = RootDoc.SelectSingleNode("//components/component[@name='" + fieldName + "']");
@@ -634,7 +638,7 @@ namespace QuickFix.DataDictionary
                     bool? compRequired = (req != null && req.Value == "Y");
                     ParseMsgEl(compNode, ddmap, compRequired);
                 }
-			}
-		}
-	}
+            }
+        }
+    }
 }

--- a/QuickFIXn/DataDictionary/DataDictionary.cs
+++ b/QuickFIXn/DataDictionary/DataDictionary.cs
@@ -33,6 +33,7 @@ namespace QuickFix.DataDictionary
             CheckFieldsHaveValues = true;
             CheckFieldsOutOfOrder = true;
             CheckUserDefinedFields = true;
+            AllowUnknownMessageFields = false;
         }
 
         /// <summary>

--- a/QuickFIXn/DataDictionary/DataDictionary.cs
+++ b/QuickFIXn/DataDictionary/DataDictionary.cs
@@ -380,8 +380,6 @@ namespace QuickFix.DataDictionary
         /// <param name="msgType">Message type that contains the group (included in exceptions thrown on failure)</param>
         public void CheckIsInGroup(Fields.IField field, DDGrp ddgrp, string msgType)
         {
-            if (AllowUnknownMessageFields)
-                return;
             if (ddgrp.IsField(field.Tag))
                 return;
             throw new TagNotDefinedForMessage(field.Tag, msgType);

--- a/QuickFIXn/DataDictionary/DataDictionary.cs
+++ b/QuickFIXn/DataDictionary/DataDictionary.cs
@@ -23,7 +23,6 @@ namespace QuickFix.DataDictionary
         public bool CheckFieldsOutOfOrder { get; set; }
         public bool CheckFieldsHaveValues { get; set; }
         public bool CheckUserDefinedFields { get; set; }
-        public bool AllowUnknownFieldValues { get; set; }
         public bool AllowUnknownMessageFields { get; set; }
 
         public DDMap Header = new DDMap();
@@ -341,8 +340,6 @@ namespace QuickFix.DataDictionary
         /// <param name="field"></param>
         public void CheckValue(Fields.IField field)
         {
-            if (AllowUnknownFieldValues)
-                return;
             DDField fld = FieldsByTag[field.Tag];
             if (fld.HasEnums())
             {

--- a/QuickFIXn/SessionFactory.cs
+++ b/QuickFIXn/SessionFactory.cs
@@ -173,6 +173,10 @@ namespace QuickFix
                 ddCopy.CheckFieldsHaveValues = settings.GetBool(SessionSettings.VALIDATE_FIELDS_HAVE_VALUES);
             if (settings.Has(SessionSettings.VALIDATE_USER_DEFINED_FIELDS))
                 ddCopy.CheckUserDefinedFields = settings.GetBool(SessionSettings.VALIDATE_USER_DEFINED_FIELDS);
+            if (settings.Has(SessionSettings.ALLOW_UNKNOWN_FIELD_VALUES))
+	            ddCopy.AllowUnknownFieldValues = settings.GetBool(SessionSettings.ALLOW_UNKNOWN_FIELD_VALUES);
+            if (settings.Has(SessionSettings.ALLOW_UNKNOWN_MSG_FIELDS))
+	            ddCopy.AllowUnknownMessageFields = settings.GetBool(SessionSettings.ALLOW_UNKNOWN_MSG_FIELDS);
 
             return ddCopy;
         }

--- a/QuickFIXn/SessionFactory.cs
+++ b/QuickFIXn/SessionFactory.cs
@@ -174,7 +174,7 @@ namespace QuickFix
             if (settings.Has(SessionSettings.VALIDATE_USER_DEFINED_FIELDS))
                 ddCopy.CheckUserDefinedFields = settings.GetBool(SessionSettings.VALIDATE_USER_DEFINED_FIELDS);
             if (settings.Has(SessionSettings.ALLOW_UNKNOWN_MSG_FIELDS))
-	            ddCopy.AllowUnknownMessageFields = settings.GetBool(SessionSettings.ALLOW_UNKNOWN_MSG_FIELDS);
+                ddCopy.AllowUnknownMessageFields = settings.GetBool(SessionSettings.ALLOW_UNKNOWN_MSG_FIELDS);
 
             return ddCopy;
         }

--- a/QuickFIXn/SessionFactory.cs
+++ b/QuickFIXn/SessionFactory.cs
@@ -173,8 +173,6 @@ namespace QuickFix
                 ddCopy.CheckFieldsHaveValues = settings.GetBool(SessionSettings.VALIDATE_FIELDS_HAVE_VALUES);
             if (settings.Has(SessionSettings.VALIDATE_USER_DEFINED_FIELDS))
                 ddCopy.CheckUserDefinedFields = settings.GetBool(SessionSettings.VALIDATE_USER_DEFINED_FIELDS);
-            if (settings.Has(SessionSettings.ALLOW_UNKNOWN_FIELD_VALUES))
-	            ddCopy.AllowUnknownFieldValues = settings.GetBool(SessionSettings.ALLOW_UNKNOWN_FIELD_VALUES);
             if (settings.Has(SessionSettings.ALLOW_UNKNOWN_MSG_FIELDS))
 	            ddCopy.AllowUnknownMessageFields = settings.GetBool(SessionSettings.ALLOW_UNKNOWN_MSG_FIELDS);
 

--- a/QuickFIXn/SessionSettings.cs
+++ b/QuickFIXn/SessionSettings.cs
@@ -46,7 +46,6 @@ namespace QuickFix
         public const string VALIDATE_FIELDS_HAVE_VALUES = "ValidateFieldsHaveValues";
         public const string VALIDATE_USER_DEFINED_FIELDS = "ValidateUserDefinedFields";
         public const string VALIDATE_LENGTH_AND_CHECKSUM = "ValidateLengthAndChecksum";
-        public const string ALLOW_UNKNOWN_FIELD_VALUES = "AllowUnknownFieldValues";
         public const string ALLOW_UNKNOWN_MSG_FIELDS = "AllowUnknownMsgFields";
         public const string DATA_DICTIONARY = "DataDictionary";
         public const string TRANSPORT_DATA_DICTIONARY = "TransportDataDictionary";

--- a/QuickFIXn/SessionSettings.cs
+++ b/QuickFIXn/SessionSettings.cs
@@ -46,6 +46,8 @@ namespace QuickFix
         public const string VALIDATE_FIELDS_HAVE_VALUES = "ValidateFieldsHaveValues";
         public const string VALIDATE_USER_DEFINED_FIELDS = "ValidateUserDefinedFields";
         public const string VALIDATE_LENGTH_AND_CHECKSUM = "ValidateLengthAndChecksum";
+        public const string ALLOW_UNKNOWN_FIELD_VALUES = "AllowUnknownFieldValues";
+        public const string ALLOW_UNKNOWN_MSG_FIELDS = "AllowUnknownMsgFields";
         public const string DATA_DICTIONARY = "DataDictionary";
         public const string TRANSPORT_DATA_DICTIONARY = "TransportDataDictionary";
         public const string APP_DATA_DICTIONARY = "AppDataDictionary";

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,6 +14,7 @@ What's New
 * (patch) #547 - Implement Refresh() method in FileStore (roederja2)
 * (minor) #570 - change Parser.AddToStream() interface to not use 'ref' (roederja2)
 * (patch) #526 - Do not ignore MsgSeqNum on ResendRequest when no persistence (ledusskapis)
+* (patch) #430 - Support config AllowUnknownMsgFields (peto268/gbirchmeier)
 
 ### v1.9.0:
 * (minor) #469 - Add support for NET Standard 2.0 (jhickson)

--- a/UnitTests/DataDictionaryTests.cs
+++ b/UnitTests/DataDictionaryTests.cs
@@ -165,12 +165,33 @@ namespace UnitTests
         }
 
         [Test]
-        public void CheckValidTagTest()
+        public void CheckValidTagNumberTest()
         {
             QuickFix.DataDictionary.DataDictionary dd = new QuickFix.DataDictionary.DataDictionary();
             dd.LoadFIXSpec("FIX44");
+
+            Assert.DoesNotThrow(delegate { dd.CheckValidTagNumber(35); });
+
             Assert.Throws(typeof(InvalidTagNumber),
                 delegate { dd.CheckValidTagNumber(999); });
+
+            dd.AllowUnknownMessageFields = true;
+            Assert.DoesNotThrow(delegate { dd.CheckValidTagNumber(999); });
+        }
+
+        [Test]
+        public void CheckIsInMessageTest()
+        {
+            QuickFix.DataDictionary.DataDictionary dd = new QuickFix.DataDictionary.DataDictionary();
+            dd.LoadFIXSpec("FIX44");
+
+            Assert.DoesNotThrow(delegate { dd.CheckIsInMessage(new QuickFix.Fields.MDReqID("foo"), "W"); });
+
+            Assert.Throws(typeof(TagNotDefinedForMessage),
+                delegate { dd.CheckIsInMessage(new QuickFix.Fields.EmailThreadID("foo"), "W"); });
+
+            dd.AllowUnknownMessageFields = true;
+            Assert.DoesNotThrow(delegate { dd.CheckIsInMessage(new QuickFix.Fields.EmailThreadID("foo"), "W"); });
         }
 
         [Test]


### PR DESCRIPTION
adapts #543's `AllowUnknownMsgFields` addition (but leaves out `AllowUnknownFieldValues` which should be handled by DD alteration, and has no precedent)

Add `?w=1` to your URL to view this diff, as it includes a lot of lines tab/whitespace corrections that are not interesting.

root issue is #430 