### PR TITLE
Add config override for CheckHasRequired

### DIFF
--- a/QuickFIXn/DataDictionary/DataDictionary.cs
+++ b/QuickFIXn/DataDictionary/DataDictionary.cs
@@ -24,7 +24,7 @@ namespace QuickFix.DataDictionary
         public bool CheckFieldsHaveValues { get; set; }
         public bool CheckUserDefinedFields { get; set; }
         public bool AllowUnknownMessageFields { get; set; }
-        public bool EnforceRequiredFields { get; set; }
+        public bool ValidateRequiredFields { get; set; }
 
         public DDMap Header = new DDMap();
         public DDMap Trailer = new DDMap();
@@ -35,7 +35,7 @@ namespace QuickFix.DataDictionary
             CheckFieldsOutOfOrder = true;
             CheckUserDefinedFields = true;
             AllowUnknownMessageFields = false;
-            EnforceRequiredFields = true;
+            ValidateRequiredFields = true;
         }
 
         /// <summary>
@@ -99,10 +99,7 @@ namespace QuickFix.DataDictionary
             if ((null != appDataDict) && (null != appDataDict.Version))
             {
                 appDataDict.CheckMsgType(msgType);
-                if (appDataDict.EnforceRequiredFields)
-                {
-                    appDataDict.CheckHasRequired(message, msgType);
-                }
+                appDataDict.CheckHasRequired(message, msgType);
             }
 
             if (!bodyOnly)
@@ -157,7 +154,12 @@ namespace QuickFix.DataDictionary
 
         public void CheckHasRequired(Message message, string msgType)
         {
-            foreach (int field in Header.ReqFields)
+            if (!ValidateRequiredFields)
+            {
+                return;
+            }
+
+                foreach (int field in Header.ReqFields)
             {
                 if (!message.Header.IsSetField(field))
                     throw new RequiredTagMissing(field);

--- a/QuickFIXn/DataDictionary/DataDictionary.cs
+++ b/QuickFIXn/DataDictionary/DataDictionary.cs
@@ -24,6 +24,7 @@ namespace QuickFix.DataDictionary
         public bool CheckFieldsHaveValues { get; set; }
         public bool CheckUserDefinedFields { get; set; }
         public bool AllowUnknownMessageFields { get; set; }
+        public bool EnforceRequiredFields { get; set; }
 
         public DDMap Header = new DDMap();
         public DDMap Trailer = new DDMap();
@@ -34,6 +35,7 @@ namespace QuickFix.DataDictionary
             CheckFieldsOutOfOrder = true;
             CheckUserDefinedFields = true;
             AllowUnknownMessageFields = false;
+            EnforceRequiredFields = true;
         }
 
         /// <summary>
@@ -97,7 +99,10 @@ namespace QuickFix.DataDictionary
             if ((null != appDataDict) && (null != appDataDict.Version))
             {
                 appDataDict.CheckMsgType(msgType);
-                appDataDict.CheckHasRequired(message, msgType);
+                if (appDataDict.EnforceRequiredFields)
+                {
+                    appDataDict.CheckHasRequired(message, msgType);
+                }
             }
 
             if (!bodyOnly)

--- a/QuickFIXn/SessionFactory.cs
+++ b/QuickFIXn/SessionFactory.cs
@@ -182,6 +182,8 @@ namespace QuickFix
                 ddCopy.CheckUserDefinedFields = settings.GetBool(SessionSettings.VALIDATE_USER_DEFINED_FIELDS);
             if (settings.Has(SessionSettings.ALLOW_UNKNOWN_MSG_FIELDS))
                 ddCopy.AllowUnknownMessageFields = settings.GetBool(SessionSettings.ALLOW_UNKNOWN_MSG_FIELDS);
+            if (settings.Has(SessionSettings.ENFORCE_REQUIRED_FILEDS))
+                ddCopy.EnforceRequiredFields = settings.GetBool(SessionSettings.ENFORCE_REQUIRED_FILEDS);
 
             return ddCopy;
         }

--- a/QuickFIXn/SessionFactory.cs
+++ b/QuickFIXn/SessionFactory.cs
@@ -182,8 +182,8 @@ namespace QuickFix
                 ddCopy.CheckUserDefinedFields = settings.GetBool(SessionSettings.VALIDATE_USER_DEFINED_FIELDS);
             if (settings.Has(SessionSettings.ALLOW_UNKNOWN_MSG_FIELDS))
                 ddCopy.AllowUnknownMessageFields = settings.GetBool(SessionSettings.ALLOW_UNKNOWN_MSG_FIELDS);
