### PR TITLE
Acceptor Dynamic Session Templates (2nd version)

### DIFF
--- a/QuickFIXn/AcceptorSocketDescriptor.cs
+++ b/QuickFIXn/AcceptorSocketDescriptor.cs
@@ -28,10 +28,10 @@ namespace QuickFix
 
         #endregion
 
-        public AcceptorSocketDescriptor(IPEndPoint socketEndPoint, SocketSettings socketSettings, QuickFix.Dictionary sessionDict)
+        public AcceptorSocketDescriptor(IPEndPoint socketEndPoint, SocketSettings socketSettings, QuickFix.Dictionary sessionDict, SessionProvider sessionProvider)
         {
             socketEndPoint_ = socketEndPoint;
-            socketReactor_ = new ThreadedSocketReactor(socketEndPoint_, socketSettings, sessionDict, this);
+            socketReactor_ = new ThreadedSocketReactor(socketEndPoint_, socketSettings, sessionDict, this, sessionProvider);
         }
 
         public void AcceptSession(Session session)

--- a/QuickFIXn/ClientHandlerThread.cs
+++ b/QuickFIXn/ClientHandlerThread.cs
@@ -54,13 +54,13 @@ namespace QuickFix
         /// <param name="settingsDict"></param>
         /// <param name="socketSettings"></param>
         public ClientHandlerThread(TcpClient tcpClient, long clientId, QuickFix.Dictionary settingsDict, SocketSettings socketSettings)
-            : this(tcpClient, clientId, settingsDict, socketSettings, null)
+            : this(tcpClient, clientId, settingsDict, socketSettings, null, null)
         {
             
         }
 
         internal ClientHandlerThread(TcpClient tcpClient, long clientId, QuickFix.Dictionary settingsDict,
-            SocketSettings socketSettings, AcceptorSocketDescriptor acceptorDescriptor)
+            SocketSettings socketSettings, AcceptorSocketDescriptor acceptorDescriptor, SessionProvider sessionProvider)
         {
             string debugLogFilePath = "log";
             if (settingsDict.Has(SessionSettings.DEBUG_FILE_LOG_PATH))
@@ -73,7 +73,7 @@ namespace QuickFix
                     "ClientHandlerThread", clientId.ToString(), "Debug-" + Guid.NewGuid().ToString()));
 
             this.Id = clientId;
-            socketReader_ = new SocketReader(tcpClient, socketSettings, this, acceptorDescriptor);
+            socketReader_ = new SocketReader(tcpClient, socketSettings, this, acceptorDescriptor, sessionProvider);
         }
 
         public void Start()

