### PR TITLE
Dynamic SocketAcceptPort

### DIFF
--- a/QuickFIXn/ThreadedSocketAcceptor.cs
+++ b/QuickFIXn/ThreadedSocketAcceptor.cs
@@ -99,9 +99,6 @@ namespace QuickFix
                 QuickFix.Dictionary dict = settings.Get(sessionID);
                 CreateSession(sessionID, dict);
             }
-
-            if (0 == socketDescriptorForAddress_.Count)
-                throw new ConfigError("No acceptor sessions found in SessionSettings.");
         }
 
         private AcceptorSocketDescriptor GetAcceptorSocketDescriptor(Dictionary dict)

--- a/QuickFIXn/ThreadedSocketAcceptor.cs
+++ b/QuickFIXn/ThreadedSocketAcceptor.cs
@@ -153,6 +153,14 @@ namespace QuickFix
                     Session session = sessionFactory_.Create(sessionID, dict);
                     descriptor.AcceptSession(session);
                     sessions_[sessionID] = session;
+
+                    // start SocketReactor if it was created via AddSession call
+                    // and if acceptor is already started
+                    if (isStarted_ && !_disposed)
+                    {
+                        descriptor.SocketReactor.Start();
+                    }
+
                     return true;
                 }
             }

--- a/QuickFIXn/ThreadedSocketReactor.cs
+++ b/QuickFIXn/ThreadedSocketReactor.cs
@@ -61,8 +61,14 @@ namespace QuickFix
 
         public void Start()
         {
-            serverThread_ = new Thread(new ThreadStart(Run));
-            serverThread_.Start();
+            lock (sync_)
+            {
+                if (state_ == State.RUNNING && serverThread_ == null)
+                {
+                    serverThread_ = new Thread(Run);
+                    serverThread_.Start();
+                }
+            }
         }
 
         public void Shutdown()

--- a/UnitTests/SessionDynamicTest.cs
+++ b/UnitTests/SessionDynamicTest.cs
@@ -384,6 +384,25 @@ namespace UnitTests
         }
 
         [Test]
+        public void AddSessionDynamicWithDifferentPortTest()
+        {
+            StartEngine(false);
+
+            // Add the dynamic acceptor with another port and ensure that we can now log on
+            string dynamicCompID = "acc10";
+            var sessionID = CreateSessionID(dynamicCompID);
+            var sessionConfig = CreateSessionConfig(dynamicCompID, false);
+            sessionConfig.SetString(SessionSettings.SOCKET_ACCEPT_PORT, AcceptPort2.ToString());
+
+            _acceptor.AddSession(sessionID, sessionConfig);
+
+            var socket = ConnectToEngine(AcceptPort2);
+            SendLogon(socket, dynamicCompID);
+
+            Assert.IsTrue(WaitForLogonStatus(dynamicCompID), "Failde to logon dynamic added acceptor session with another port");
+        }
+        
+        [Test]
         public void DynamicAcceptor()
         {
             StartEngine(false);


### PR DESCRIPTION
If sessions with a custom `SocketAcceptPort` are added (via `AddSession`) to a ThreadedSocketAcceptor instance after it has been created, the underlying `ThreadedSocketReactor` is not started. So, the created session is effectively useless because it cannot be connected to.

Additionally, the code throwing a `ConfigError` has been removed from `CreateSessions` because `AddSession` allows adding sessions dynamically after the `ThreadedSocketAcceptor` has been created.

(Replaces https://github.com/connamara/quickfixn/pull/453)