### PR TITLE
fix missing SSL config override

### DIFF
--- a/QuickFIXn/SocketSettings.cs
+++ b/QuickFIXn/SocketSettings.cs
@@ -192,7 +192,10 @@ namespace QuickFix
                 ValidateCertificates = dictionary.GetBool(SessionSettings.SSL_VALIDATE_CERTIFICATES);
 
             if (dictionary.Has(SessionSettings.SSL_CHECK_CERTIFICATE_REVOCATION))
-                CheckCertificateRevocation = dictionary.GetBool(SessionSettings.SSL_CHECK_CERTIFICATE_REVOCATION);
+            {
+                // can only be true if ValdateCertificates is true (this is noted in the config docs)
+                CheckCertificateRevocation = ValidateCertificates && dictionary.GetBool(SessionSettings.SSL_CHECK_CERTIFICATE_REVOCATION);
+            }
 
             // Use setting for client certificate check if one exist 
             // otherwise enable client certificate check if a ca certificate is specified

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -24,6 +24,7 @@ What's New
 * (patch) #591 - Nanosecond DateTime reader bugfix (gbirchmeier)
 * (patch) #592/#601 - better detection of malformed DD elements (gbirchmeier/roederja2)
 * (patch) #606 - fix IDisposable implementations to follow MS general pattern (pavka1799)
+* (patch) #566 - SSLValidateCertificates=N overrides SSLCheckCertificateRevocation (gbirchmeier, h/t to Mad-Lynx)
 
 ### v1.9.0:
 * (minor) #469 - Add support for NET Standard 2.0 (jhickson)


### PR DESCRIPTION
 #566

SSLCheckCertificateRevocation can only be true vim if SSLValidateCertificates is true