### PR TITLE
Use Ticks in place of clientID to avoid debug log file name clash (resubmit of #383)

### DIFF
--- a/QuickFIXn/ClientHandlerThread.cs
+++ b/QuickFIXn/ClientHandlerThread.cs
@@ -62,7 +62,9 @@ namespace QuickFix
                 debugLogFilePath = settingsDict.GetString(SessionSettings.FILE_LOG_PATH);
 
             // FIXME - do something more flexible than hardcoding a filelog
-            log_ = new FileLog(debugLogFilePath, new SessionID("ClientHandlerThread", DateTime.UtcNow.Ticks.ToString(), "Debug"));
+            log_ = new FileLog(debugLogFilePath, new SessionID(
+                    "ClientHandlerThread", clientId.ToString(), "Debug-" + Guid.NewGuid().ToString()));
+            //log_ = new FileLog(debugLogFilePath, new SessionID("ClientHandlerThread", clientId.ToString(), "Debug"));
 
             this.Id = clientId;
             socketReader_ = new SocketReader(tcpClient, socketSettings, this);

--- a/QuickFIXn/ClientHandlerThread.cs
+++ b/QuickFIXn/ClientHandlerThread.cs
@@ -62,7 +62,7 @@ namespace QuickFix
                 debugLogFilePath = settingsDict.GetString(SessionSettings.FILE_LOG_PATH);
 
             // FIXME - do something more flexible than hardcoding a filelog
-            log_ = new FileLog(debugLogFilePath, new SessionID("ClientHandlerThread", clientId.ToString(), "Debug"));
+            log_ = new FileLog(debugLogFilePath, new SessionID("ClientHandlerThread", DateTime.UtcNow.Ticks.ToString(), "Debug"));
 
             this.Id = clientId;
             socketReader_ = new SocketReader(tcpClient, socketSettings, this);

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,6 +18,7 @@ What's New
 * (patch) #349 - Improvement to repeating-group error detection when delimiter is missing (gbirchmeier)
 * (minor) #561 - Fix nanosecond config throw (dckorben)
 * (minor) #512 - Support config SocketSendTimeout/SocketReceiveTimeout to prevent SSL socket timeouts (allysutherland)
+* (patch) #383/#582 - Fix debug logfile name clash (chizz5056/gbirchmeier)
 
 ### v1.9.0:
 * (minor) #469 - Add support for NET Standard 2.0 (jhickson)


### PR DESCRIPTION
Re-submit of #383 (because original PR branch was contaminated):

Comments from original submission:

> clientId can clash if there's more than one Acceptor endpoint listening on different IP or Port but trying to write to the same debug log file as all starting at 0.  
>
> Using ticks to hopefully keep unique in between each client logon attempt.