### PR TITLE
fix loading issues of quickfix files in linux

### DIFF
--- a/QuickFIXn/DefaultMessageFactory.cs
+++ b/QuickFIXn/DefaultMessageFactory.cs
@@ -153,11 +153,14 @@ namespace QuickFix
                 {
                     return;
                 }
-
-                var dlls = Directory.GetFiles(directory, "quickfix.*.dll");
+                var quickFixRootLib = Path.GetFileName(assemblyLocation);
+                var dlls = Directory.GetFiles(directory, "*.dll");
                 foreach (var path in dlls)
                 {
-                    Assembly.LoadFrom(path);
+                    var pi = new FileInfo(path);
+                    //in linux casing is important, or we compare insensitive
+                    if(pi.Name.StartsWith("quickfix.", StringComparison.OrdinalIgnoreCase) && !pi.Name.Equals(quickFixRootLib))
+                        Assembly.LoadFrom(path);
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
We run into a loading issue of the FIX acceptor on linux. After investigations, figured out, that the `DefaultMessageFactory` ist loading libs with assembly load command, unfortunately the string for the libs is lower-cased but all assemblies are generated with name like "QuickFix.*.dll". 
To reflect a case-insesitive loading we change the `LoadLocalDlls` method.