### PR TITLE
Fix NullReferenceException crash

### DIFF
--- a/QuickFIXn/DataDictionary/DataDictionary.cs
+++ b/QuickFIXn/DataDictionary/DataDictionary.cs
@@ -561,7 +561,7 @@ namespace QuickFix.DataDictionary
             Console.WriteLine(s);
             */
 
-            string messageTypeName = (node.Attributes["name"] != null) ? node.Attributes["name"].Value : node.Name;
+            string messageTypeName = (node.Attributes?["name"] != null) ? node.Attributes["name"].Value : node.Name;
 
             if (!node.HasChildNodes) { return; }
             foreach (XmlNode childNode in node.ChildNodes)


### PR DESCRIPTION
This fixes a crash that occurs when instantiating a DataDictionary object with the attached DataDictionary file
[FIX44.xml.txt](https://github.com/connamara/quickfixn/files/4449828/FIX44.xml.txt)

