### PR TITLE
Fixes several issues with New-Release.ps1

### DIFF
--- a/New-Release.ps1
+++ b/New-Release.ps1
@@ -18,16 +18,16 @@ Param (
 )
 
 $QFDir = "quickfixn-$TagVersion"
-$BuildTarget = if ($NuGetApiKey) { 'build' } else { 'pack' }
-$BuildProps = "-c Release$(if ($NuGetApiKey) { ' --include-symbols -o tmp\NuGet' })"
+$BuildTarget = if ($NuGetApiKey) { 'pack' } else { 'build' }
+$BuildProps = @('-c', 'Release', @(if ($NuGetApiKey) { @('--include-symbols', '-o', 'tmp\NuGet') }))
 
 Write-Host '--== QuickFIX/n Package Release Script ==--' -ForegroundColor Cyan
 Write-Host "`nTag Version: $TagVersion`n"
 
 if ($UseWslRuby -and $UseWslRuby.IsPresent) {
-	wsl ruby scripts\update_assembly_version.rb $TagVersion QuickFIXn\QuickFix.csproj Messages\FIX40\QuickFix.FIX40.csproj Messages\FIX41\QuickFix.FIX41.csproj Messages\FIX42\QuickFix.FIX42.csproj Messages\FIX43\QuickFix.FIX43.csproj Messages\FIX44\QuickFix.FIX44.csproj Messages\FIX50\QuickFix.FIX50.csproj Messages\FIX50SP1\QuickFix.FIX50SP1.csproj Messages\FIX50SP2\QuickFix.FIX50SP2.csproj
+	wsl ruby scripts/update_assembly_version.rb "v$TagVersion" QuickFIXn/QuickFix.csproj Messages/FIX40/QuickFix.FIX40.csproj Messages/FIX41/QuickFix.FIX41.csproj Messages/FIX42/QuickFix.FIX42.csproj Messages/FIX43/QuickFix.FIX43.csproj Messages/FIX44/QuickFix.FIX44.csproj Messages/FIX50/QuickFix.FIX50.csproj Messages/FIX50SP1/QuickFix.FIX50SP1.csproj Messages/FIX50SP2/QuickFix.FIX50SP2.csproj
 } else {
-	ruby scripts\update_assembly_version.rb $TagVersion QuickFIXn\QuickFix.csproj Messages\FIX40\QuickFix.FIX40.csproj Messages\FIX41\QuickFix.FIX41.csproj Messages\FIX42\QuickFix.FIX42.csproj Messages\FIX43\QuickFix.FIX43.csproj Messages\FIX44\QuickFix.FIX44.csproj Messages\FIX50\QuickFix.FIX50.csproj Messages\FIX50SP1\QuickFix.FIX50SP1.csproj Messages\FIX50SP2\QuickFix.FIX50SP2.csproj
+	ruby scripts\update_assembly_version.rb "v$TagVersion" QuickFIXn\QuickFix.csproj Messages\FIX40\QuickFix.FIX40.csproj Messages\FIX41\QuickFix.FIX41.csproj Messages\FIX42\QuickFix.FIX42.csproj Messages\FIX43\QuickFix.FIX43.csproj Messages\FIX44\QuickFix.FIX44.csproj Messages\FIX50\QuickFix.FIX50.csproj Messages\FIX50SP1\QuickFix.FIX50SP1.csproj Messages\FIX50SP2\QuickFix.FIX50SP2.csproj
 }
 
 $ExitCode = $LASTEXITCODE
@@ -77,10 +77,10 @@ if ($ExitCode -eq 0) {
 }
 
 if (Test-Path 'tmp') {
-	Get-ChildItem 'tmp' -Recurse | Remove-Item -Force > $null
+	Get-ChildItem 'tmp' -Recurse | Remove-Item -Recurse -Force > $null
 }
 
-dotnet $BuildTarget $BuildProps QuickFIXn.sln
+dotnet $BuildTarget @BuildProps QuickFIXn.sln
 $ExitCode = $LASTEXITCODE
 if ($ExitCode -eq 0) {
 	Write-Host '* Built QuickFIX/n and created NuGet packages at .\tmp\Nuget'
@@ -91,25 +91,25 @@ if ($ExitCode -eq 0) {
 
 # DO NOT remove quotes around *.nupkg. Due to a bug in older versions of the .NET SDK,
 # without the surrounding quotes, only the first package will be pushed.
-#if ($BuildTarget -ieq 'pack') {
-#	dotnet nuget push '*.nupkg' -s 'https://api.nuget.org/v3/index.json' -k $NuGetApiKey 'tmp\NuGet'
-#}
+if ($BuildTarget -ieq 'pack') {
+	dotnet nuget push '*.nupkg' -s 'https://api.nuget.org/v3/index.json' -k $NuGetApiKey 'tmp\NuGet'
+}
 
-#$ExitCode = $LASTEXITCODE
-#if ($ExitCode -eq 0) {
-#	Write-Host '* Pushed QuickFIX/n NuGet packages to NuGet.org'
-#} else {
-#	Write-Error 'A problem occurred while pushing NuGet packages to NuGet.org'
-#	Exit $ExitCode
-#}
+$ExitCode = $LASTEXITCODE
+if ($ExitCode -eq 0) {
+	Write-Host '* Pushed QuickFIX/n NuGet packages to NuGet.org'
+} else {
+	Write-Error 'A problem occurred while pushing NuGet packages to NuGet.org'
+	Exit $ExitCode
+}
 
 @(
-	$QFDir
-	"$QFDir\bin"
-	"$QFDir\bin\netstandard2.0"
-	"$QFDir\spec"
-	"$QFDir\spec\fix"
-	"$QFDir\config"
+	"tmp\$QFDir"
+	"tmp\$QFDir\bin"
+	"tmp\$QFDir\bin\netstandard2.0"
+	"tmp\$QFDir\spec"
+	"tmp\$QFDir\spec\fix"
+	"tmp\$QFDir\config"
 ) | ForEach-Object { New-Item -ItemType Directory $_ }
 
 @(
@@ -158,7 +158,7 @@ git checkout master
 Write-Host '* Changed back to master.'
 
 Write-Host "`nSuccessfully created QuickFIX/n $TagVersion" -ForegroundColor Green
-Write-Host "You can download the zip here: http://quickfix.s3.amazonaws.com/$QFDir.zip"
+Write-Host "You can download the zip here: https://quickfix.s3.amazonaws.com/$QFDir.zip"
 if ($NuGetApiKey) {
 	Write-Host "Alternatively, you can download the NuGet packages from NuGet.org."
 }


### PR DESCRIPTION
The first issue fixed was that `$BuildProps` was being passed to `dotnet` as
a single string, and therefore, a single argument. So instead,
`$BuildProps` is now an array and is splatted to the call to `dotnet`
resulting in the desired behavior.

The second issue was found when running Ruby in WSL. Ruby expected the
paths to use `/` path separators--duh, it's Linux. A simple mistake on
my part.

When originally writing this script, I commented out the nuget push
code because I had nowhere to push packages&mdash;but I subsequently forgot
to uncomment that code.

Lastly, I needed to fix up some paths when generating various artifacts.