### PR TITLE
Changed IDisposed implementation to follow MS general pattern

### DIFF
--- a/QuickFIXn/ClientHandlerThread.cs
+++ b/QuickFIXn/ClientHandlerThread.cs
@@ -150,19 +150,32 @@ namespace QuickFix
 
         #endregion
 
+        ~ClientHandlerThread() => Dispose(false);
         public void Dispose()
         {
-            if (socketReader_ != null)
-            {
-                socketReader_.Dispose();
-                socketReader_ = null;
-            }
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
 
-            if (log_ != null)
+        private bool _disposed = false;
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed) return;
+            if (disposing)
             {
-                log_.Dispose();
-                log_ = null;
+                if (socketReader_ != null)
+                {
+                    socketReader_.Dispose();
+                    socketReader_ = null;
+                }
+
+                if (log_ != null)
+                {
+                    log_.Dispose();
+                    log_ = null;
+                }
             }
+            _disposed = true;
         }
     }
 }

--- a/QuickFIXn/HttpServer.cs
+++ b/QuickFIXn/HttpServer.cs
@@ -555,13 +555,14 @@ namespace Acceptor
             return "<"+entryType+" align=\"left\">" + cellContent + "</"+entryType+">";
         }
 
-        public virtual void Dispose()
+        ~HttpServer() => Dispose(false);
+        public void Dispose()
         {
             Dispose(true);
             GC.SuppressFinalize(this);
         }
 
-        private void Dispose(bool disposing)
+        protected virtual void Dispose(bool disposing)
         {
             if (_disposed)
             {

--- a/QuickFIXn/Session.cs
+++ b/QuickFIXn/Session.cs
@@ -25,7 +25,6 @@ namespace QuickFix
         private IMessageFactory msgFactory_;
         private bool appDoesEarlyIntercept_;
         private static readonly HashSet<string> AdminMsgTypes = new HashSet<string>() { "0", "A", "1", "2", "3", "4", "5" };
-        private bool disposed_;
 
         #endregion
 
@@ -1685,20 +1684,29 @@ namespace QuickFix
 
         public void Dispose()
         {
-            if (!disposed_)
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        private bool disposed_ = false;
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposed_) return;
+            if (disposing)
             {
                 if (state_ != null) { state_.Dispose(); }
                 lock (sessions_)
                 {
                     sessions_.Remove(this.SessionID);
                 }
-                disposed_ = true;
             }
+            disposed_ = true;
         }
 
         public bool Disposed
         {
             get { return disposed_; }
         }
+        ~Session() => Dispose(false);
     }
 }

--- a/QuickFIXn/ThreadedSocketAcceptor.cs
+++ b/QuickFIXn/ThreadedSocketAcceptor.cs
@@ -387,17 +387,20 @@ namespace QuickFix
         /// <param name="disposing"></param>
         protected virtual void Dispose(bool disposing)
         {
-            try
+            if (_disposed) return;
+            if (disposing)
             {
-                Stop();
-                _disposed = true;
+                try
+                {
+                    Stop();
+                }
+                catch (ObjectDisposedException)
+                {
+                    // ignore
+                }
             }
-            catch (ObjectDisposedException)
-            {
-                // ignore
-            }
+            _disposed = true;
         }
-
         /// <summary>
         /// Disposes created sessions
         /// </summary>
@@ -406,7 +409,9 @@ namespace QuickFix
         /// </remarks>
         public void Dispose()
         {
-            Stop();
+            Dispose(true);
+            GC.SuppressFinalize(this);
         }
+        ~ThreadedSocketAcceptor() => Dispose(false);
     }
 }


### PR DESCRIPTION
IDisposed as described in [https://docs.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-dispose]. Cleans up CA1063 warning. [https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1063].
Passed unit and acceptance tests (<results total='56' failures='0'/>)