-            if (settings.Has(SessionSettings.ENFORCE_REQUIRED_FILEDS))
-                ddCopy.EnforceRequiredFields = settings.GetBool(SessionSettings.ENFORCE_REQUIRED_FILEDS);
+            if (settings.Has(SessionSettings.VALIDATE_REQUIRED_FIELDS))
+                ddCopy.ValidateRequiredFields = settings.GetBool(SessionSettings.VALIDATE_REQUIRED_FIELDS);
 
             return ddCopy;
         }

--- a/QuickFIXn/SessionSettings.cs
+++ b/QuickFIXn/SessionSettings.cs
@@ -69,7 +69,7 @@ namespace QuickFix
         public const string RESETSEQUENCE_MESSAGE_REQUIRES_ORIGSENDINGTIME = "RequiresOrigSendingTime";
         public const string CHECK_LATENCY = "CheckLatency";
         public const string MAX_LATENCY = "MaxLatency";
-        public const string ENFORCE_REQUIRED_FILEDS = "EnforceRequiredFields";
+        public const string VALIDATE_REQUIRED_FIELDS = "ValidateRequiredFields";
 
         public const string SSL_ENABLE = "SSLEnable";
         public const string SSL_SERVERNAME = "SSLServerName";

--- a/QuickFIXn/SessionSettings.cs
+++ b/QuickFIXn/SessionSettings.cs
@@ -69,6 +69,7 @@ namespace QuickFix
         public const string RESETSEQUENCE_MESSAGE_REQUIRES_ORIGSENDINGTIME = "RequiresOrigSendingTime";
         public const string CHECK_LATENCY = "CheckLatency";
         public const string MAX_LATENCY = "MaxLatency";
+        public const string ENFORCE_REQUIRED_FILEDS = "EnforceRequiredFields";
 
         public const string SSL_ENABLE = "SSLEnable";
         public const string SSL_SERVERNAME = "SSLServerName";

--- a/UnitTests/DataDictionaryTests.cs
+++ b/UnitTests/DataDictionaryTests.cs
@@ -596,6 +596,30 @@ namespace UnitTests
         }
 
         [Test]
+        public void NotThrowRequiredTagMissingIfEnforceRequiredFieldsIsSet()
+        {
+            QuickFix.DataDictionary.DataDictionary dd = new QuickFix.DataDictionary.DataDictionary();
+            dd.LoadFIXSpec("FIX44");
+            dd.EnforceRequiredFields = false;
+            QuickFix.FIX44.MessageFactory f = new QuickFix.FIX44.MessageFactory();
+
+            string[] msgFields = { "8=FIX.4.4", "9=76", "35=7", "34=3", "49=sender", "52=20110909-09:09:09.999", "56=target",
+                                     "2=AdvId", "5=N", "4=B", "53=1", "10=138" };
+            string msgStr = String.Join(Message.SOH, msgFields) + Message.SOH;
+
+            string msgType = "7";
+            string beginString = "FIX.4.4";
+
+            Message message = f.Create(beginString, msgType);
+            message.FromString(msgStr, true, dd, dd, f);
+
+            dd.Validate(message, beginString, msgType);
+
+            // If we got this far we passed.
+            Assert.True(true);
+        }
+
+        [Test]
         public void ComponentFieldsRequirements()
         {
             QuickFix.DataDictionary.DataDictionary dd = new QuickFix.DataDictionary.DataDictionary();

--- a/UnitTests/DataDictionaryTests.cs
+++ b/UnitTests/DataDictionaryTests.cs
@@ -596,7 +596,7 @@ namespace UnitTests
         }
 
         [Test]
-        public void NotThrowRequiredTagMissingIfEnforceRequiredFieldsIsSet()
+        public void NotThrowRequiredTagMissingIfEnforceRequiredFieldsIsFalse()
         {
             QuickFix.DataDictionary.DataDictionary dd = new QuickFix.DataDictionary.DataDictionary();
             dd.LoadFIXSpec("FIX44");

--- a/UnitTests/DataDictionaryTests.cs
+++ b/UnitTests/DataDictionaryTests.cs
@@ -596,11 +596,11 @@ namespace UnitTests
         }
 
         [Test]
-        public void NotThrowRequiredTagMissingIfEnforceRequiredFieldsIsFalse()
+        public void NotThrowRequiredTagMissingIfValidateRequiredFieldsIsFalse()
         {
             QuickFix.DataDictionary.DataDictionary dd = new QuickFix.DataDictionary.DataDictionary();
             dd.LoadFIXSpec("FIX44");
-            dd.EnforceRequiredFields = false;
+            dd.ValidateRequiredFields = false;
             QuickFix.FIX44.MessageFactory f = new QuickFix.FIX44.MessageFactory();
 
             string[] msgFields = { "8=FIX.4.4", "9=76", "35=7", "34=3", "49=sender", "52=20110909-09:09:09.999", "56=target",


### PR DESCRIPTION
The scenario occurs when a field marked as required is missing from the message, we don't want QuickFix to reject the message, that will may handled by a downstream consumer.  