### PR TITLE
Disable ClientHandlerThread debug logs

### DIFF
--- a/QuickFIXn/SessionSettings.cs
+++ b/QuickFIXn/SessionSettings.cs
@@ -37,6 +37,7 @@ namespace QuickFix
         public const string RECONNECT_INTERVAL = "ReconnectInterval";
         public const string FILE_LOG_PATH = "FileLogPath";
         public const string DEBUG_FILE_LOG_PATH = "DebugFileLogPath";
+        public const string DISABLE_CLIENT_HANDLER_THREAD_LOGS = "DisableClientHandlerThreadLogs";
         public const string FILE_STORE_PATH = "FileStorePath";
         public const string REFRESH_ON_LOGON = "RefreshOnLogon";
         public const string RESET_ON_LOGON = "ResetOnLogon";


### PR DESCRIPTION
Adds a config flag that disables the creation of ClientHandlerThread debug logs by using a null logger if enabled.

Fixes: #684 