### PR TITLE
Add setting to allow disabling of enumeration validation.

### DIFF
--- a/QuickFIXn/DataDictionary/DataDictionary.cs
+++ b/QuickFIXn/DataDictionary/DataDictionary.cs
@@ -25,6 +25,8 @@ namespace QuickFix.DataDictionary
         public bool CheckUserDefinedFields { get; set; }
         public bool AllowUnknownMessageFields { get; set; }
 
+        public bool CheckEnumValues { get; set; }
+
         public DDMap Header = new DDMap();
         public DDMap Trailer = new DDMap();
 
@@ -33,6 +35,7 @@ namespace QuickFix.DataDictionary
             CheckFieldsHaveValues = true;
             CheckFieldsOutOfOrder = true;
             CheckUserDefinedFields = true;
+            CheckEnumValues = true;
             AllowUnknownMessageFields = false;
         }
 
@@ -75,6 +78,7 @@ namespace QuickFix.DataDictionary
             this.CheckFieldsHaveValues = src.CheckFieldsHaveValues;
             this.CheckFieldsOutOfOrder = src.CheckFieldsOutOfOrder;
             this.CheckUserDefinedFields = src.CheckUserDefinedFields;
+            this.CheckEnumValues = src.CheckEnumValues;
             this.Header = src.Header;
             this.Trailer = src.Trailer;
         }
@@ -353,7 +357,7 @@ namespace QuickFix.DataDictionary
         {
             if (FieldsByTag.TryGetValue(field.Tag, out var fld))
             {
-                if (fld.HasEnums())
+                if (fld.HasEnums() && this.CheckEnumValues)
                 {
                     if (fld.IsMultipleValueFieldWithEnums)
                     {

--- a/QuickFIXn/SessionFactory.cs
+++ b/QuickFIXn/SessionFactory.cs
@@ -182,6 +182,8 @@ namespace QuickFix
                 ddCopy.CheckUserDefinedFields = settings.GetBool(SessionSettings.VALIDATE_USER_DEFINED_FIELDS);
             if (settings.Has(SessionSettings.ALLOW_UNKNOWN_MSG_FIELDS))
                 ddCopy.AllowUnknownMessageFields = settings.GetBool(SessionSettings.ALLOW_UNKNOWN_MSG_FIELDS);
+            if (settings.Has(SessionSettings.VALIDATE_ENUM_VALUES))
+                ddCopy.CheckEnumValues = settings.GetBool(SessionSettings.VALIDATE_ENUM_VALUES);
 
             return ddCopy;
         }

--- a/QuickFIXn/SessionSettings.cs
+++ b/QuickFIXn/SessionSettings.cs
@@ -42,6 +42,7 @@ namespace QuickFix
         public const string RESET_ON_LOGON = "ResetOnLogon";
         public const string RESET_ON_LOGOUT = "ResetOnLogout";
         public const string RESET_ON_DISCONNECT = "ResetOnDisconnect";
+        public const string VALIDATE_ENUM_VALUES = "ValidateEnumValues";
         public const string VALIDATE_FIELDS_OUT_OF_ORDER = "ValidateFieldsOutOfOrder";
         public const string VALIDATE_FIELDS_HAVE_VALUES = "ValidateFieldsHaveValues";
         public const string VALIDATE_USER_DEFINED_FIELDS = "ValidateUserDefinedFields";

--- a/UnitTests/DataDictionaryTests.cs
+++ b/UnitTests/DataDictionaryTests.cs
@@ -266,6 +266,11 @@ namespace UnitTests
             // multiple-value field, one value is invalid
             Assert.Throws(typeof(IncorrectTagValue),
                delegate { dd.CheckValue(new QuickFix.Fields.QuoteCondition("A @ D")); });
+
+
+            dd.CheckEnumValues = false;
+            dd.CheckValue(new QuickFix.Fields.TickDirection('9'));
+            dd.CheckValue(new QuickFix.Fields.QuoteCondition("A @ D"));
         }
 
         [Test]
@@ -298,6 +303,7 @@ namespace UnitTests
         }
 
         [Test]
+        [Category("Integration")]
         public void CheckGroupCountTest()
         {
             QuickFix.DataDictionary.DataDictionary dd = new QuickFix.DataDictionary.DataDictionary();


### PR DESCRIPTION
Sometimes providers change their schemas, adding new enum values not currently in our schema.  When that happens, we don't want things to start failing.

By default, QuickFix will blow up if an enum value doesn't match and there's no way to turn this off.

This PR adds the ability to disable this validation, if desired.  The default behavior is unchanged.