### PR TITLE
replace lock with memory barrier to avoid deadlocks.

### DIFF
--- a/QuickFIXn/Session.cs
+++ b/QuickFIXn/Session.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using QuickFix.Fields;
 using QuickFix.Fields.Converters;
 
@@ -230,7 +231,7 @@ namespace QuickFix
         /// <summary>
         /// Returns whether the Session has a Responder. This method is synchronized
         /// </summary>
-        public bool HasResponder { get { lock (sync_) { return null != responder_; } } }
+        public bool HasResponder { get { Thread.MemoryBarrier(); return null != responder_; } }
 
         /// <summary>
         /// Returns whether the Sessions will allow ResetSequence messages sent as


### PR DESCRIPTION
As described in closed pull request [here](https://github.com/connamara/quickfixn/pull/253) there may be a deadlock when socket is full and data needs to be writen and read at the same time.

I was able to reproduce with unit tests in my environment but writing a specific unit test here is quite complex as it's hardware dependent.