--- a/QuickFIXn/SessionTemplate.cs
+++ b/QuickFIXn/SessionTemplate.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace QuickFix
+{
+    /// <summary>
+    /// Support for wildcards in session names, i.e for session templates,
+    /// to create a session upon connect, if its SessionID matches a template
+    /// </summary>
+    internal static class SessionTemplate
+    {
+        const string WildcardValue = "*";
+        internal static bool IsSessionTemplate(SessionID sessionID)
+        {
+            return sessionID.SenderCompID.Equals(WildcardValue)
+                || sessionID.SenderSubID.Equals(WildcardValue)
+                || sessionID.SenderLocationID.Equals(WildcardValue)
+                || sessionID.TargetCompID.Equals(WildcardValue)
+                || sessionID.TargetSubID.Equals(WildcardValue)
+                || sessionID.TargetLocationID.Equals(WildcardValue);
+        }
+        /// <summary>
+        /// Settings, Acceptor and Socket Descriptor for each "template" SessionID 
+        /// </summary>
+        private static Dictionary<SessionID, TemplateParams> _templates =
+            new Dictionary<SessionID, TemplateParams>();
+        internal static void AddTemplate(SessionID sessionID, Dictionary dict, ThreadedSocketAcceptor acceptor, AcceptorSocketDescriptor descriptor)
+        {
+            lock (_templates)
+            {
+                if (_templates.ContainsKey(sessionID)) throw new ConfigError($"Duplicate session template {sessionID}");
+                _templates.Add(sessionID, new TemplateParams(dict, acceptor, descriptor));
+            }
+        }
+        /// <summary>
+        /// Looks up an earlier created session, or creates a new one,
+        /// if the SessionID matches a session's template
+        /// </summary>
+        internal static Session GetSession(SessionID sessionID)
+        {
+            Session session = Session.LookupSession(sessionID);
+            if (null == session) session = CreateFromTemplate(sessionID);
+            return session;
+        }
+        /// <summary>
+        /// If the given SessionID matches any of the templates,
+        /// creates and returns the new session from the first matching template
+        /// </summary>
+        /// <param name="sessionID">Session name without wildcards</param>
+        private static Session CreateFromTemplate(SessionID sessionID)
+        {
+            lock (_templates)
+            {
+                foreach (KeyValuePair<SessionID, TemplateParams> kv in _templates)
+                {
+                    if (IsMatching(sessionID, kv.Key))
+                    {
+                        Dictionary dict = ReplaceWildcardsInSettins(sessionID, kv.Value.Dict);
+                        return kv.Value.Acceptor.CreateAcceptorSession(sessionID, dict, kv.Value.Descriptor);
+                    }
+                }
+                return null;
+            }
+        }
+
+        private static bool IsMatching(SessionID sessionID, SessionID templateID)
+        {
+            // matching if for all parts (templateID is "*" AND sessionID is set) OR (templateID == sessionID)
+            return templateID.BeginString.Equals(sessionID.BeginString) // do not allow a wildcard for BeginString, as would have to implement logic to switch data dictionary to match FIX version, which does not seem to worth it...
+                && ((templateID.SenderCompID.Equals(WildcardValue) && !sessionID.SenderCompID.Equals(SessionID.NOT_SET)) || templateID.SenderCompID.Equals(sessionID.SenderCompID))
+                && ((templateID.SenderSubID.Equals(WildcardValue) && !sessionID.SenderSubID.Equals(SessionID.NOT_SET)) || templateID.SenderSubID.Equals(sessionID.SenderSubID))
+                && ((templateID.SenderLocationID.Equals(WildcardValue) && !sessionID.SenderLocationID.Equals(SessionID.NOT_SET)) || templateID.SenderLocationID.Equals(sessionID.SenderLocationID))
+                && ((templateID.TargetCompID.Equals(WildcardValue) && !sessionID.TargetCompID.Equals(SessionID.NOT_SET)) || templateID.TargetCompID.Equals(sessionID.TargetCompID))
+                && ((templateID.TargetSubID.Equals(WildcardValue) && !sessionID.TargetSubID.Equals(SessionID.NOT_SET)) || templateID.TargetSubID.Equals(sessionID.TargetSubID))
+                && ((templateID.TargetLocationID.Equals(WildcardValue) && !sessionID.TargetLocationID.Equals(SessionID.NOT_SET)) || templateID.TargetLocationID.Equals(sessionID.TargetLocationID));
+        }
+
+        private static Dictionary ReplaceWildcardsInSettins(SessionID sessionID, Dictionary dict)
+        {
+            QuickFix.Dictionary actualSettings = new QuickFix.Dictionary(dict);
+            if (WildcardValue.Equals(sessionID.BeginString)) actualSettings.SetString(SessionSettings.BEGINSTRING, sessionID.BeginString);
+            if (WildcardValue.Equals(sessionID.SenderCompID)) actualSettings.SetString(SessionSettings.SENDERCOMPID, sessionID.SenderCompID);
+            if (WildcardValue.Equals(sessionID.SenderSubID)) actualSettings.SetString(SessionSettings.SENDERSUBID, sessionID.SenderSubID);
+            if (WildcardValue.Equals(sessionID.SenderLocationID)) actualSettings.SetString(SessionSettings.SENDERLOCID, sessionID.SenderLocationID);
+            if (WildcardValue.Equals(sessionID.TargetCompID)) actualSettings.SetString(SessionSettings.TARGETCOMPID, sessionID.TargetCompID);
+            if (WildcardValue.Equals(sessionID.TargetSubID)) actualSettings.SetString(SessionSettings.TARGETSUBID, sessionID.TargetSubID);
+            if (WildcardValue.Equals(sessionID.TargetLocationID)) actualSettings.SetString(SessionSettings.TARGETLOCID, sessionID.TargetLocationID);
+            return actualSettings;
+        }
+    }
+
+    internal class TemplateParams
+    {
+        internal Dictionary Dict { get; }
+        internal ThreadedSocketAcceptor Acceptor { get; }
+        internal AcceptorSocketDescriptor Descriptor { get; }
+        internal TemplateParams(Dictionary dict, ThreadedSocketAcceptor acceptor, AcceptorSocketDescriptor descriptor)
+        {
+            Dict = dict;
+            Acceptor = acceptor;
+            Descriptor = descriptor;
+        }
+    }
+}

--- a/QuickFIXn/SessionTemplate.cs
+++ b/QuickFIXn/SessionTemplate.cs
@@ -55,7 +55,8 @@ namespace QuickFix
                 {
                     if (IsMatching(sessionID, kv.Key))
                     {
-                        Dictionary dict = ReplaceWildcardsInSettins(sessionID, kv.Value.Dict);
+                        Dictionary dict = ReplaceWildcardsInSettins(sessionID, kv.Key, kv.Value.Dict);
+                        kv.Value.Acceptor.SetSessionSettings(sessionID, dict);
                         return kv.Value.Acceptor.CreateAcceptorSession(sessionID, dict, kv.Value.Descriptor);
                     }
                 }
@@ -75,16 +76,15 @@ namespace QuickFix
                 && ((templateID.TargetLocationID.Equals(WildcardValue) && !sessionID.TargetLocationID.Equals(SessionID.NOT_SET)) || templateID.TargetLocationID.Equals(sessionID.TargetLocationID));
         }
 
