### PR TITLE
Directory.GetFiles on Linux is Case Sensitive

### DIFF
--- a/QuickFIXn/DefaultMessageFactory.cs
+++ b/QuickFIXn/DefaultMessageFactory.cs
@@ -154,7 +154,7 @@ namespace QuickFix
                     return;
                 }
 
-                var dlls = Directory.GetFiles(directory, "quickfix.*.dll");
+                var dlls = Directory.GetFiles(directory, "QuickFix.*.dll");
                 foreach (var path in dlls)
                 {
                     Assembly.LoadFrom(path);


### PR DESCRIPTION
In linux it was not possible to find the dll.