### PR TITLE
Added missing toXML functionality to message (rebase part of #323)

### DIFF
--- a/QuickFIXn/Message/Message.cs
+++ b/QuickFIXn/Message/Message.cs
@@ -835,6 +835,11 @@ namespace QuickFix
             return s.ToString();
         }
 
+        /// <summary>
+        /// Get a representation of the message as an XML string.
+        /// (NOTE: this is just an ad-hoc XML; it is NOT FIXML.)
+        /// </summary>
+        /// <returns>an XML string</returns>
         public string ToXML()
         {
             StringBuilder s = new StringBuilder();

--- a/QuickFIXn/Message/Message.cs
+++ b/QuickFIXn/Message/Message.cs
@@ -803,7 +803,7 @@ namespace QuickFix
             return this.Header.CalculateLength() + CalculateLength() + this.Trailer.CalculateLength();
         }
 
-        public string ToXMLFields(FieldMap fields, int space)
+        private static string FieldMapToXML(DataDictionary.DataDictionary dd, FieldMap fields, int space)
         {
             StringBuilder s = new StringBuilder();
             string name = string.Empty;
@@ -812,9 +812,9 @@ namespace QuickFix
             foreach (var f in fields)
             {
                s.Append("<field ");
-               if ((dataDictionary_ != null) && ( dataDictionary_.FieldsByTag.ContainsKey(f.Key)))
+               if ((dd != null) && ( dd.FieldsByTag.ContainsKey(f.Key)))
                {
-                   s.Append("name=\"" + dataDictionary_.FieldsByTag[f.Key].Name + "\" ");
+                   s.Append("name=\"" + dd.FieldsByTag[f.Key].Name + "\" ");
                }
                s.Append("number=\"" + f.Key.ToString() + "\">");
                s.Append("<![CDATA[" + f.Value.ToString() + "]]>");
@@ -827,7 +827,7 @@ namespace QuickFix
                 for (int counter = 1; counter <= fields.GroupCount(groupTag); counter++)
                 {
                     s.Append("<group>");
-                    s.Append( ToXMLFields( fields.GetGroup(counter, groupTag), space+1));
+                    s.Append(FieldMapToXML(dd, fields.GetGroup(counter, groupTag), space+1));
                     s.Append("</group>");
                 }
             }
@@ -840,13 +840,13 @@ namespace QuickFix
             StringBuilder s = new StringBuilder();
             s.AppendLine("<message>");
             s.AppendLine("<header>");
-            s.AppendLine(ToXMLFields(Header, 4));
+            s.AppendLine(FieldMapToXML(dataDictionary_, Header, 4));
             s.AppendLine("</header>");
             s.AppendLine("<body>");
-            s.AppendLine(ToXMLFields(this, 4));
+            s.AppendLine(FieldMapToXML(dataDictionary_, this, 4));
             s.AppendLine("</body>");
             s.AppendLine("<trailer>");
-            s.AppendLine(ToXMLFields(Trailer, 4));
+            s.AppendLine(FieldMapToXML(dataDictionary_, Trailer, 4));
             s.AppendLine("</trailer>");
             s.AppendLine("</message>");
             return s.ToString();

--- a/QuickFIXn/Message/Message.cs
+++ b/QuickFIXn/Message/Message.cs
@@ -2,6 +2,7 @@
 using System.Text;
 using QuickFix.Fields;
 using System.Text.RegularExpressions;
+using System.Collections.Generic;
 
 namespace QuickFix
 {
@@ -801,6 +802,7 @@ namespace QuickFix
         {
             return this.Header.CalculateLength() + CalculateLength() + this.Trailer.CalculateLength();
         }
+
         protected bool InitializeXML(string url)
         {
             try
@@ -816,7 +818,7 @@ namespace QuickFix
         }
 
 
-        public string toXMLFields(FieldMap fields, int space)
+        public string ToXMLFields(FieldMap fields, int space)
         {
             StringBuilder s = new StringBuilder();
             string name = string.Empty;
@@ -824,7 +826,6 @@ namespace QuickFix
             // fields
             foreach (var f in fields)
             {
-                
                s.Append("<field ");
                if ((dataDictionary_ != null) && ( dataDictionary_.FieldsByTag.ContainsKey(f.Key)))
                {
@@ -833,7 +834,6 @@ namespace QuickFix
                s.Append("number=\"" + f.Key.ToString() + "\">");
                s.Append("<![CDATA[" + f.Value.ToString() + "]]>");
                s.Append("</field>");
-
             }
             // now groups
             List<int> groupTags = fields.GetGroupTags();
@@ -842,26 +842,26 @@ namespace QuickFix
                 for (int counter = 1; counter <= fields.GroupCount(groupTag); counter++)
                 {
                     s.Append("<group>");
-                    s.Append( toXMLFields( fields.GetGroup(counter, groupTag), space+1));
+                    s.Append( ToXMLFields( fields.GetGroup(counter, groupTag), space+1));
                     s.Append("</group>");
                 }
             }
-            
+
             return s.ToString();
         }
 
-        public string toXML()
+        public string ToXML()
         {
             StringBuilder s = new StringBuilder();
             s.AppendLine("<message>");
             s.AppendLine("<header>");
-            s.AppendLine(toXMLFields(Header, 4));
+            s.AppendLine(ToXMLFields(Header, 4));
             s.AppendLine("</header>");
             s.AppendLine("<body>");
-            s.AppendLine(toXMLFields(this, 4));
+            s.AppendLine(ToXMLFields(this, 4));
             s.AppendLine("</body>");
             s.AppendLine("<trailer>");
-            s.AppendLine(toXMLFields(Trailer, 4));
+            s.AppendLine(ToXMLFields(Trailer, 4));
             s.AppendLine("</trailer>");
             s.AppendLine("</message>");
             return s.ToString();

--- a/QuickFIXn/Message/Message.cs
+++ b/QuickFIXn/Message/Message.cs
@@ -803,21 +803,6 @@ namespace QuickFix
             return this.Header.CalculateLength() + CalculateLength() + this.Trailer.CalculateLength();
         }
 
-        protected bool InitializeXML(string url)
-        {
-            try
-            {
-                DataDictionary.DataDictionary p = new DataDictionary.DataDictionary(url);
-                dataDictionary_ = p;
-                return true;
-            }
-            catch
-            {
-                return false;
-            }
-        }
-
-
         public string ToXMLFields(FieldMap fields, int space)
         {
             StringBuilder s = new StringBuilder();

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -20,6 +20,7 @@ What's New
 * (minor) #512 - Support config SocketSendTimeout/SocketReceiveTimeout to prevent SSL socket timeouts (allysutherland)
 * (patch) #383/#582 - Fix debug logfile name clash (chizz5056/gbirchmeier)
 * (patch) #410/#583 - SocketAcceptPort now fully-obeyed (mvdtom)
+* (minor) #585/#323 - Add Message.ToXML() (baffles/gbirchmeier)
 
 ### v1.9.0:
 * (minor) #469 - Add support for NET Standard 2.0 (jhickson)

--- a/UnitTests/MessageTests.cs
+++ b/UnitTests/MessageTests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Xml.Linq;
+
 using NUnit.Framework;
 using QuickFix;
 using QuickFix.Fields;
@@ -963,6 +965,139 @@ namespace UnitTests
 
             string foo = msg.ToString().Replace(Message.SOH, "|");
             StringAssert.EndsWith("|10=099|", foo);
+        }
+
+        [Test]
+        public void ToXMLTest()
+        {
+            string str1 = "8=FIX.4.2\x01" + "9=55\x01" + "35=0\x01" + "34=3\x01" + "49=TW\x01" +
+                "52=20000426-12:05:06\x01" + "56=ISLD\x01" + "1=acct123\x01" + "10=123\x01";
+            Message msg = new Message();
+            try
+            {
+                msg.FromString(str1, true, null, null, _defaultMsgFactory);
+            }
+            catch (InvalidMessage e)
+            {
+                Assert.Fail("Unexpected exception (InvalidMessage): " + e.Message);
+            }
+
+            string xmlDoc = msg.toXML();
+            XDocument doc = null;
+            try
+            {
+                doc = XDocument.Parse(xmlDoc);
+            }
+            catch (Exception e)
+            {
+                Assert.Fail("Badly formed XML generated: " + e.Message);
+            }
+
+            var fields = doc.Descendants("message").Descendants("body")
+                .Select(field =>
+                    new
+                    {
+                        number = field.Descendants("field").Attributes("number").Single().Value,
+                        value = field.Descendants("field").Single().Value
+                    })
+                    .ToList();
+
+            foreach (var elem in fields)
+            {
+                int number = 0;
+                if (int.TryParse(elem.number.ToString(), out number) == false)
+                {
+                    Assert.Fail("should be number " + elem.number.ToString() + " " + elem.value.ToString());
+                }
+                else
+                {
+                    string value = msg.GetField(number);
+                    Assert.That(value, Is.EqualTo(elem.value));
+                }
+            }
+        }
+
+
+        [Test]
+        public void ToXMLWithGroupsTest()
+        {
+            var dd = new QuickFix.DataDictionary.DataDictionary();
+            dd.Load("../../../spec/fix/FIX44.xml");
+
+            string[] msgFields = {
+                // header
+                "8=FIX.4.4","9=638", "35=8", "34=360", "49=BLPTSOX", "52=20130321-15:21:23", "56=THINKTSOX", "57=6804469", "128=ZERO",
+                // non-group body fields
+                "6=122.255", "11=61101189", "14=1990000", "15=GBP", "17=VCON:20130321:50018:5:12", "22=4", "31=122.255", "32=1990000",
+                "37=116", "38=1990000", "39=2", "48=GB0032452392", "54=1", "55=[N/A]", "60=20130321-15:21:23", "64=20130322", "75=20130321",
+                "106=UK TSY 4 1/4% 2036", "118=2436321.85", "150=F", "151=0", "157=15", "159=3447.35", "192=0", "198=3739:20130321:50018:5",
+                "223=0.0425", "228=1", "236=0.0291371041", "238=0", "381=2432874.5", "423=1", "470=GB", "541=20360307",
+                // NoPartyIDs
+                "453=6",
+                "448=VCON", "447=D", "452=1", "802=1", "523=14", "803=4",
+                "448=TFOLIO:6804469", "447=D", "452=12",
+                "448=TFOLIO", "447=D", "452=11",
+                "448=THINKFOLIO LTD", "447=D", "452=13",
+                "448=SXT", "447=D", "452=16",
+                "448=TFOLIO:6804469", "447=D", "452=36",
+                "10=152"
+            };
+            string msgStr = String.Join(Message.SOH, msgFields) + Message.SOH;
+
+            QuickFix.FIX44.ExecutionReport msg = new QuickFix.FIX44.ExecutionReport();
+            msg.FromString(msgStr, true, dd, dd, null); // <-- null factory!
+
+
+            string xmlDoc = msg.toXML();
+
+            System.Diagnostics.Debug.Print(xmlDoc.ToString());
+
+            XDocument doc = null;
+            try
+            {
+                doc = XDocument.Parse(xmlDoc);
+            }
+            catch (Exception e)
+            {
+                Assert.Fail("Badly formed XML generated: " + e.Message);
+            }
+
+
+            var groups = doc.Descendants("message").Descendants("body").Elements("group")
+                .Select(group =>
+                    new
+                    {
+                        numbers = group.Descendants("field").Attributes("number"),
+                        values = group.Descendants("field")
+                    })
+
+                    .ToList();
+            int ct = 0;
+            foreach (var elem in groups)
+            {
+                int number = 0;
+                Group group = msg.GetGroup(++ct, 453);
+
+                var valueEnum = elem.values.GetEnumerator();
+                foreach (var numberEnum in elem.numbers)
+                {
+                    valueEnum.MoveNext();
+                    string value = valueEnum.Current.Value;
+
+                    if (int.TryParse(numberEnum.Value.ToString(), out number) == false)
+                    {
+                        Assert.Fail("should be number " + numberEnum.Value.ToString());
+                    }
+                    else
+                    {
+                        if (group.IsSetField(number))
+                        {
+                            string msgValue = group.GetField(number);
+                            Assert.That(value, Is.EqualTo(msgValue));
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/UnitTests/MessageTests.cs
+++ b/UnitTests/MessageTests.cs
@@ -982,7 +982,7 @@ namespace UnitTests
                 Assert.Fail("Unexpected exception (InvalidMessage): " + e.Message);
             }
 
-            string xmlDoc = msg.toXML();
+            string xmlDoc = msg.ToXML();
             XDocument doc = null;
             try
             {
@@ -1011,7 +1011,7 @@ namespace UnitTests
                 }
                 else
                 {
-                    string value = msg.GetField(number);
+                    string value = msg.GetString(number);
                     Assert.That(value, Is.EqualTo(elem.value));
                 }
             }
@@ -1048,7 +1048,7 @@ namespace UnitTests
             msg.FromString(msgStr, true, dd, dd, null); // <-- null factory!
 
 
-            string xmlDoc = msg.toXML();
+            string xmlDoc = msg.ToXML();
 
             System.Diagnostics.Debug.Print(xmlDoc.ToString());
 
@@ -1092,7 +1092,7 @@ namespace UnitTests
                     {
                         if (group.IsSetField(number))
                         {
-                            string msgValue = group.GetField(number);
+                            string msgValue = group.GetString(number);
                             Assert.That(value, Is.EqualTo(msgValue));
                         }
                     }

--- a/UnitTests/MessageTests.cs
+++ b/UnitTests/MessageTests.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Xml.Linq;
 
 using NUnit.Framework;
 using QuickFix;

--- a/UnitTests/MessageTests.cs
+++ b/UnitTests/MessageTests.cs
@@ -533,7 +533,7 @@ namespace UnitTests
             header.SetField(new TargetLocationID("TARGETLOC"));
 
             msg.ReverseRoute(header);
-            
+
             Assert.That(msg.Header.GetString(Tags.BeginString), Is.EqualTo("FIX.4.2"));
             Assert.That(msg.Header.GetString(Tags.TargetCompID), Is.EqualTo("SENDER"));
             Assert.That(msg.Header.GetString(Tags.TargetSubID), Is.EqualTo("SENDERSUB"));
@@ -798,8 +798,8 @@ namespace UnitTests
             dd.LoadFIXSpec("FIX44");
 
             string[] msgFields = { "8=FIX.4.4", "9=332", "35=W", "34=2", "49=MA", "52=20121024-12:21:42.170", "56=xxxx",
-                "22=4", "48=BE0932900518", "55=[N/A]", "262=1b145288-9c9a-4911-a084-7341c69d3e6b", "762=EURO_EUR", "268=2", 
-                "269=0", "270=97.625", "15=EUR", "271=1246000", "272=20121024", "273=07:30:47", "276=I", "282=BEARGB21XXX", "299=15478575", 
+                "22=4", "48=BE0932900518", "55=[N/A]", "262=1b145288-9c9a-4911-a084-7341c69d3e6b", "762=EURO_EUR", "268=2",
+                "269=0", "270=97.625", "15=EUR", "271=1246000", "272=20121024", "273=07:30:47", "276=I", "282=BEARGB21XXX", "299=15478575",
                 "269=1", "270=108.08", "15=EUR", "271=884000", "272=20121024", "273=07:30:47", "276=I", "282=BEARGB21XXX", "299=15467902", "10=77"
             };
             string msgStr = String.Join(Message.SOH, msgFields) + Message.SOH;
@@ -852,8 +852,8 @@ namespace UnitTests
 
             string msgString = msg.ToString();
 
-            string expected = String.Join(Message.SOH, new string[] { "35=W", "22=4", "48=BE0932900518", "55=[N/A]", "262=1b145288-9c9a-4911-a084-7341c69d3e6b", "762=EURO_EUR", "268=2", 
-                "269=0", "270=97.625", "15=EUR", "271=1246000", "272=20121024", "273=07:30:47", "276=I", "282=BEARGB21XXX", "299=15478575", 
+            string expected = String.Join(Message.SOH, new string[] { "35=W", "22=4", "48=BE0932900518", "55=[N/A]", "262=1b145288-9c9a-4911-a084-7341c69d3e6b", "762=EURO_EUR", "268=2",
+                "269=0", "270=97.625", "15=EUR", "271=1246000", "272=20121024", "273=07:30:47", "276=I", "282=BEARGB21XXX", "299=15478575",
                 "269=1", "270=108.08", "15=EUR", "271=884000", "272=20121024", "273=07:30:47", "276=I", "282=BEARGB21XXX", "299=15467902"
             });
 
@@ -965,139 +965,6 @@ namespace UnitTests
 
             string foo = msg.ToString().Replace(Message.SOH, "|");
             StringAssert.EndsWith("|10=099|", foo);
-        }
-
-        [Test]
-        public void ToXMLTest()
-        {
-            string str1 = "8=FIX.4.2\x01" + "9=55\x01" + "35=0\x01" + "34=3\x01" + "49=TW\x01" +
-                "52=20000426-12:05:06\x01" + "56=ISLD\x01" + "1=acct123\x01" + "10=123\x01";
-            Message msg = new Message();
-            try
-            {
-                msg.FromString(str1, true, null, null, _defaultMsgFactory);
-            }
-            catch (InvalidMessage e)
-            {
-                Assert.Fail("Unexpected exception (InvalidMessage): " + e.Message);
-            }
-
-            string xmlDoc = msg.ToXML();
-            XDocument doc = null;
-            try
-            {
-                doc = XDocument.Parse(xmlDoc);
-            }
-            catch (Exception e)
-            {
-                Assert.Fail("Badly formed XML generated: " + e.Message);
-            }
-
-            var fields = doc.Descendants("message").Descendants("body")
-                .Select(field =>
-                    new
-                    {
-                        number = field.Descendants("field").Attributes("number").Single().Value,
-                        value = field.Descendants("field").Single().Value
-                    })
-                    .ToList();
-
-            foreach (var elem in fields)
-            {
-                int number = 0;
-                if (int.TryParse(elem.number.ToString(), out number) == false)
-                {
-                    Assert.Fail("should be number " + elem.number.ToString() + " " + elem.value.ToString());
-                }
-                else
-                {
-                    string value = msg.GetString(number);
-                    Assert.That(value, Is.EqualTo(elem.value));
-                }
-            }
-        }
-
-
-        [Test]
-        public void ToXMLWithGroupsTest()
-        {
-            var dd = new QuickFix.DataDictionary.DataDictionary();
-            dd.Load("../../../spec/fix/FIX44.xml");
-
-            string[] msgFields = {
-                // header
-                "8=FIX.4.4","9=638", "35=8", "34=360", "49=BLPTSOX", "52=20130321-15:21:23", "56=THINKTSOX", "57=6804469", "128=ZERO",
-                // non-group body fields
-                "6=122.255", "11=61101189", "14=1990000", "15=GBP", "17=VCON:20130321:50018:5:12", "22=4", "31=122.255", "32=1990000",
-                "37=116", "38=1990000", "39=2", "48=GB0032452392", "54=1", "55=[N/A]", "60=20130321-15:21:23", "64=20130322", "75=20130321",
-                "106=UK TSY 4 1/4% 2036", "118=2436321.85", "150=F", "151=0", "157=15", "159=3447.35", "192=0", "198=3739:20130321:50018:5",
-                "223=0.0425", "228=1", "236=0.0291371041", "238=0", "381=2432874.5", "423=1", "470=GB", "541=20360307",
-                // NoPartyIDs
-                "453=6",
-                "448=VCON", "447=D", "452=1", "802=1", "523=14", "803=4",
-                "448=TFOLIO:6804469", "447=D", "452=12",
-                "448=TFOLIO", "447=D", "452=11",
-                "448=THINKFOLIO LTD", "447=D", "452=13",
-                "448=SXT", "447=D", "452=16",
-                "448=TFOLIO:6804469", "447=D", "452=36",
-                "10=152"
-            };
-            string msgStr = String.Join(Message.SOH, msgFields) + Message.SOH;
-
-            QuickFix.FIX44.ExecutionReport msg = new QuickFix.FIX44.ExecutionReport();
-            msg.FromString(msgStr, true, dd, dd, null); // <-- null factory!
-
-
-            string xmlDoc = msg.ToXML();
-
-            System.Diagnostics.Debug.Print(xmlDoc.ToString());
-
-            XDocument doc = null;
-            try
-            {
-                doc = XDocument.Parse(xmlDoc);
-            }
-            catch (Exception e)
-            {
-                Assert.Fail("Badly formed XML generated: " + e.Message);
-            }
-
-
-            var groups = doc.Descendants("message").Descendants("body").Elements("group")
-                .Select(group =>
-                    new
-                    {
-                        numbers = group.Descendants("field").Attributes("number"),
-                        values = group.Descendants("field")
-                    })
-
-                    .ToList();
-            int ct = 0;
-            foreach (var elem in groups)
-            {
-                int number = 0;
-                Group group = msg.GetGroup(++ct, 453);
-
-                var valueEnum = elem.values.GetEnumerator();
-                foreach (var numberEnum in elem.numbers)
-                {
-                    valueEnum.MoveNext();
-                    string value = valueEnum.Current.Value;
-
-                    if (int.TryParse(numberEnum.Value.ToString(), out number) == false)
-                    {
-                        Assert.Fail("should be number " + numberEnum.Value.ToString());
-                    }
-                    else
-                    {
-                        if (group.IsSetField(number))
-                        {
-                            string msgValue = group.GetString(number);
-                            Assert.That(value, Is.EqualTo(msgValue));
-                        }
-                    }
-                }
-            }
         }
     }
 }

--- a/UnitTests/MessageToXmlTests.cs
+++ b/UnitTests/MessageToXmlTests.cs
@@ -1,0 +1,150 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using NUnit.Framework;
+using QuickFix;
+using QuickFix.Fields;
+using UnitTests.TestHelpers;
+
+namespace UnitTests
+{
+    [TestFixture]
+    public class MessageToXmlTests
+    {
+        private readonly IMessageFactory _defaultMsgFactory = new DefaultMessageFactory();
+
+        [Test]
+        public void ToXMLTest()
+        {
+            string str1 = "8=FIX.4.2\x01" + "9=55\x01" + "35=0\x01" + "34=3\x01" + "49=TW\x01" +
+                "52=20000426-12:05:06\x01" + "56=ISLD\x01" + "1=acct123\x01" + "10=123\x01";
+            Message msg = new Message();
+            try
+            {
+                msg.FromString(str1, true, null, null, _defaultMsgFactory);
+            }
+            catch (InvalidMessage e)
+            {
+                Assert.Fail("Unexpected exception (InvalidMessage): " + e.Message);
+            }
+
+            string xmlDoc = msg.ToXML();
+            XDocument doc = null;
+            try
+            {
+                doc = XDocument.Parse(xmlDoc);
+            }
+            catch (Exception e)
+            {
+                Assert.Fail("Badly formed XML generated: " + e.Message);
+            }
+
+            var fields = doc.Descendants("message").Descendants("body")
+                .Select(field =>
+                    new
+                    {
+                        number = field.Descendants("field").Attributes("number").Single().Value,
+                        value = field.Descendants("field").Single().Value
+                    })
+                    .ToList();
+
+            foreach (var elem in fields)
+            {
+                int number = 0;
+                if (int.TryParse(elem.number.ToString(), out number) == false)
+                {
+                    Assert.Fail("should be number " + elem.number.ToString() + " " + elem.value.ToString());
+                }
+                else
+                {
+                    string value = msg.GetString(number);
+                    Assert.That(value, Is.EqualTo(elem.value));
+                }
+            }
+        }
+
+
+        [Test]
+        public void ToXMLWithGroupsTest()
+        {
+            var dd = new QuickFix.DataDictionary.DataDictionary();
+            dd.Load(Path.Combine(TestContext.CurrentContext.TestDirectory, "spec", "fix", "FIX44.xml"));
+
+            string[] msgFields = {
+                // header
+                "8=FIX.4.4","9=638", "35=8", "34=360", "49=BLPTSOX", "52=20130321-15:21:23", "56=THINKTSOX", "57=6804469", "128=ZERO",
+                // non-group body fields
+                "6=122.255", "11=61101189", "14=1990000", "15=GBP", "17=VCON:20130321:50018:5:12", "22=4", "31=122.255", "32=1990000",
+                "37=116", "38=1990000", "39=2", "48=GB0032452392", "54=1", "55=[N/A]", "60=20130321-15:21:23", "64=20130322", "75=20130321",
+                "106=UK TSY 4 1/4% 2036", "118=2436321.85", "150=F", "151=0", "157=15", "159=3447.35", "192=0", "198=3739:20130321:50018:5",
+                "223=0.0425", "228=1", "236=0.0291371041", "238=0", "381=2432874.5", "423=1", "470=GB", "541=20360307",
+                // NoPartyIDs
+                "453=6",
+                "448=VCON", "447=D", "452=1", "802=1", "523=14", "803=4",
+                "448=TFOLIO:6804469", "447=D", "452=12",
+                "448=TFOLIO", "447=D", "452=11",
+                "448=THINKFOLIO LTD", "447=D", "452=13",
+                "448=SXT", "447=D", "452=16",
+                "448=TFOLIO:6804469", "447=D", "452=36",
+                "10=152"
+            };
+            string msgStr = String.Join(Message.SOH, msgFields) + Message.SOH;
+
+            QuickFix.FIX44.ExecutionReport msg = new QuickFix.FIX44.ExecutionReport();
+            msg.FromString(msgStr, true, dd, dd, null); // <-- null factory!
+
+
+            string xmlDoc = msg.ToXML();
+
+            System.Diagnostics.Debug.Print(xmlDoc.ToString());
+
+            XDocument doc = null;
+            try
+            {
+                doc = XDocument.Parse(xmlDoc);
+            }
+            catch (Exception e)
+            {
+                Assert.Fail("Badly formed XML generated: " + e.Message);
+            }
+
+
+            var groups = doc.Descendants("message").Descendants("body").Elements("group")
+                .Select(group =>
+                    new
+                    {
+                        numbers = group.Descendants("field").Attributes("number"),
+                        values = group.Descendants("field")
+                    })
+
+                    .ToList();
+            int ct = 0;
+            foreach (var elem in groups)
+            {
+                int number = 0;
+                Group group = msg.GetGroup(++ct, 453);
+
+                var valueEnum = elem.values.GetEnumerator();
+                foreach (var numberEnum in elem.numbers)
+                {
+                    valueEnum.MoveNext();
+                    string value = valueEnum.Current.Value;
+
+                    if (int.TryParse(numberEnum.Value.ToString(), out number) == false)
+                    {
+                        Assert.Fail("should be number " + numberEnum.Value.ToString());
+                    }
+                    else
+                    {
+                        if (group.IsSetField(number))
+                        {
+                            string msgValue = group.GetString(number);
+                            Assert.That(value, Is.EqualTo(msgValue));
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/UnitTests/MessageToXmlTests.cs
+++ b/UnitTests/MessageToXmlTests.cs
@@ -20,48 +20,22 @@ namespace UnitTests
             string str1 = "8=FIX.4.2\x01" + "9=55\x01" + "35=0\x01" + "34=3\x01" + "49=TW\x01" +
                 "52=20000426-12:05:06\x01" + "56=ISLD\x01" + "1=acct123\x01" + "10=123\x01";
             Message msg = new Message();
-            try
-            {
-                msg.FromString(str1, true, null, null, _defaultMsgFactory);
-            }
-            catch (InvalidMessage e)
-            {
-                Assert.Fail("Unexpected exception (InvalidMessage): " + e.Message);
-            }
+            msg.FromString(str1, true, null, null, _defaultMsgFactory);
 
-            string xmlDoc = msg.ToXML();
-            XDocument doc = null;
-            try
-            {
-                doc = XDocument.Parse(xmlDoc);
-            }
-            catch (Exception e)
-            {
-                Assert.Fail("Badly formed XML generated: " + e.Message);
-            }
+            string expected = @"<message>
+<header>
+<field number=""8""><![CDATA[FIX.4.2]]></field><field number=""9""><![CDATA[55]]></field><field number=""34""><![CDATA[3]]></field><field number=""35""><![CDATA[0]]></field><field number=""49""><![CDATA[TW]]></field><field number=""52""><![CDATA[20000426-12:05:06]]></field><field number=""56""><![CDATA[ISLD]]></field>
+</header>
+<body>
+<field number=""1""><![CDATA[acct123]]></field>
+</body>
+<trailer>
+<field number=""10""><![CDATA[123]]></field>
+</trailer>
+</message>
+";
 
-            var fields = doc.Descendants("message").Descendants("body")
-                .Select(field =>
-                    new
-                    {
-                        number = field.Descendants("field").Attributes("number").Single().Value,
-                        value = field.Descendants("field").Single().Value
-                    })
-                    .ToList();
-
-            foreach (var elem in fields)
-            {
-                int number = 0;
-                if (int.TryParse(elem.number.ToString(), out number) == false)
-                {
-                    Assert.Fail("should be number " + elem.number.ToString() + " " + elem.value.ToString());
-                }
-                else
-                {
-                    string value = msg.GetString(number);
-                    Assert.That(value, Is.EqualTo(elem.value));
-                }
-            }
+            Assert.AreEqual(expected, msg.ToXML());
         }
 
 
@@ -94,57 +68,20 @@ namespace UnitTests
             QuickFix.FIX44.ExecutionReport msg = new QuickFix.FIX44.ExecutionReport();
             msg.FromString(msgStr, true, dd, dd, null); // <-- null factory!
 
+            string expected = @"<message>
+<header>
+<field number=""8""><![CDATA[FIX.4.4]]></field><field number=""9""><![CDATA[638]]></field><field number=""34""><![CDATA[360]]></field><field number=""35""><![CDATA[8]]></field><field number=""49""><![CDATA[BLPTSOX]]></field><field number=""52""><![CDATA[20130321-15:21:23]]></field><field number=""56""><![CDATA[THINKTSOX]]></field><field number=""57""><![CDATA[6804469]]></field><field number=""128""><![CDATA[ZERO]]></field>
+</header>
+<body>
+<field number=""6""><![CDATA[122.255]]></field><field number=""11""><![CDATA[61101189]]></field><field number=""14""><![CDATA[1990000]]></field><field number=""15""><![CDATA[GBP]]></field><field number=""17""><![CDATA[VCON:20130321:50018:5:12]]></field><field number=""22""><![CDATA[4]]></field><field number=""31""><![CDATA[122.255]]></field><field number=""32""><![CDATA[1990000]]></field><field number=""37""><![CDATA[116]]></field><field number=""38""><![CDATA[1990000]]></field><field number=""39""><![CDATA[2]]></field><field number=""48""><![CDATA[GB0032452392]]></field><field number=""54""><![CDATA[1]]></field><field number=""55""><![CDATA[[N/A]]]></field><field number=""60""><![CDATA[20130321-15:21:23]]></field><field number=""64""><![CDATA[20130322]]></field><field number=""75""><![CDATA[20130321]]></field><field number=""106""><![CDATA[UK TSY 4 1/4% 2036]]></field><field number=""118""><![CDATA[2436321.85]]></field><field number=""150""><![CDATA[F]]></field><field number=""151""><![CDATA[0]]></field><field number=""157""><![CDATA[15]]></field><field number=""159""><![CDATA[3447.35]]></field><field number=""192""><![CDATA[0]]></field><field number=""198""><![CDATA[3739:20130321:50018:5]]></field><field number=""223""><![CDATA[0.0425]]></field><field number=""228""><![CDATA[1]]></field><field number=""236""><![CDATA[0.0291371041]]></field><field number=""238""><![CDATA[0]]></field><field number=""381""><![CDATA[2432874.5]]></field><field number=""423""><![CDATA[1]]></field><field number=""453""><![CDATA[6]]></field><field number=""470""><![CDATA[GB]]></field><field number=""541""><![CDATA[20360307]]></field><group><field number=""447""><![CDATA[D]]></field><field number=""448""><![CDATA[VCON]]></field><field number=""452""><![CDATA[1]]></field><field number=""802""><![CDATA[1]]></field><group><field number=""523""><![CDATA[14]]></field><field number=""803""><![CDATA[4]]></field></group></group><group><field number=""447""><![CDATA[D]]></field><field number=""448""><![CDATA[TFOLIO:6804469]]></field><field number=""452""><![CDATA[12]]></field></group><group><field number=""447""><![CDATA[D]]></field><field number=""448""><![CDATA[TFOLIO]]></field><field number=""452""><![CDATA[11]]></field></group><group><field number=""447""><![CDATA[D]]></field><field number=""448""><![CDATA[THINKFOLIO LTD]]></field><field number=""452""><![CDATA[13]]></field></group><group><field number=""447""><![CDATA[D]]></field><field number=""448""><![CDATA[SXT]]></field><field number=""452""><![CDATA[16]]></field></group><group><field number=""447""><![CDATA[D]]></field><field number=""448""><![CDATA[TFOLIO:6804469]]></field><field number=""452""><![CDATA[36]]></field></group>
+</body>
+<trailer>
+<field number=""10""><![CDATA[152]]></field>
+</trailer>
+</message>
+";
 
-            string xmlDoc = msg.ToXML();
-
-            System.Diagnostics.Debug.Print(xmlDoc.ToString());
-
-            XDocument doc = null;
-            try
-            {
-                doc = XDocument.Parse(xmlDoc);
-            }
-            catch (Exception e)
-            {
-                Assert.Fail("Badly formed XML generated: " + e.Message);
-            }
-
-
-            var groups = doc.Descendants("message").Descendants("body").Elements("group")
-                .Select(group =>
-                    new
-                    {
-                        numbers = group.Descendants("field").Attributes("number"),
-                        values = group.Descendants("field")
-                    })
-
-                    .ToList();
-            int ct = 0;
-            foreach (var elem in groups)
-            {
-                int number = 0;
-                Group group = msg.GetGroup(++ct, 453);
-
-                var valueEnum = elem.values.GetEnumerator();
-                foreach (var numberEnum in elem.numbers)
-                {
-                    valueEnum.MoveNext();
-                    string value = valueEnum.Current.Value;
-
-                    if (int.TryParse(numberEnum.Value.ToString(), out number) == false)
-                    {
-                        Assert.Fail("should be number " + numberEnum.Value.ToString());
-                    }
-                    else
-                    {
-                        if (group.IsSetField(number))
-                        {
-                            string msgValue = group.GetString(number);
-                            Assert.That(value, Is.EqualTo(msgValue));
-                        }
-                    }
-                }
-            }
+            Assert.AreEqual(expected, msg.ToXML());
         }
     }
 }


### PR DESCRIPTION
See #323 for description.

We are intentionally not accepting the "QuickFIX Compatible" feature of #323, because we can't quite figure out what it's for, or what it's even supposed to be compatible with.