-        private static Dictionary ReplaceWildcardsInSettins(SessionID sessionID, Dictionary dict)
+        private static Dictionary ReplaceWildcardsInSettins(SessionID sessionID, SessionID templateID, Dictionary dict)
         {
             QuickFix.Dictionary actualSettings = new QuickFix.Dictionary(dict);
-            if (WildcardValue.Equals(sessionID.BeginString)) actualSettings.SetString(SessionSettings.BEGINSTRING, sessionID.BeginString);
-            if (WildcardValue.Equals(sessionID.SenderCompID)) actualSettings.SetString(SessionSettings.SENDERCOMPID, sessionID.SenderCompID);
-            if (WildcardValue.Equals(sessionID.SenderSubID)) actualSettings.SetString(SessionSettings.SENDERSUBID, sessionID.SenderSubID);
-            if (WildcardValue.Equals(sessionID.SenderLocationID)) actualSettings.SetString(SessionSettings.SENDERLOCID, sessionID.SenderLocationID);
-            if (WildcardValue.Equals(sessionID.TargetCompID)) actualSettings.SetString(SessionSettings.TARGETCOMPID, sessionID.TargetCompID);
-            if (WildcardValue.Equals(sessionID.TargetSubID)) actualSettings.SetString(SessionSettings.TARGETSUBID, sessionID.TargetSubID);
-            if (WildcardValue.Equals(sessionID.TargetLocationID)) actualSettings.SetString(SessionSettings.TARGETLOCID, sessionID.TargetLocationID);
+            if (WildcardValue.Equals(templateID.SenderCompID)) actualSettings.SetString(SessionSettings.SENDERCOMPID, sessionID.SenderCompID);
+            if (WildcardValue.Equals(templateID.SenderSubID)) actualSettings.SetString(SessionSettings.SENDERSUBID, sessionID.SenderSubID);
+            if (WildcardValue.Equals(templateID.SenderLocationID)) actualSettings.SetString(SessionSettings.SENDERLOCID, sessionID.SenderLocationID);
+            if (WildcardValue.Equals(templateID.TargetCompID)) actualSettings.SetString(SessionSettings.TARGETCOMPID, sessionID.TargetCompID);
+            if (WildcardValue.Equals(templateID.TargetSubID)) actualSettings.SetString(SessionSettings.TARGETSUBID, sessionID.TargetSubID);
+            if (WildcardValue.Equals(templateID.TargetLocationID)) actualSettings.SetString(SessionSettings.TARGETLOCID, sessionID.TargetLocationID);
             return actualSettings;
         }
     }

--- a/QuickFIXn/SocketReader.cs
+++ b/QuickFIXn/SocketReader.cs
@@ -142,7 +142,7 @@ namespace QuickFix
             {
                 if (null == qfSession_)
                 {
-                    qfSession_ = Session.LookupSession(Message.GetReverseSessionID(msg));
+                    qfSession_ = SessionTemplate.GetSession(Message.GetReverseSessionID(msg));
                     if (null == qfSession_)
                     {
                         this.Log("ERROR: Disconnecting; received message for unknown session: " + msg);

--- a/QuickFIXn/SocketReader.cs
+++ b/QuickFIXn/SocketReader.cs
@@ -19,6 +19,7 @@ namespace QuickFix
         private TcpClient tcpClient_;
         private ClientHandlerThread responder_;
         private readonly AcceptorSocketDescriptor acceptorDescriptor_;
+        private readonly SessionProvider _sessionProvider;
 
         /// <summary>
         /// Keep a handle to the current outstanding read request (if any)
@@ -32,7 +33,7 @@ namespace QuickFix
         }
 
         public SocketReader(TcpClient tcpClient, SocketSettings settings, ClientHandlerThread responder)
-            : this(tcpClient, settings, responder, null)
+            : this(tcpClient, settings, responder, null, null)
         {
             
         }
@@ -41,12 +42,14 @@ namespace QuickFix
             TcpClient tcpClient,
             SocketSettings settings,
             ClientHandlerThread responder,
-            AcceptorSocketDescriptor acceptorDescriptor)
+            AcceptorSocketDescriptor acceptorDescriptor,
+            SessionProvider sessionProvider)
         {
             tcpClient_ = tcpClient;
             responder_ = responder;
             acceptorDescriptor_ = acceptorDescriptor;
             stream_ = Transport.StreamFactory.CreateServerStream(tcpClient, settings, responder.GetLog());
+            _sessionProvider = sessionProvider;
         }
 
         /// <summary> FIXME </summary>
