### PR TITLE
 Avoid "'pwsh' is not recognized..." message from build.bat (resubmit of 617)

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -4,7 +4,7 @@ set CONFIGURATION=%1
 
 if "%1" == "" set CONFIGURATION=Release
 
-pwsh -v >nul
+pwsh -v >nul 2>&1
 if "%ERRORLEVEL%" == "0" (
 	pwsh .\build.ps1 %CONFIGURATION%
 ) else (

--- a/build.bat
+++ b/build.bat
@@ -4,6 +4,7 @@ set CONFIGURATION=%1
 
 if "%1" == "" set CONFIGURATION=Release
 
+REM pwsh is in PowerShell 6+
 pwsh -v >nul 2>&1
 if "%ERRORLEVEL%" == "0" (
 	pwsh .\build.ps1 %CONFIGURATION%


### PR DESCRIPTION
Re-submit of #617 

Redirected stderr to stdout (nul) to avoid confusing message "'pwsh' is not recognized as an internal or external command, operable program or batch file."

@pavka1799 - I redid it because your PR had that weird merge commit in there.  Probably wouldn't hurt anything, just thought it was odd.