### PR TITLE
#1 refactor of load messages using yield return (no collection)

### DIFF
--- a/QuickFIXn/FileStore.cs
+++ b/QuickFIXn/FileStore.cs
@@ -198,6 +198,27 @@ namespace QuickFix
         }
         
         /// <summary>
+        /// Return messages within the range of sequence numbers
+        /// </summary>
+        /// <param name="startSeqNum"></param>
+        /// <param name="endSeqNum"></param>
+        /// <returns></returns>
+        public IEnumerable<string> GetEnumerable(int startSeqNum, int endSeqNum)
+        {
+            for (int i = startSeqNum; i <= endSeqNum; i++)
+            {
+                if (offsets_.ContainsKey(i))
+                {
+                    msgFile_.Seek(offsets_[i].index, System.IO.SeekOrigin.Begin);
+                    byte[] msgBytes = new byte[offsets_[i].size];
+                    msgFile_.Read(msgBytes, 0, msgBytes.Length);
+
+                    yield return CharEncoding.DefaultEncoding.GetString(msgBytes);
+                }
+            }
+        }
+
+        /// <summary>
         /// Store a message
         /// </summary>
         /// <param name="msgSeqNum"></param>

--- a/QuickFIXn/IMessageStore.cs
+++ b/QuickFIXn/IMessageStore.cs
@@ -26,6 +26,14 @@ namespace QuickFix
         void Get(int startSeqNum, int endSeqNum, List<string> messages);
 
         /// <summary>
+        /// Return messages within the range of sequence numbers
+        /// </summary>
+        /// <param name="startSeqNum"></param>
+        /// <param name="endSeqNum"></param>
+        /// <returns></returns>
+        IEnumerable<string> GetEnumerable(int startSeqNum, int endSeqNum);
+
+        /// <summary>
         /// Adds a raw fix message to the store with the give sequence number
         /// </summary>
         /// <param name="msgSeqNum">the sequence number</param>

--- a/QuickFIXn/Session.cs
+++ b/QuickFIXn/Session.cs
@@ -814,11 +814,12 @@ namespace QuickFix
                         return;
                     }
 
-                    List<string> messages = new List<string>();
-                    state_.Get(begSeqNo, endSeqNo, messages);
+                    //List<string> messages = new List<string>();
+                    //state_.Get(begSeqNo, endSeqNo, messages);
                     int current = begSeqNo;
                     int begin = 0;
-                    foreach (string msgStr in messages)
+                    //foreach (string msgStr in messages)
+                    foreach(string msgStr in state_.GetEnumerable(begSeqNo, endSeqNo))
                     {
                         Message msg = new Message();
                         msg.FromString(msgStr, true, this.SessionDataDictionary, this.ApplicationDataDictionary, msgFactory_);

--- a/QuickFIXn/SessionState.cs
+++ b/QuickFIXn/SessionState.cs
@@ -290,6 +290,11 @@ namespace QuickFix
             }
         }
 
+        public void GetEnumerable(int begSeqNo, int endSeqNo)
+        {
+            return MessageStore.GetEnumerable(begSeqNo, endSeqNo);
+        }
+
         public void SetResendRange(int begin, int end)
         {
             SetResendRange(begin, end, -1);


### PR DESCRIPTION
The objective is to refactor the function used on ResendRequest to not return a Collection that will consume a high portion of memory.
The actual function gets the range of messages and puts them into a collection that will be returned to be sent.
With a large range of messages, the flow tends to be slow.
Using yield return, we don't create a collection allocated in memory, and we speed up the return of messages by increasing the throughput.