@@ -142,7 +145,7 @@ namespace QuickFix
             {
                 if (null == qfSession_)
                 {
-                    qfSession_ = SessionTemplate.GetSession(Message.GetReverseSessionID(msg));
+                    qfSession_ = _sessionProvider.GetSession(Message.GetReverseSessionID(msg));
                     if (null == qfSession_)
                     {
                         this.Log("ERROR: Disconnecting; received message for unknown session: " + msg);

--- a/QuickFIXn/ThreadedSocketAcceptor.cs
+++ b/QuickFIXn/ThreadedSocketAcceptor.cs
@@ -17,6 +17,7 @@ namespace QuickFix
         private SessionSettings settings_;
         private Dictionary<IPEndPoint, AcceptorSocketDescriptor> socketDescriptorForAddress_ = new Dictionary<IPEndPoint, AcceptorSocketDescriptor>();
         private SessionFactory sessionFactory_;
+        private SessionProvider _sessionProvider = new SessionProvider();
         private bool isStarted_ = false;
         private bool _disposed = false;
         private object sync_ = new object();
@@ -129,7 +130,7 @@ namespace QuickFix
             AcceptorSocketDescriptor descriptor;
             if (!socketDescriptorForAddress_.TryGetValue(socketEndPoint, out descriptor))
             {
-                descriptor = new AcceptorSocketDescriptor(socketEndPoint, socketSettings, dict);
+                descriptor = new AcceptorSocketDescriptor(socketEndPoint, socketSettings, dict, _sessionProvider);
                 socketDescriptorForAddress_[socketEndPoint] = descriptor;
             }
 
@@ -150,9 +151,9 @@ namespace QuickFix
                 if ("acceptor" == connectionType)
                 {
                     AcceptorSocketDescriptor descriptor = GetAcceptorSocketDescriptor(dict);
-                    if (SessionTemplate.IsSessionTemplate(sessionID))
+                    if (SessionProvider.IsSessionTemplate(sessionID))
                     {
-                        SessionTemplate.AddTemplate(sessionID, dict, this, descriptor);
+                        _sessionProvider.AddTemplate(sessionID, dict, this, descriptor);
                     }
                     else
                     {

--- a/QuickFIXn/ThreadedSocketAcceptor.cs
+++ b/QuickFIXn/ThreadedSocketAcceptor.cs
@@ -164,8 +164,8 @@ namespace QuickFix
             return false;
         }
         /// <summary>
-        /// Can be called at initial session creation or
-        /// to create a dynamic session from a template right at the first connect
+        /// Can be called at initial sessions creation
+        /// or to create from a template a new dynamic session right at its first connect
         /// </summary>
         internal Session CreateAcceptorSession(SessionID sessionID, Dictionary dict, AcceptorSocketDescriptor descriptor)
         {
@@ -173,6 +173,14 @@ namespace QuickFix
             descriptor.AcceptSession(session);
             sessions_[sessionID] = session;
             return session;
+        }
+        /// <summary>
+        /// Must be called before creating a dynamic session at its first connect
+        /// to add its settings into the global dictionary
+        /// </summary>
+        internal void SetSessionSettings(SessionID sessionID, Dictionary dict)
+        {
+            settings_.Set(sessionID, dict);
         }
 
         private void StartAcceptingConnections()

--- a/QuickFIXn/ThreadedSocketReactor.cs
+++ b/QuickFIXn/ThreadedSocketReactor.cs
@@ -37,7 +37,7 @@ namespace QuickFix
         private QuickFix.Dictionary sessionDict_;
         private IPEndPoint serverSocketEndPoint_;
         private readonly AcceptorSocketDescriptor acceptorDescriptor_;
-
+        private readonly SessionProvider _sessionProvider;
         #endregion
 
         [Obsolete("Use the other constructor")]
@@ -46,17 +46,18 @@ namespace QuickFix
         { }
 
         public ThreadedSocketReactor(IPEndPoint serverSocketEndPoint, SocketSettings socketSettings,
-            QuickFix.Dictionary sessionDict) : this(serverSocketEndPoint, socketSettings, sessionDict, null)
+            QuickFix.Dictionary sessionDict) : this(serverSocketEndPoint, socketSettings, sessionDict, null, null)
         {
             
         }
-        internal ThreadedSocketReactor(IPEndPoint serverSocketEndPoint, SocketSettings socketSettings, QuickFix.Dictionary sessionDict, AcceptorSocketDescriptor acceptorDescriptor)
+        internal ThreadedSocketReactor(IPEndPoint serverSocketEndPoint, SocketSettings socketSettings, QuickFix.Dictionary sessionDict, AcceptorSocketDescriptor acceptorDescriptor, SessionProvider sessionProvider)
         {
             socketSettings_ = socketSettings;
             serverSocketEndPoint_ = serverSocketEndPoint;
             tcpListener_ = new TcpListener(serverSocketEndPoint_);
             sessionDict_ = sessionDict;
             acceptorDescriptor_ = acceptorDescriptor;
+            _sessionProvider = sessionProvider;
         }
 
         public void Start()
@@ -115,7 +116,7 @@ namespace QuickFix
                     {
                         ApplySocketOptions(client, socketSettings_);
                         ClientHandlerThread t =
-                            new ClientHandlerThread(client, nextClientId_++, sessionDict_, socketSettings_, acceptorDescriptor_);
+                            new ClientHandlerThread(client, nextClientId_++, sessionDict_, socketSettings_, acceptorDescriptor_, _sessionProvider);
                         t.Exited += OnClientHandlerThreadExited;
                         lock (sync_)
                         {

--- a/UnitTests/SessionSettingsTest.cs
+++ b/UnitTests/SessionSettingsTest.cs
@@ -144,6 +144,37 @@ namespace UnitTests
         }
 
         [Test]
+        public void LoadSettingsWithWildcards()
+        {
+            // May set wildcards to any field in the [DEFAULT] section
+            string configuration = new System.Text.StringBuilder()
+                .AppendLine("[DEFAULT]")
+                .AppendLine("ConnectionType=acceptor")
+                .AppendLine("BeginString=*")
+                .AppendLine("SenderCompID=*")
+                .AppendLine("TargetCompID=*")
+                .AppendLine("SessionQualifier=*")
+                .AppendLine("SomeValue=whatever")
+                .AppendLine("Empty=")
+                .ToString();
+            SessionSettings settings = new SessionSettings(new System.IO.StringReader(configuration));
+            Assert.That(settings.Get().GetString("BeginString"), Is.EqualTo("*"));
+            Assert.That(settings.Get().GetString("SenderCompID"), Is.EqualTo("*"));
+            Assert.That(settings.Get().GetString("TargetCompID"), Is.EqualTo("*"));
+            Assert.That(settings.Get().GetString("SessionQualifier"), Is.EqualTo("*"));
+            // BeginString cannot be a wildcard in any [SESSION] section
+            configuration = new System.Text.StringBuilder()
+                .AppendLine("[SESSION]")
+                .AppendLine("ConnectionType=acceptor")
+                .AppendLine("BeginString=*")
+                .AppendLine("SenderCompID=*")
+                .AppendLine("TargetCompID=*")
+                .ToString();
+            ConfigError ex = Assert.Throws<ConfigError>(delegate { _ = new SessionSettings(new System.IO.StringReader(configuration)); });
+            Assert.That(ex.Message, Is.EqualTo("Configuration failed: BeginString (*) must be FIX.4.0 to FIX.4.4 or FIXT.1.1"));
+        }
+
+        [Test]
         public void DuplicateSession()
         {
             string configuration = new System.Text.StringBuilder()

--- a/UnitTests/SessionTemplateTest.cs
+++ b/UnitTests/SessionTemplateTest.cs
@@ -1,0 +1,387 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Net;
+using System.Net.Sockets;
+using System.Text.RegularExpressions;
+
+using NUnit.Framework;
+using QuickFix;
+using QuickFix.Transport;
+
+namespace UnitTests
+{
+    [TestFixture]
+    class SessionTemplateTest
+    {
+        public class TestApplication : IApplication
+        {
+            Action<string> _logonNotify;
+            Action<string> _logoffNotify;
+            public TestApplication(Action<string> logonNotify, Action<string> logoffNotify)
+            {
+                _logonNotify = logonNotify;
+                _logoffNotify = logoffNotify;
+            }
+            public void FromAdmin(Message message, SessionID sessionID)
+            { }
+
+            public void FromApp(Message message, SessionID sessionID)
+            { }
+
+            public void OnCreate(SessionID sessionID) { }
+            public void OnLogout(SessionID sessionID)
+            {
+                _logoffNotify(sessionID.TargetCompID);
+            }
+            public void OnLogon(SessionID sessionID)
+            {
+                _logonNotify(sessionID.TargetCompID);
+            }
+
+            public void ToAdmin(Message message, SessionID sessionID) { }
+            public void ToApp(Message message, SessionID sessionID) { }
+        }
+        class SocketState
+        {
+            public SocketState(Socket s)
+            {
+                _socket = s;
+            }
+            public Socket _socket;
+            public byte[] _rxBuffer = new byte[1024];
+            public string _messageFragment = string.Empty;
+            public string _exMessage;
+        }
+
+        const string Host = "127.0.0.1";
+        const int ConnectPort = 55100;
+        const int AcceptPort = 55101;
+        const int AcceptPort2 = 55102;
+        const string ServerCompID = "dummy";
+        const string StaticInitiatorCompID = "ini01";
+        const string StaticAcceptorCompID = "acc01";
+        const string StaticAcceptorCompID2 = "acc02";
+
+        const string FIXMessageEnd = @"\x0110=\d{3}\x01";
+        const string FIXMessageDelimit = @"(8=FIX|\A).*?(" + FIXMessageEnd + @"|\z)";
+
+        string _logPath;
+        SocketInitiator _initiator;
+        ThreadedSocketAcceptor _acceptor;
+        Dictionary<string, SocketState> _sessions;
+        HashSet<string> _loggedOnCompIDs;
+        Socket _listenSocket;
+
+        Dictionary CreateAcceptorConfig()
+        {
+            Dictionary settings = new Dictionary();
+            settings.SetString(SessionSettings.CONNECTION_TYPE, "acceptor");
+            settings.SetString(SessionSettings.USE_DATA_DICTIONARY, "N");
+            settings.SetString(SessionSettings.START_TIME, "12:00:00");
+            settings.SetString(SessionSettings.END_TIME, "12:00:00");
+            settings.SetString(SessionSettings.HEARTBTINT, "300");
+            return settings;
+        }
+
+        SessionID CreateSessionID(string targetCompID)
+        {
+            return new SessionID(QuickFix.Values.BeginString_FIX42, ServerCompID, targetCompID);
+        }
+
+        void LogonCallback(string compID)
+        {
+            lock (_loggedOnCompIDs)
+            {
+                _loggedOnCompIDs.Add(compID);
+                Monitor.Pulse(_loggedOnCompIDs);
+            }
+        }
+        void LogoffCallback(string compID)
+        {
+            lock (_loggedOnCompIDs)
+            {
+                _loggedOnCompIDs.Remove(compID);
+                Monitor.Pulse(_loggedOnCompIDs);
+            }
+        }
+
+        void StartAcceptor(SessionID sessionID)
+        {
+            TestApplication application = new TestApplication(LogonCallback, LogoffCallback);
+            IMessageStoreFactory storeFactory = new MemoryStoreFactory();
+            SessionSettings settings = new SessionSettings();
+            Dictionary defaults = new Dictionary();
+            defaults.SetString(QuickFix.SessionSettings.FILE_LOG_PATH, _logPath);
+
+            // Put IP endpoint settings into default section to verify that that defaults get merged into
+            // session-specific settings not only for static sessions, but also for dynamic ones
+            defaults.SetString(SessionSettings.SOCKET_ACCEPT_HOST, Host);
+            defaults.SetString(SessionSettings.SOCKET_ACCEPT_PORT, AcceptPort.ToString());
+
+            settings.Set(defaults);
+            ILogFactory logFactory = new FileLogFactory(settings);
+
+            settings.Set(sessionID, CreateAcceptorConfig());
+
+            _acceptor = new ThreadedSocketAcceptor(application, storeFactory, settings, logFactory);
+            _acceptor.Start();
+        }
+
+        void StartListener()
+        {
+            var address = IPAddress.Parse(Host);
+            var listenEndpoint = new IPEndPoint(address, ConnectPort);
+            _listenSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            _listenSocket.Bind(listenEndpoint);
+            _listenSocket.Listen(10);
+            _listenSocket.BeginAccept(new AsyncCallback(ProcessInboundConnect), null);
+        }
+
+        void ProcessInboundConnect(IAsyncResult ar)
+        {
+            Socket handler = null;
+            try
+            {
+                handler = _listenSocket.EndAccept(ar);
+            }
+            catch
+            {
+                _listenSocket = null; // Assume listener has been closed
+            }
+
+            if (handler != null)
+            {
+                ReceiveAsync(new SocketState(handler));
+                _listenSocket.BeginAccept(new AsyncCallback(ProcessInboundConnect), null);
+            }
+        }
+
+        void ProcessRXData(IAsyncResult ar)
+        {
+            SocketState socketState = (SocketState)ar.AsyncState;
+            int bytesReceived = 0;
+            try
+            {
+                bytesReceived = socketState._socket.EndReceive(ar);
+            }
+            catch (Exception ex)
+            {
+                socketState._exMessage = ex.InnerException == null ? ex.Message : ex.InnerException.Message;
+            }
+
+            if (bytesReceived == 0)
+            {
+                socketState._socket.Close();
+                lock (socketState._socket)
+                    Monitor.Pulse(socketState._socket);
+                return;
+            }
+            string msgText = CharEncoding.DefaultEncoding.GetString(socketState._rxBuffer, 0, bytesReceived);
+            foreach (Match m in Regex.Matches(msgText, FIXMessageDelimit))
+            {
+                socketState._messageFragment += m.Value;
+                if (Regex.IsMatch(socketState._messageFragment, FIXMessageEnd))
+                {
+                    Message message = new Message(socketState._messageFragment);
+                    socketState._messageFragment = string.Empty;
+                    string targetCompID = message.Header.GetString(QuickFix.Fields.Tags.TargetCompID);
+                    if (message.Header.GetString(QuickFix.Fields.Tags.MsgType) == QuickFix.Fields.MsgType.LOGON)
+                        lock (_sessions)
+                        {
+                            _sessions[targetCompID] = socketState;
+                            Monitor.Pulse(_sessions);
+                        }
+                }
+            }
+            ReceiveAsync(socketState);
+        }
+
+        void ReceiveAsync(SocketState socketState)
+        {
+            socketState._socket.BeginReceive(socketState._rxBuffer, 0, socketState._rxBuffer.Length, SocketFlags.None, new AsyncCallback(ProcessRXData), socketState); ;
+        }
+
+        Socket ConnectToEngine()
+        {
+            return ConnectToEngine(AcceptPort);
+        }
+
+        Socket ConnectToEngine(int port)
+        {
+            var address = IPAddress.Parse(Host);
+            var endpoint = new IPEndPoint(address, port);
+            var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            try
+            {
+                socket.Connect(endpoint);
+                ReceiveAsync(new SocketState(socket));
+                return socket;
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail(string.Format("Failed to connect: {0}", ex.Message));
+                return null;
+            }
+        }
+
+        Socket GetSocket(string compID)
+        {
+            lock (_sessions)
+                return _sessions[compID]._socket;
+        }
+
+        bool WaitForLogonStatus(string targetCompID)
+        {
+            lock (_loggedOnCompIDs)
+            {
+                if (!_loggedOnCompIDs.Contains(targetCompID))
+                    Monitor.Wait(_loggedOnCompIDs, 3000);
+                return _loggedOnCompIDs.Contains(targetCompID);
+            }
+        }
+
+        bool WaitForLogonMessage(string targetCompID)
+        {
+            lock (_sessions)
+            {
+                if (!_sessions.ContainsKey(targetCompID))
+                    Monitor.Wait(_sessions, 10000);
+                return _sessions.ContainsKey(targetCompID);
+            }
+        }
+
+        bool WaitForDisconnect(Socket s)
+        {
+            lock (s)
+            {
+                if (s.Connected)
+                    Monitor.Wait(s, 10000);
+                return !s.Connected;
+            }
+        }
+
+        bool WaitForDisconnect(string compID)
+        {
+            return WaitForDisconnect(GetSocket(compID));
+        }
+
+        bool HasReceivedMessage(string compID)
+        {
+            lock (_sessions)
+                return _sessions.ContainsKey(compID);
+        }
+
+        bool IsLoggedOn(string compID)
+        {
+            lock (_loggedOnCompIDs)
+                return _loggedOnCompIDs.Contains(compID);
+        }
+
+        void SendInitiatorLogon(string senderCompID)
+        {
+            SendLogon(GetSocket(senderCompID), senderCompID);
+        }
+
+        void SendLogon(Socket s, string senderCompID)
+        {
+            SendLogon(s, senderCompID, ServerCompID);
+        }
+
+        void SendLogon(Socket s, string senderCompID, string targetCompID)
+        {
+            var msg = new QuickFix.FIX42.Logon();
+            msg.Header.SetField(new QuickFix.Fields.TargetCompID(targetCompID));
+            msg.Header.SetField(new QuickFix.Fields.SenderCompID(senderCompID));
+            msg.Header.SetField(new QuickFix.Fields.MsgSeqNum(1));
+            msg.Header.SetField(new QuickFix.Fields.SendingTime(System.DateTime.UtcNow));
+            msg.SetField(new QuickFix.Fields.HeartBtInt(300));
+            // Simple logon message
+            s.Send(CharEncoding.DefaultEncoding.GetBytes(msg.ToString()));
+        }
+
+        void ClearLogs()
+        {
+            if (System.IO.Directory.Exists(_logPath))
+                try
+                {
+                    System.IO.Directory.Delete(_logPath, true);
+                }
+                catch { }
+        }
+
+        [SetUp]
+        public void Setup()
+        {
+            _logPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "log");
+            _sessions = new Dictionary<string, SocketState>();
+            _loggedOnCompIDs = new HashSet<string>();
+            ClearLogs();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_listenSocket != null)
+                _listenSocket.Close();
+            if (_initiator != null)
+                _initiator.Stop(true);
+            if (_acceptor != null)
+                _acceptor.Stop(true);
+
+            _initiator = null;
+            _acceptor = null;
+
+            Thread.Sleep(500);
+            ClearLogs();
+        }
+
+        [Test]
+        public void DynamicAcceptor()
+        {
+            // Starting Acceptor with template for sessions
+            SessionID templateSessionID = new SessionID(QuickFix.Values.BeginString_FIX42, "DYN_SERVER", "*");
+            StartAcceptor(templateSessionID);
+
+            // Ensure we can log using the defined template
+            var socket01 = ConnectToEngine();
+            SendLogon(socket01, "ANY_CLIENT", "DYN_SERVER");
+            Assert.IsTrue(WaitForLogonStatus("ANY_CLIENT"), "Failed to logon templated acceptor session");
+
+            // Ensure we can log using the defined template with the other client CompID
+            var socket011 = ConnectToEngine();
+            SendLogon(socket011, "ANY_OTHER_CLIENT", "DYN_SERVER");
+            Assert.IsTrue(WaitForLogonStatus("ANY_OTHER_CLIENT"), "Failed to logon templated acceptor session");
+
+            // Ensure that attempt to log on as not matching the template does not work
+            var socket02 = ConnectToEngine();
+            SendLogon(socket02, "NEW_CLIENT", "NOT_CONFIGURED");
+            Assert.IsTrue(WaitForDisconnect(socket02), "Server failed to disconnect unconfigured CompID");
+            Assert.False(HasReceivedMessage("NEW_CLIENT"), "Unexpected message received for unconfigured CompID");
+
+            // Add the new session template to acceptor and ensure that we can now log on
+            SessionID secondTemplateSessionID = new SessionID(QuickFix.Values.BeginString_FIX42, "DYN_2ND_SERVER", "*");
+            var sessionConfig = CreateAcceptorConfig();
+            Assert.IsTrue(_acceptor.AddSession(secondTemplateSessionID, sessionConfig), "Failed to add dynamic session template to acceptor");
+            var socket03 = ConnectToEngine();
+            SendLogon(socket03, "NEW_CLIENT", "DYN_2ND_SERVER");
+            Assert.IsTrue(WaitForLogonStatus("NEW_CLIENT"), "Failed to logon dynamically added acceptor template session");
+            SessionID dynamicDessionID = new SessionID(Values.BeginString_FIX42, "DYN_2ND_SERVER", "NEW_CLIENT");
+
+            // Ensure that we can't add the same session again
+            Assert.IsFalse(_acceptor.AddSession(secondTemplateSessionID, sessionConfig), "Added dynamic session template twice");
+
+            // Template session can be deleted even after logon, as the new (non-template) sessions are created for those
+            Assert.IsTrue(_acceptor.RemoveSession(secondTemplateSessionID, false), "Failed to remove active session template");
+            // Now that dynamic acceptor is logged on, ensure that unforced attempt to remove session fails
+            Assert.IsFalse(_acceptor.RemoveSession(dynamicDessionID, false), "Unexpected success removing active session");
+            Assert.IsTrue(socket03.Connected, "Unexpected loss of connection");
+
+            // Ensure that forced attempt to remove session dynamic session succeeds, even though it is in logged on state
+            Assert.IsTrue(_acceptor.RemoveSession(dynamicDessionID, true), "Failed to remove active session");
+            Assert.IsTrue(WaitForDisconnect(socket03), "Socket still connected after session removed");
+            Assert.IsFalse(IsLoggedOn("NEW_CLIENT"), "Session still logged on after being removed");
+        }    
+    }
+}

--- a/UnitTests/ThreadedSocketAcceptorTests.cs
+++ b/UnitTests/ThreadedSocketAcceptorTests.cs
@@ -28,14 +28,14 @@ TargetCompID = target
 BeginString = FIX.4.4
 ";
 
-        private static SessionSettings CreateSettings()
+        private static SessionSettings CreateSettings(string config)
         {
-            return new SessionSettings(new StringReader(Config));
+            return new SessionSettings(new StringReader(config));
         }
 
-        private static ThreadedSocketAcceptor CreateAcceptor()
+        private static ThreadedSocketAcceptor CreateAcceptor(string config)
         {
-            var settings = CreateSettings();
+            var settings = CreateSettings(config);
             return new ThreadedSocketAcceptor(
                 new NullApplication(),
                 new FileStoreFactory(settings),
@@ -46,16 +46,41 @@ BeginString = FIX.4.4
         [Test]
         public void TestRecreation()
         {
-            StartStopAcceptor();
-            StartStopAcceptor();
-            StartStopAcceptor();
+            StartStopAcceptor(Config);
+            StartStopAcceptor(Config);
+            StartStopAcceptor(Config);
         }
 
-        private static void StartStopAcceptor()
+        private static void StartStopAcceptor(string config)
         {
-            var acceptor = CreateAcceptor();
+            var acceptor = CreateAcceptor(config);
             acceptor.Start();
             acceptor.Dispose();
         }
+
+        private static string ConfigWildcards = $@"
+[DEFAULT]
+StartTime = 00:00:00
+EndTime = 23:59:59
+ConnectionType = acceptor
+SocketAcceptHost = 127.0.0.1
+SocketAcceptPort = 10000
+FileStorePath = {TestContext.CurrentContext.TestDirectory}\store
+FileLogPath = {TestContext.CurrentContext.TestDirectory}\log
+UseDataDictionary = N
+
+[SESSION]
+SenderCompID = *
+TargetCompID = *
+BeginString = FIX.4.4
+";
+        [Test]
+        public void TestRecreationWildcards()
+        {
+            StartStopAcceptor(ConfigWildcards);
+            StartStopAcceptor(ConfigWildcards);
+            StartStopAcceptor(ConfigWildcards);
+        }
+
     }
 }


### PR DESCRIPTION
This PR enables `"*"` wildcards in Acceptor's session configuration (for `SenderCompID`, `SenderSubID`, `SenderLocationID`, `TargetCompID`, `TargetSubID`, and `TargetLocationID`).
Such session templates can be defined either at start-up or as an ad-hoc operation, just like "normal" sessions.
When processing a new incoming connection, if the incoming `SessionID` is not equal to any of the created sessions, it is then matched vs. templates with wildcards. Upon the first match, the new `Session` is created with the same settings as the template ones, just changing wildcards to the actual values from the incoming `SessionID`.

This PR is an alternative for #607 to address architectural concerns.
Here, instead of changing the `Session` class, I added the new `SessionProvider` class, implementing in it most of the logic for creating `Session`s on-the-fly. Change in `SocketReader` is to call `SessionProvider.GetSession` instead of `Session.LookupSession`.
In `ThreadedSocketAcceptor`, the main change is in `CreateSession`, to check for wildcards in session settings and do not create such a `Session` immediately, but record it as a template while still creating `AcceptorSocketDescriptor` for it. I separated the block of code to do the actual session creation into internal `CreateAcceptorSession`, so `SessionProvider` can call it when it needs to create a new `Session` on-the-fly. Placing `SetSessionSettings` also into `ThreadedSocketAcceptor` maybe not the best option; still, it seems to fit OK there to change settings for the entire Acceptor.
I tried replacing **`static`** `Session.LookupSession` with also **`static`** `SessionProvider.GetSession`, but that seems to be logically incorrect, as `ThreadedSocketAcceptor` is not `static`, so theoretically, several of its instances may be created, and then they all will share the same `SessionTemplate`, which does not look correct. So `ThreadedSocketAcceptor` has to create a `SessionProvider` object, and pass it through `AcceptorSocketDescriptor` -> `ThreadedSocketReactor` -> `ClientHandlerThread` to `SocketReader`, causing minor changes in all those classes. If you think those changes are not necessary, and there can be only one `ThreadedSocketAcceptor`, then `SessionProvider` can be made **`static`**. In this case, `ThreadedSocketAcceptor` will need to clean up the `SessionProvider` on its `Stop` (as static `SessionProvider` will keep templates between acceptor stop/start, causing duplication of the templates).

Your remarks would be highly appreciated!