### PR TITLE
Update DefaultMessageFactory.cs

### DIFF
--- a/QuickFIXn/DefaultMessageFactory.cs
+++ b/QuickFIXn/DefaultMessageFactory.cs
@@ -154,7 +154,7 @@ namespace QuickFix
                     return;
                 }
 
-                var dlls = Directory.GetFiles(directory, "quickfix.*.dll");
+                var dlls = Directory.GetFiles(directory, "QuickFix.*.dll");
                 foreach (var path in dlls)
                 {
                     Assembly.LoadFrom(path);


### PR DESCRIPTION
Loading of local dlls does not work on Linux because of case sensitivity. After migrate to netstandard2.1 will be better to fix it with

                var dlls = Directory.GetFiles(directory, "quickfix.*.dll",
                    new EnumerationOptions() {MatchCasing = MatchCasing.CaseInsensitive});
