### PR TITLE
[Proposal] netstandard2.0 libraries to netstandard2.1 and executables net461 to netcoreapp3.1 

### DIFF
--- a/AcceptanceTest/AcceptanceTest.csproj
+++ b/AcceptanceTest/AcceptanceTest.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <Platforms>AnyCPU;x64</Platforms>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/AcceptanceTest/runat.ps1
+++ b/AcceptanceTest/runat.ps1
@@ -15,7 +15,7 @@ Param(
     [string] $Conf,
 
     [Parameter(Mandatory, Position=4)]
-    [ValidateSet('net461','netcoreapp2.1')]
+    [ValidateSet('netcoreapp3.1')]
     [string] $Framework,
 
     [switch]$UseWsl

--- a/Examples/Executor/Examples.Executor.csproj
+++ b/Examples/Executor/Examples.Executor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <RootNamespace>Executor</RootNamespace>
     <AssemblyName>Executor</AssemblyName>
     <Copyright>Copyright © Connamara Systems, LLC 2011</Copyright>

--- a/Examples/SimpleAcceptor/Examples.SimpleAcceptor.csproj
+++ b/Examples/SimpleAcceptor/Examples.SimpleAcceptor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <RootNamespace>SimpleAcceptor</RootNamespace>
     <AssemblyName>SimpleAcceptor</AssemblyName>
     <Copyright>Copyright © Connamara Systems, LLC 2011</Copyright>

--- a/Examples/TradeClient/Examples.TradeClient.csproj
+++ b/Examples/TradeClient/Examples.TradeClient.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <RootNamespace>TradeClient</RootNamespace>
     <AssemblyName>TradeClient</AssemblyName>
     <Copyright>Copyright © Connamara Systems, LLC 2011</Copyright>

--- a/Messages/FIX40/QuickFix.FIX40.csproj
+++ b/Messages/FIX40/QuickFix.FIX40.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1</TargetFrameworks>
     <GenerateAppxPackageOnBuild>true</GenerateAppxPackageOnBuild>
     <Title>QuickFIX/n FIX4.0 Messages</Title>
     <PackageId>QuickFIXn.FIX4.0</PackageId>

--- a/Messages/FIX41/QuickFix.FIX41.csproj
+++ b/Messages/FIX41/QuickFix.FIX41.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1</TargetFrameworks>
     <GenerateAppxPackageOnBuild>true</GenerateAppxPackageOnBuild>
     <Title>QuickFIX/n FIX4.1 Messages</Title>
     <PackageId>QuickFIXn.FIX4.1</PackageId>

--- a/Messages/FIX42/QuickFix.FIX42.csproj
+++ b/Messages/FIX42/QuickFix.FIX42.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1</TargetFrameworks>
     <GenerateAppxPackageOnBuild>true</GenerateAppxPackageOnBuild>
     <Title>QuickFIX/n FIX4.2 Messages</Title>
     <PackageId>QuickFIXn.FIX4.2</PackageId>

--- a/Messages/FIX43/QuickFix.FIX43.csproj
+++ b/Messages/FIX43/QuickFix.FIX43.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1</TargetFrameworks>
     <GenerateAppxPackageOnBuild>true</GenerateAppxPackageOnBuild>
     <Title>QuickFIX/n FIX4.3 Messages</Title>
     <PackageId>QuickFIXn.FIX4.3</PackageId>

--- a/Messages/FIX44/QuickFix.FIX44.csproj
+++ b/Messages/FIX44/QuickFix.FIX44.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1</TargetFrameworks>
     <GenerateAppxPackageOnBuild>true</GenerateAppxPackageOnBuild>
     <Title>QuickFIX/n FIX4.4 Messages</Title>
     <PackageId>QuickFIXn.FIX4.4</PackageId>

--- a/Messages/FIX50/QuickFix.FIX50.csproj
+++ b/Messages/FIX50/QuickFix.FIX50.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1</TargetFrameworks>
     <GenerateAppxPackageOnBuild>true</GenerateAppxPackageOnBuild>
     <Title>QuickFIX/n FIX5.0 Messages</Title>
     <PackageId>QuickFIXn.FIX5.0</PackageId>

--- a/Messages/FIX50SP1/QuickFix.FIX50SP1.csproj
+++ b/Messages/FIX50SP1/QuickFix.FIX50SP1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1</TargetFrameworks>
     <GenerateAppxPackageOnBuild>true</GenerateAppxPackageOnBuild>
     <Title>QuickFIX/n FIX5.0 SP1 Messages</Title>
     <PackageId>QuickFIXn.FIX5.0SP1</PackageId>

--- a/Messages/FIX50SP2/QuickFix.FIX50SP2.csproj
+++ b/Messages/FIX50SP2/QuickFix.FIX50SP2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1</TargetFrameworks>
     <GenerateAppxPackageOnBuild>true</GenerateAppxPackageOnBuild>
     <Title>QuickFIX/n FIX5.0 SP2 Messages</Title>
     <PackageId>QuickFIXn.FIX5.0SP2</PackageId>

--- a/New-Release.ps1
+++ b/New-Release.ps1
@@ -106,25 +106,25 @@ if ($ExitCode -eq 0) {
 @(
 	$QFDir
 	"$QFDir\bin"
-	"$QFDir\bin\netstandard2.0"
+	"$QFDir\bin\netstandard2.1"
 	"$QFDir\spec"
 	"$QFDir\spec\fix"
 	"$QFDir\config"
 ) | ForEach-Object { New-Item -ItemType Directory $_ }
 
 @(
-	'QuickFIXn\bin\Release\netstandard2.0\QuickFix.dll',
-	'Messages\FIX40\bin\Release\netstandard2.0\QuickFix.FIX40.dll',
-	'Messages\FIX41\bin\Release\netstandard2.0\QuickFix.FIX41.dll',
-	'Messages\FIX42\bin\Release\netstandard2.0\QuickFix.FIX42.dll',
-	'Messages\FIX43\bin\Release\netstandard2.0\QuickFix.FIX43.dll',
-	'Messages\FIX44\bin\Release\netstandard2.0\QuickFix.FIX44.dll',
-	'Messages\FIX50\bin\Release\netstandard2.0\QuickFix.FIX50.dll',
-	'Messages\FIX50SP1\bin\Release\netstandard2.0\QuickFix.FIX50SP1.dll',
-	'Messages\FIX50SP2\bin\Release\netstandard2.0\QuickFix.FIX50SP2.dll'
+	'QuickFIXn\bin\Release\netstandard2.1\QuickFix.dll',
+	'Messages\FIX40\bin\Release\netstandard2.1\QuickFix.FIX40.dll',
+	'Messages\FIX41\bin\Release\netstandard2.1\QuickFix.FIX41.dll',
+	'Messages\FIX42\bin\Release\netstandard2.1\QuickFix.FIX42.dll',
+	'Messages\FIX43\bin\Release\netstandard2.1\QuickFix.FIX43.dll',
+	'Messages\FIX44\bin\Release\netstandard2.1\QuickFix.FIX44.dll',
+	'Messages\FIX50\bin\Release\netstandard2.1\QuickFix.FIX50.dll',
+	'Messages\FIX50SP1\bin\Release\netstandard2.1\QuickFix.FIX50SP1.dll',
+	'Messages\FIX50SP2\bin\Release\netstandard2.1\QuickFix.FIX50SP2.dll'
 ) | ForEach-Object {
 	$Filename = Split-Path $_ -Leaf
-	Copy-Item -Path $_ -Destination "tmp\$QFDir\bin\netstandard2.0\$Filename"
+	Copy-Item -Path $_ -Destination "tmp\$QFDir\bin\netstandard2.1\$Filename"
 }
 
 Copy-Item -Path 'spec\fix' -Destination "tmp\$QFDir\spec\fix" -Recurse -Force

--- a/QuickFIXn/QuickFix.csproj
+++ b/QuickFIXn/QuickFix.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1</TargetFrameworks>
     <Title>QuickFIX/n</Title>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GenerateAppxPackageOnBuild>true</GenerateAppxPackageOnBuild>

--- a/README.md
+++ b/README.md
@@ -90,10 +90,10 @@ To run one particular acceptance test, e.g. fix42\14e_IncorrectEnumValue.def:
 
 ```
 cd AcceptanceTest
-pwsh runat.ps1 release 5003 definitions\server\fix42\14e_IncorrectEnumValue.def cfg\at_42.cfg netcoreapp2.1
+pwsh runat.ps1 release 5003 definitions\server\fix42\14e_IncorrectEnumValue.def cfg\at_42.cfg netcoreapp3.1
 ```
 
-The final param must be "net461" or "netcoreapp2.1".
+The final param must be "3.1".
 
 (See acceptance_test.ps1 for the proper port numbers and config files to use in the above command.)
 

--- a/RELEASE_README.md
+++ b/RELEASE_README.md
@@ -19,7 +19,7 @@ File and Directory Information
 
 Getting Started
 ---------------
-The directory bin/netstandard2.0 contains
+The directory bin/netstandard2.1 contains
 * the QF/n core, QuickFix.dll
 * a message-definition dll for each FIX version (e.g. QuickFix.FIX40.dll, QuickFix.FIX41.dll, ...)
 

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Platforms>AnyCPU;x64</Platforms>
     <IsPackable>false</IsPackable>

--- a/acceptance_test.ps1
+++ b/acceptance_test.ps1
@@ -53,7 +53,7 @@ function RunSuite
         [string]$Configuration,
 
         [Parameter(Mandatory, Position=1, ValueFromPipeline)]
-        [ValidateSet('net461','netcoreapp2.1')]
+        [ValidateSet('netcoreapp3.1')]
         [string[]]$Framework,
 
         [switch]$UseWsl
@@ -100,7 +100,7 @@ try {
 
     Remove-Item AcceptanceTests_*.xml
 
-    'net461', 'netcoreapp2.1' | RunSuite -Configuration $Configuration -UseWsl:$($UseWsl -and $UseWsl.IsPresent)
+    'netcoreapp3.1' | RunSuite -Configuration $Configuration -UseWsl:$($UseWsl -and $UseWsl.IsPresent)
 } finally {
     Pop-Location -StackName AcceptanceTest
 

--- a/package_release.bat
+++ b/package_release.bat
@@ -74,20 +74,20 @@ IF EXIST tmp rmdir /s /q tmp
 mkdir tmp
 mkdir tmp\%QF_DIR%
 mkdir tmp\%QF_DIR%\bin
-mkdir tmp\%QF_DIR%\bin\netstandard2.0
+mkdir tmp\%QF_DIR%\bin\netstandard2.1
 mkdir tmp\%QF_DIR%\spec
 mkdir tmp\%QF_DIR%\spec\fix
 mkdir tmp\%QF_DIR%\config
-copy QuickFIXn\bin\Release\netstandard2.0\QuickFix.dll tmp\%QF_DIR%\bin\netstandard2.0\QuickFix.dll
+copy QuickFIXn\bin\Release\netstandard2.1\QuickFix.dll tmp\%QF_DIR%\bin\netstandard2.1\QuickFix.dll
 
-copy Messages\FIX40\bin\Release\netstandard2.0\QuickFix.FIX40.dll tmp\%QF_DIR%\bin\netstandard2.0\QuickFix.FIX40.dll
-copy Messages\FIX41\bin\Release\netstandard2.0\QuickFix.FIX41.dll tmp\%QF_DIR%\bin\netstandard2.0\QuickFix.FIX41.dll
-copy Messages\FIX42\bin\Release\netstandard2.0\QuickFix.FIX42.dll tmp\%QF_DIR%\bin\netstandard2.0\QuickFix.FIX42.dll
-copy Messages\FIX43\bin\Release\netstandard2.0\QuickFix.FIX43.dll tmp\%QF_DIR%\bin\netstandard2.0\QuickFix.FIX43.dll
-copy Messages\FIX44\bin\Release\netstandard2.0\QuickFix.FIX44.dll tmp\%QF_DIR%\bin\netstandard2.0\QuickFix.FIX44.dll
-copy Messages\FIX50\bin\Release\netstandard2.0\QuickFix.FIX50.dll tmp\%QF_DIR%\bin\netstandard2.0\QuickFix.FIX50.dll
-copy Messages\FIX50SP1\bin\Release\netstandard2.0\QuickFix.FIX50SP1.dll tmp\%QF_DIR%\bin\netstandard2.0\QuickFix.FIX50SP1.dll
-copy Messages\FIX50SP2\bin\Release\netstandard2.0\QuickFix.FIX50SP2.dll tmp\%QF_DIR%\bin\netstandard2.0\QuickFix.FIX50SP2.dll
+copy Messages\FIX40\bin\Release\netstandard2.1\QuickFix.FIX40.dll tmp\%QF_DIR%\bin\netstandard2.1\QuickFix.FIX40.dll
+copy Messages\FIX41\bin\Release\netstandard2.1\QuickFix.FIX41.dll tmp\%QF_DIR%\bin\netstandard2.1\QuickFix.FIX41.dll
+copy Messages\FIX42\bin\Release\netstandard2.1\QuickFix.FIX42.dll tmp\%QF_DIR%\bin\netstandard2.1\QuickFix.FIX42.dll
+copy Messages\FIX43\bin\Release\netstandard2.1\QuickFix.FIX43.dll tmp\%QF_DIR%\bin\netstandard2.1\QuickFix.FIX43.dll
+copy Messages\FIX44\bin\Release\netstandard2.1\QuickFix.FIX44.dll tmp\%QF_DIR%\bin\netstandard2.1\QuickFix.FIX44.dll
+copy Messages\FIX50\bin\Release\netstandard2.1\QuickFix.FIX50.dll tmp\%QF_DIR%\bin\netstandard2.1\QuickFix.FIX50.dll
+copy Messages\FIX50SP1\bin\Release\netstandard2.1\QuickFix.FIX50SP1.dll tmp\%QF_DIR%\bin\netstandard2.1\QuickFix.FIX50SP1.dll
+copy Messages\FIX50SP2\bin\Release\netstandard2.1\QuickFix.FIX50SP2.dll tmp\%QF_DIR%\bin\netstandard2.1\QuickFix.FIX50SP2.dll
 
 xcopy spec\fix tmp\%QF_DIR%\spec\fix /e /y
 copy config\sample_acceptor.cfg tmp\%QF_DIR%\config\


### PR DESCRIPTION
### Good points

- More features like Span<T> and methods to handle this type of buffer see more [here](https://devblogs.microsoft.com/dotnet/announcing-net-standard-2-1/)
- New language features
   - IAsyncEnumerable<T>
   - Index and Range expressions
   - Default interface methods
- Increase compatibility with more APIs

### Bad points

- No NET Framework compatibility [life cycle .NET Framework info](https://docs.microsoft.com/en-us/lifecycle/products/microsoft-net-framework) NET Core 3.0+ only is available see more [here](https://dotnet.microsoft.com/platform/dotnet-standard#versions)

### Reason of this modifications

- Start pushing unification of frameworks to NET6.0 as this LTS is already out and NET Core 3.1 end support is on December 3, 2022
- NET Framework 4.6.2+ doesn´t have an end support detailed yet. 4.6.1 will end on Apr 26, 2022
    - Depending of the general usage of NET Framework I think that it would be better to start giving an advice of this update to let it know companies and individual developers adjust to this changes.

### Unit tests
[QuickFixnUnitTests_2021-12-05_16_59_58.txt](https://github.com/connamara/quickfixn/files/7656417/QuickFixnUnitTests_2021-12-05_16_59_58.txt)

### Acceptance 
[AcceptanceTestQuickfixnResult.log](https://github.com/connamara/quickfixn/files/7656419/AcceptanceTestQuickfixnResult.log)


