### PR TITLE
Allow decimals to handle exponential values.

### DIFF
--- a/QuickFIXn/Fields/Converters/DecimalConverter.cs
+++ b/QuickFIXn/Fields/Converters/DecimalConverter.cs
@@ -26,7 +26,7 @@ namespace QuickFix.Fields.Converters
                 if ((asciiValOfFirstChar < IntConverter.ASCII_ZERO) || (asciiValOfFirstChar > IntConverter.ASCII_NINE))
                     if (asciiValOfFirstChar != IntConverter.ASCII_MINUS && asciiValOfFirstChar != ASCII_DECIMALPOINT)
                         throw new FieldConvertError("Could not convert string to decimal (" + d + "): The first character must be a digit, decimal point, or minus sign");
-                return System.Convert.ToDecimal( d, System.Globalization.CultureInfo.InvariantCulture );
+                return decimal.Parse(d, System.Globalization.NumberStyles.AllowExponent | System.Globalization.NumberStyles.AllowLeadingSign | System.Globalization.NumberStyles.AllowDecimalPoint, System.Globalization.CultureInfo.InvariantCulture);
             }
             catch (System.OverflowException e)
             {

--- a/UnitTests/ConverterTests.cs
+++ b/UnitTests/ConverterTests.cs
@@ -63,6 +63,7 @@ namespace UnitTests
             Assert.That(DecimalConverter.Convert(new Decimal(4.23322)), Is.EqualTo("4.23322"));
             Assert.That(DecimalConverter.Convert(new Decimal(-4.23322)), Is.EqualTo("-4.23322"));
             Assert.That(DecimalConverter.Convert("4332.33"), Is.EqualTo(new Decimal(4332.33)));
+            Assert.That(DecimalConverter.Convert("3.000000000021874E-4"), Is.EqualTo(0.0003000000000021874M));
             Assert.Throws(typeof(FieldConvertError), delegate { DecimalConverter.Convert("2.32a34"); });
             Assert.Throws(typeof(FieldConvertError), delegate { DecimalConverter.Convert("+1.2"); });
             Assert.Throws(typeof(FieldConvertError), delegate { DecimalConverter.Convert("(1.2)"); });


### PR DESCRIPTION
This change will allow exponential values to work as decimal values as expected.

I know that the provider shouldn't be sending exponential values, but in some cases they are.  The unit test value is an actual example from a feed from an actual ATS in production.