### PR TITLE
Add methods for serializing to FIX JSON Encoding

### DIFF
--- a/Examples/FixToJson/Examples.FixToJson.csproj
+++ b/Examples/FixToJson/Examples.FixToJson.csproj
@@ -13,5 +13,8 @@
 
   <ItemGroup>
       <ProjectReference Include="..\..\QuickFIXn\QuickFix.csproj" />
+      <ProjectReference Include="..\..\Messages\FIX50SP2\QuickFix.FIX50SP2.csproj" />
+      <ProjectReference Include="..\..\Messages\FIX44\QuickFix.FIX44.csproj" />
+      <ProjectReference Include="..\..\Messages\FIX42\QuickFix.FIX42.csproj" />
   </ItemGroup>
 </Project>

--- a/Examples/FixToJson/Examples.FixToJson.csproj
+++ b/Examples/FixToJson/Examples.FixToJson.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+    <RootNamespace>FixToJson</RootNamespace>
+    <AssemblyName>FixToJson</AssemblyName>
+    <Copyright>Copyright © Connamara Systems, LLC 2022</Copyright>
+    <Company>Connamara Systems, LLC</Company>
+    <Platforms>AnyCPU;x64</Platforms>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+      <ProjectReference Include="..\..\QuickFIXn\QuickFix.csproj" />
+  </ItemGroup>
+</Project>

--- a/Examples/FixToJson/Program.cs
+++ b/Examples/FixToJson/Program.cs
@@ -10,18 +10,22 @@ namespace TradeClient
         {
             try
             {
+                Console.WriteLine("[");
                 using (StreamReader streamReader = new StreamReader(fname))
                 {
                     QuickFix.IMessageFactory msgFactory = new QuickFix.DefaultMessageFactory();
                     QuickFix.Message msg = new QuickFix.Message();
                     string line = null;
+                    string comma = "";
                     while ((line = streamReader.ReadLine()) != null)
                     {
                         line = line.Trim();
                         msg.FromString(line, false, sessionDataDictionary, appDataDictionary, msgFactory);
-                        Console.WriteLine(msg.ToJSON(humanReadableValues));
+                        Console.WriteLine(comma + msg.ToJSON(humanReadableValues));
+                        comma = ",";
                     }
                 }
+                Console.WriteLine("]");
 
             }
             catch (System.Exception e)
@@ -38,13 +42,13 @@ namespace TradeClient
             {
                 System.Console.WriteLine("USAGE");
                 System.Console.WriteLine("");
-                System.Console.WriteLine("    FixToJson.exe FILE [HUMAN_READABLE_VALUES] [APP_DATA_DICTIONARY] [SESSION_DATA_DICTIONARY]");
+                System.Console.WriteLine("    FixToJson.exe FILE [HUMAN_READABLE_VALUES] [DATA_DICTIONARY]");
                 System.Console.WriteLine("");
                 System.Console.WriteLine("EXAMPLES");
                 System.Console.WriteLine("");
-                System.Console.WriteLine("    FixToJson.exe messages.log true FIX50SP2.xml FIXT11.xml");
-                System.Console.WriteLine("    FixToJson.exe messages.log true FIX42.xml");
-                System.Console.WriteLine("    FixToJson.exe messages.log false FIX42.xml");
+                System.Console.WriteLine("    FixToJson.exe messages.log true ../../spec/fix/FIX50SP2.xml");
+                System.Console.WriteLine("    FixToJson.exe messages.log true ../../spec/fix/FIX44.xml");
+                System.Console.WriteLine("    FixToJson.exe messages.log false ../../spec/fix/FIX42.xml");
                 System.Console.WriteLine("");
                 System.Console.WriteLine("NOTE");
                 System.Console.WriteLine("");
@@ -69,11 +73,6 @@ namespace TradeClient
                 appDataDictionary = sessionDataDictionary;
             }
             
-            if (args.Length > 3)
-            {
-                appDataDictionary = new QuickFix.DataDictionary.DataDictionary(args[3]);
-            }
-
             FixToJson(fname, humanReadableValues, sessionDataDictionary, appDataDictionary);
             Environment.Exit(1);
         }

--- a/Examples/FixToJson/Program.cs
+++ b/Examples/FixToJson/Program.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Text;
+using System.IO;
+
+namespace TradeClient
+{
+    class Program
+    {
+        static void FixToJson(string fname, bool humanReadableValues, QuickFix.DataDictionary.DataDictionary sessionDataDictionary, QuickFix.DataDictionary.DataDictionary appDataDictionary)
+        {
+            try
+            {
+                using (StreamReader streamReader = new StreamReader(fname))
+                {
+                    QuickFix.IMessageFactory msgFactory = new QuickFix.DefaultMessageFactory();
+                    QuickFix.Message msg = new QuickFix.Message();
+                    string line = null;
+                    while ((line = streamReader.ReadLine()) != null)
+                    {
+                        line = line.Trim();
+                        msg.FromString(line, false, sessionDataDictionary, appDataDictionary, msgFactory);
+                        Console.WriteLine(msg.ToJSON(humanReadableValues));
+                    }
+                }
+
+            }
+            catch (System.Exception e)
+            {
+                Console.WriteLine(e.Message);
+                Console.WriteLine(e.StackTrace);
+            }
+        }
+
+        [STAThread]
+        static void Main(string[] args)
+        {
+            if (args.Length < 1 || args.Length > 4)
+            {
+                System.Console.WriteLine("USAGE");
+                System.Console.WriteLine("");
+                System.Console.WriteLine("    FixToJson.exe FILE [HUMAN_READABLE_VALUES] [APP_DATA_DICTIONARY] [SESSION_DATA_DICTIONARY]");
+                System.Console.WriteLine("");
+                System.Console.WriteLine("EXAMPLES");
+                System.Console.WriteLine("");
+                System.Console.WriteLine("    FixToJson.exe messages.log true FIX50SP2.xml FIXT11.xml");
+                System.Console.WriteLine("    FixToJson.exe messages.log true FIX42.xml");
+                System.Console.WriteLine("    FixToJson.exe messages.log false FIX42.xml");
+                System.Console.WriteLine("");
+                System.Console.WriteLine("NOTE");
+                System.Console.WriteLine("");
+                System.Console.WriteLine("    Per the FIX JSON Encoding Specification, tags are converted to human-readable form, but values are not.");
+                System.Console.WriteLine("    Set the HUMAN_READABLE_VALUES argument to TRUE to override the standard behavior.");
+                System.Environment.Exit(2);
+            }
+
+            string fname = args[0];
+            bool humanReadableValues = false;
+            QuickFix.DataDictionary.DataDictionary sessionDataDictionary = null;
+            QuickFix.DataDictionary.DataDictionary appDataDictionary = null;
+ 
+            if (args.Length > 1)
+            {
+                humanReadableValues = bool.Parse(args[1]);
+            }
+
+            if (args.Length > 2)
+            {
+                sessionDataDictionary = new QuickFix.DataDictionary.DataDictionary(args[2]);
+                appDataDictionary = sessionDataDictionary;
+            }
+            
+            if (args.Length > 3)
+            {
+                appDataDictionary = new QuickFix.DataDictionary.DataDictionary(args[3]);
+            }
+
+            FixToJson(fname, humanReadableValues, sessionDataDictionary, appDataDictionary);
+            Environment.Exit(1);
+        }
+    }
+}

--- a/Examples/FixToJson/Program.cs
+++ b/Examples/FixToJson/Program.cs
@@ -10,7 +10,7 @@ namespace TradeClient
         {
             try
             {
-                Console.WriteLine("[");
+                Console.WriteLine("{\n\"messages\": [");
                 using (StreamReader streamReader = new StreamReader(fname))
                 {
                     QuickFix.IMessageFactory msgFactory = new QuickFix.DefaultMessageFactory();
@@ -25,7 +25,7 @@ namespace TradeClient
                         comma = ",";
                     }
                 }
-                Console.WriteLine("]");
+                Console.WriteLine("]\n}");
 
             }
             catch (System.Exception e)

--- a/QuickFIXn/Message/Message.cs
+++ b/QuickFIXn/Message/Message.cs
@@ -60,13 +60,13 @@ namespace QuickFix
         public const string SOH = "\u0001";
         private int field_ = 0;
         private bool validStructure_;
-        protected DataDictionary.DataDictionary dataDictionary_ = null;
 
         #region Properties
 
         public Header Header { get; private set; }
         public Trailer Trailer { get; private set; }
-        
+        public DataDictionary.DataDictionary ApplicationDataDictionary { get; private set; }
+
         #endregion
 
         #region Constructors
@@ -89,12 +89,14 @@ namespace QuickFix
         public Message(string msgstr, DataDictionary.DataDictionary dataDictionary, bool validate)
             : this()
         {
+            this.ApplicationDataDictionary = dataDictionary;
             FromString(msgstr, validate, dataDictionary, dataDictionary, null);
         }
 
         public Message(string msgstr, DataDictionary.DataDictionary sessionDataDictionary, DataDictionary.DataDictionary appDD, bool validate)
             : this()
         {
+            this.ApplicationDataDictionary = appDD;
             FromStringHeader(msgstr);
             if(IsAdmin())
                 FromString(msgstr, validate, sessionDataDictionary, sessionDataDictionary, null);
@@ -369,6 +371,7 @@ namespace QuickFix
         /// <param name="appDD"></param>
         public void FromString(string msgstr, bool validate, DataDictionary.DataDictionary sessionDD, DataDictionary.DataDictionary appDD)
         {
+            this.ApplicationDataDictionary = appDD;
             FromString(msgstr, validate, sessionDD, appDD, null);
         }
 
@@ -383,6 +386,7 @@ namespace QuickFix
         public void FromString(string msgstr, bool validate,
             DataDictionary.DataDictionary sessionDD, DataDictionary.DataDictionary appDD, IMessageFactory msgFactory)
         {
+            this.ApplicationDataDictionary = appDD;
             FromString(msgstr, validate, sessionDD, appDD, msgFactory, false);
         }
 
@@ -401,6 +405,7 @@ namespace QuickFix
             DataDictionary.DataDictionary sessionDD, DataDictionary.DataDictionary appDD, IMessageFactory msgFactory,
             bool ignoreBody)
         {
+            this.ApplicationDataDictionary = appDD;
             Clear();
 
             string msgType = "";
@@ -835,6 +840,67 @@ namespace QuickFix
             return s.ToString();
         }
 
+
+        /// <summary>
+        /// ToJSON() helper method.
+        /// </summary>
+        /// <returns>an XML string</returns>
+        private static StringBuilder FieldMapToJSON(StringBuilder sb, DataDictionary.DataDictionary dd, FieldMap fields)
+        {
+            IList<int> numInGroupTagList = fields.GetGroupTags();
+            IList<Fields.IField> numInGroupFieldList = new List<Fields.IField>();
+
+            // Non-Group Fields
+            foreach (var field in fields)
+            {
+                if (QuickFix.Fields.CheckSum.TAG == field.Value.Tag)
+                    continue; // FIX JSON Encoding does not include CheckSum
+
+                if (numInGroupTagList.Contains(field.Value.Tag))
+                {
+                    numInGroupFieldList.Add(field.Value);
+                    continue; // Groups will be handled below
+                }
+
+                if ((dd != null) && ( dd.FieldsByTag.ContainsKey(field.Value.Tag)))
+                    sb.Append("\"" + dd.FieldsByTag[field.Value.Tag].Name + "\":");
+                else
+                    sb.Append("\"" + field.Value.Tag.ToString() + "\":");
+
+                sb.Append("\"" + field.Value.ToString() + "\",");
+
+            }
+
+            // Group Fields
+            foreach(Fields.IField numInGroupField in numInGroupFieldList)
+            {
+                // The name of the NumInGroup field is the key of the JSON list containing the Group items
+                if ((dd != null) && ( dd.FieldsByTag.ContainsKey(numInGroupField.Tag)))
+                    sb.Append("\"" + dd.FieldsByTag[numInGroupField.Tag].Name + "\":[");
+                else
+                    sb.Append("\"" + numInGroupField.Tag.ToString() + "\":[");
+
+                // Populate the JSON list with the Group items
+                for (int counter = 1; counter <= fields.GroupCount(numInGroupField.Tag); counter++)
+                {
+                    sb.Append("{");
+                    FieldMapToJSON(sb, dd, fields.GetGroup(counter, numInGroupField.Tag));
+                    sb.Append("},");
+                }
+
+                // Remove trailing comma
+                if (sb.Length > 0 && sb[sb.Length - 1] == ',')
+                    sb.Remove(sb.Length - 1, 1);
+
+                sb.Append("],");
+            }
+            // Remove trailing comma
+            if (sb.Length > 0 && sb[sb.Length - 1] == ',')
+                sb.Remove(sb.Length - 1, 1);
+
+            return sb;
+        }
+
         /// <summary>
         /// Get a representation of the message as an XML string.
         /// (NOTE: this is just an ad-hoc XML; it is NOT FIXML.)
@@ -842,19 +908,53 @@ namespace QuickFix
         /// <returns>an XML string</returns>
         public string ToXML()
         {
+            return ToXML(this.ApplicationDataDictionary);
+        }
+
+        /// <summary>
+        /// Get a representation of the message as an XML string.
+        /// (NOTE: this is just an ad-hoc XML; it is NOT FIXML.)
+        /// </summary>
+        /// <returns>an XML string</returns>
+        public string ToXML(DataDictionary.DataDictionary dd)
+        {
             StringBuilder s = new StringBuilder();
-            s.AppendLine("<message>");
-            s.AppendLine("<header>");
-            s.AppendLine(FieldMapToXML(dataDictionary_, Header, 4));
-            s.AppendLine("</header>");
-            s.AppendLine("<body>");
-            s.AppendLine(FieldMapToXML(dataDictionary_, this, 4));
-            s.AppendLine("</body>");
-            s.AppendLine("<trailer>");
-            s.AppendLine(FieldMapToXML(dataDictionary_, Trailer, 4));
-            s.AppendLine("</trailer>");
-            s.AppendLine("</message>");
+            s.Append("<message>");
+            s.Append("<header>");
+            s.Append(FieldMapToXML(dd, Header, 4));
+            s.Append("</header>");
+            s.Append("<body>");
+            s.Append(FieldMapToXML(dd, this, 4));
+            s.Append("</body>");
+            s.Append("<trailer>");
+            s.Append(FieldMapToXML(dd, Trailer, 4));
+            s.Append("</trailer>");
+            s.Append("</message>");
             return s.ToString();
+        }
+
+        /// <summary>
+        /// Get a representation of the message as a string in FIX JSON Encoding.
+        /// See: https://github.com/FIXTradingCommunity/fix-json-encoding-spec
+        /// </summary>
+        /// <returns>a JSON string</returns>
+        public string ToJSON()
+        {
+            return ToJSON(this.ApplicationDataDictionary);
+        }
+
+        /// <summary>
+        /// Get a representation of the message as a string in FIX JSON Encoding.
+        /// See: https://github.com/FIXTradingCommunity/fix-json-encoding-spec
+        /// </summary>
+        /// <returns>a JSON string</returns>
+        public string ToJSON(DataDictionary.DataDictionary dd)
+        {
+            StringBuilder sb = new StringBuilder().Append("{").Append("\"Header\":{");
+            FieldMapToJSON(sb, dd, Header).Append("},\"Body\":{");
+            FieldMapToJSON(sb, dd, this).Append("},\"Trailer\":{");
+            FieldMapToJSON(sb, dd, Trailer).Append("}}");
+            return sb.ToString();
         }
     }
 }

--- a/UnitTests/MessageToXmlTests.cs
+++ b/UnitTests/MessageToXmlTests.cs
@@ -19,21 +19,7 @@ namespace UnitTests
             Message msg = new Message();
             msg.FromString(str1, true, null, null, _defaultMsgFactory);
 
-            var expectedArr = new List<string>();
-            expectedArr.Add("<message>");
-            expectedArr.Add("<header>");
-            expectedArr.Add(@"<field number=""8""><![CDATA[FIX.4.2]]></field><field number=""9""><![CDATA[55]]></field><field number=""34""><![CDATA[3]]></field><field number=""35""><![CDATA[0]]></field><field number=""49""><![CDATA[TW]]></field><field number=""52""><![CDATA[20000426-12:05:06]]></field><field number=""56""><![CDATA[ISLD]]></field>");
-            expectedArr.Add("</header>");
-            expectedArr.Add("<body>");
-            expectedArr.Add(@"<field number=""1""><![CDATA[acct123]]></field>");
-            expectedArr.Add("</body>");
-            expectedArr.Add("<trailer>");
-            expectedArr.Add(@"<field number=""10""><![CDATA[123]]></field>");
-            expectedArr.Add("</trailer>");
-            expectedArr.Add("</message>");
-            expectedArr.Add("");
-            var expected = string.Join(Environment.NewLine, expectedArr);
-
+            string expected = @"<message><header><field number=""8""><![CDATA[FIX.4.2]]></field><field number=""9""><![CDATA[55]]></field><field number=""34""><![CDATA[3]]></field><field number=""35""><![CDATA[0]]></field><field number=""49""><![CDATA[TW]]></field><field number=""52""><![CDATA[20000426-12:05:06]]></field><field number=""56""><![CDATA[ISLD]]></field></header><body><field number=""1""><![CDATA[acct123]]></field></body><trailer><field number=""10""><![CDATA[123]]></field></trailer></message>";
             Assert.AreEqual(expected, msg.ToXML());
         }
 
@@ -67,23 +53,41 @@ namespace UnitTests
             QuickFix.FIX44.ExecutionReport msg = new QuickFix.FIX44.ExecutionReport();
             msg.FromString(msgStr, true, dd, dd, null); // <-- null factory!
 
-            var expectedArr = new List<string>();
-
-            expectedArr.Add("<message>");
-            expectedArr.Add("<header>");
-            expectedArr.Add(@"<field number=""8""><![CDATA[FIX.4.4]]></field><field number=""9""><![CDATA[638]]></field><field number=""34""><![CDATA[360]]></field><field number=""35""><![CDATA[8]]></field><field number=""49""><![CDATA[BLPTSOX]]></field><field number=""52""><![CDATA[20130321-15:21:23]]></field><field number=""56""><![CDATA[THINKTSOX]]></field><field number=""57""><![CDATA[6804469]]></field><field number=""128""><![CDATA[ZERO]]></field>");
-            expectedArr.Add("</header>");
-            expectedArr.Add("<body>");
-            expectedArr.Add(@"<field number=""6""><![CDATA[122.255]]></field><field number=""11""><![CDATA[61101189]]></field><field number=""14""><![CDATA[1990000]]></field><field number=""15""><![CDATA[GBP]]></field><field number=""17""><![CDATA[VCON:20130321:50018:5:12]]></field><field number=""22""><![CDATA[4]]></field><field number=""31""><![CDATA[122.255]]></field><field number=""32""><![CDATA[1990000]]></field><field number=""37""><![CDATA[116]]></field><field number=""38""><![CDATA[1990000]]></field><field number=""39""><![CDATA[2]]></field><field number=""48""><![CDATA[GB0032452392]]></field><field number=""54""><![CDATA[1]]></field><field number=""55""><![CDATA[[N/A]]]></field><field number=""60""><![CDATA[20130321-15:21:23]]></field><field number=""64""><![CDATA[20130322]]></field><field number=""75""><![CDATA[20130321]]></field><field number=""106""><![CDATA[UK TSY 4 1/4% 2036]]></field><field number=""118""><![CDATA[2436321.85]]></field><field number=""150""><![CDATA[F]]></field><field number=""151""><![CDATA[0]]></field><field number=""157""><![CDATA[15]]></field><field number=""159""><![CDATA[3447.35]]></field><field number=""192""><![CDATA[0]]></field><field number=""198""><![CDATA[3739:20130321:50018:5]]></field><field number=""223""><![CDATA[0.0425]]></field><field number=""228""><![CDATA[1]]></field><field number=""236""><![CDATA[0.0291371041]]></field><field number=""238""><![CDATA[0]]></field><field number=""381""><![CDATA[2432874.5]]></field><field number=""423""><![CDATA[1]]></field><field number=""453""><![CDATA[6]]></field><field number=""470""><![CDATA[GB]]></field><field number=""541""><![CDATA[20360307]]></field><group><field number=""447""><![CDATA[D]]></field><field number=""448""><![CDATA[VCON]]></field><field number=""452""><![CDATA[1]]></field><field number=""802""><![CDATA[1]]></field><group><field number=""523""><![CDATA[14]]></field><field number=""803""><![CDATA[4]]></field></group></group><group><field number=""447""><![CDATA[D]]></field><field number=""448""><![CDATA[TFOLIO:6804469]]></field><field number=""452""><![CDATA[12]]></field></group><group><field number=""447""><![CDATA[D]]></field><field number=""448""><![CDATA[TFOLIO]]></field><field number=""452""><![CDATA[11]]></field></group><group><field number=""447""><![CDATA[D]]></field><field number=""448""><![CDATA[THINKFOLIO LTD]]></field><field number=""452""><![CDATA[13]]></field></group><group><field number=""447""><![CDATA[D]]></field><field number=""448""><![CDATA[SXT]]></field><field number=""452""><![CDATA[16]]></field></group><group><field number=""447""><![CDATA[D]]></field><field number=""448""><![CDATA[TFOLIO:6804469]]></field><field number=""452""><![CDATA[36]]></field></group>");
-            expectedArr.Add("</body>");
-            expectedArr.Add("<trailer>");
-            expectedArr.Add(@"<field number=""10""><![CDATA[152]]></field>");
-            expectedArr.Add("</trailer>");
-            expectedArr.Add("</message>");
-            expectedArr.Add("");
-            var expected = string.Join(Environment.NewLine, expectedArr);
-
+            string expected = @"<message><header><field name=""BeginString"" number=""8""><![CDATA[FIX.4.4]]></field><field name=""BodyLength"" number=""9""><![CDATA[638]]></field><field name=""MsgSeqNum"" number=""34""><![CDATA[360]]></field><field name=""MsgType"" number=""35""><![CDATA[8]]></field><field name=""SenderCompID"" number=""49""><![CDATA[BLPTSOX]]></field><field name=""SendingTime"" number=""52""><![CDATA[20130321-15:21:23]]></field><field name=""TargetCompID"" number=""56""><![CDATA[THINKTSOX]]></field><field name=""TargetSubID"" number=""57""><![CDATA[6804469]]></field><field name=""DeliverToCompID"" number=""128""><![CDATA[ZERO]]></field></header><body><field name=""AvgPx"" number=""6""><![CDATA[122.255]]></field><field name=""ClOrdID"" number=""11""><![CDATA[61101189]]></field><field name=""CumQty"" number=""14""><![CDATA[1990000]]></field><field name=""Currency"" number=""15""><![CDATA[GBP]]></field><field name=""ExecID"" number=""17""><![CDATA[VCON:20130321:50018:5:12]]></field><field name=""SecurityIDSource"" number=""22""><![CDATA[4]]></field><field name=""LastPx"" number=""31""><![CDATA[122.255]]></field><field name=""LastQty"" number=""32""><![CDATA[1990000]]></field><field name=""OrderID"" number=""37""><![CDATA[116]]></field><field name=""OrderQty"" number=""38""><![CDATA[1990000]]></field><field name=""OrdStatus"" number=""39""><![CDATA[2]]></field><field name=""SecurityID"" number=""48""><![CDATA[GB0032452392]]></field><field name=""Side"" number=""54""><![CDATA[1]]></field><field name=""Symbol"" number=""55""><![CDATA[[N/A]]]></field><field name=""TransactTime"" number=""60""><![CDATA[20130321-15:21:23]]></field><field name=""SettlDate"" number=""64""><![CDATA[20130322]]></field><field name=""TradeDate"" number=""75""><![CDATA[20130321]]></field><field name=""Issuer"" number=""106""><![CDATA[UK TSY 4 1/4% 2036]]></field><field name=""NetMoney"" number=""118""><![CDATA[2436321.85]]></field><field name=""ExecType"" number=""150""><![CDATA[F]]></field><field name=""LeavesQty"" number=""151""><![CDATA[0]]></field><field name=""NumDaysInterest"" number=""157""><![CDATA[15]]></field><field name=""AccruedInterestAmt"" number=""159""><![CDATA[3447.35]]></field><field name=""OrderQty2"" number=""192""><![CDATA[0]]></field><field name=""SecondaryOrderID"" number=""198""><![CDATA[3739:20130321:50018:5]]></field><field name=""CouponRate"" number=""223""><![CDATA[0.0425]]></field><field name=""Factor"" number=""228""><![CDATA[1]]></field><field name=""Yield"" number=""236""><![CDATA[0.0291371041]]></field><field name=""Concession"" number=""238""><![CDATA[0]]></field><field name=""GrossTradeAmt"" number=""381""><![CDATA[2432874.5]]></field><field name=""PriceType"" number=""423""><![CDATA[1]]></field><field name=""NoPartyIDs"" number=""453""><![CDATA[6]]></field><field name=""CountryOfIssue"" number=""470""><![CDATA[GB]]></field><field name=""MaturityDate"" number=""541""><![CDATA[20360307]]></field><group><field name=""PartyIDSource"" number=""447""><![CDATA[D]]></field><field name=""PartyID"" number=""448""><![CDATA[VCON]]></field><field name=""PartyRole"" number=""452""><![CDATA[1]]></field><field name=""NoPartySubIDs"" number=""802""><![CDATA[1]]></field><group><field name=""PartySubID"" number=""523""><![CDATA[14]]></field><field name=""PartySubIDType"" number=""803""><![CDATA[4]]></field></group></group><group><field name=""PartyIDSource"" number=""447""><![CDATA[D]]></field><field name=""PartyID"" number=""448""><![CDATA[TFOLIO:6804469]]></field><field name=""PartyRole"" number=""452""><![CDATA[12]]></field></group><group><field name=""PartyIDSource"" number=""447""><![CDATA[D]]></field><field name=""PartyID"" number=""448""><![CDATA[TFOLIO]]></field><field name=""PartyRole"" number=""452""><![CDATA[11]]></field></group><group><field name=""PartyIDSource"" number=""447""><![CDATA[D]]></field><field name=""PartyID"" number=""448""><![CDATA[THINKFOLIO LTD]]></field><field name=""PartyRole"" number=""452""><![CDATA[13]]></field></group><group><field name=""PartyIDSource"" number=""447""><![CDATA[D]]></field><field name=""PartyID"" number=""448""><![CDATA[SXT]]></field><field name=""PartyRole"" number=""452""><![CDATA[16]]></field></group><group><field name=""PartyIDSource"" number=""447""><![CDATA[D]]></field><field name=""PartyID"" number=""448""><![CDATA[TFOLIO:6804469]]></field><field name=""PartyRole"" number=""452""><![CDATA[36]]></field></group></body><trailer><field name=""CheckSum"" number=""10""><![CDATA[152]]></field></trailer></message>";
             Assert.AreEqual(expected, msg.ToXML());
+        }
+
+        [Test]
+        public void ToJSONWithGroupsTest()
+        {
+            var dd = new QuickFix.DataDictionary.DataDictionary();
+            dd.Load(Path.Combine(TestContext.CurrentContext.TestDirectory, "spec", "fix", "FIX44.xml"));
+
+            string[] msgFields = {
+                // header
+                "8=FIX.4.4","9=638", "35=8", "34=360", "49=BLPTSOX", "52=20130321-15:21:23", "56=THINKTSOX", "57=6804469", "128=ZERO",
+                // non-group body fields
+                "6=122.255", "11=61101189", "14=1990000", "15=GBP", "17=VCON:20130321:50018:5:12", "22=4", "31=122.255", "32=1990000",
+                "37=116", "38=1990000", "39=2", "48=GB0032452392", "54=1", "55=[N/A]", "60=20130321-15:21:23", "64=20130322", "75=20130321",
+                "106=UK TSY 4 1/4% 2036", "118=2436321.85", "150=F", "151=0", "157=15", "159=3447.35", "192=0", "198=3739:20130321:50018:5",
+                "223=0.0425", "228=1", "236=0.0291371041", "238=0", "381=2432874.5", "423=1", "470=GB", "541=20360307",
+                // NoPartyIDs
+                "453=6",
+                "448=VCON", "447=D", "452=1", "802=1", "523=14", "803=4",
+                "448=TFOLIO:6804469", "447=D", "452=12",
+                "448=TFOLIO", "447=D", "452=11",
+                "448=THINKFOLIO LTD", "447=D", "452=13",
+                "448=SXT", "447=D", "452=16",
+                "448=TFOLIO:6804469", "447=D", "452=36",
+                "10=152"
+            };
+            string msgStr = String.Join(Message.SOH, msgFields) + Message.SOH;
+
+            QuickFix.FIX44.ExecutionReport msg = new QuickFix.FIX44.ExecutionReport();
+            msg.FromString(msgStr, true, dd, dd, null); // <-- null factory!
+
+            string expected = "{\"Header\":{\"BeginString\":\"FIX.4.4\",\"BodyLength\":\"638\",\"MsgSeqNum\":\"360\",\"MsgType\":\"8\",\"SenderCompID\":\"BLPTSOX\",\"SendingTime\":\"20130321-15:21:23\",\"TargetCompID\":\"THINKTSOX\",\"TargetSubID\":\"6804469\",\"DeliverToCompID\":\"ZERO\"},\"Body\":{\"AvgPx\":\"122.255\",\"ClOrdID\":\"61101189\",\"CumQty\":\"1990000\",\"Currency\":\"GBP\",\"ExecID\":\"VCON:20130321:50018:5:12\",\"SecurityIDSource\":\"4\",\"LastPx\":\"122.255\",\"LastQty\":\"1990000\",\"OrderID\":\"116\",\"OrderQty\":\"1990000\",\"OrdStatus\":\"2\",\"SecurityID\":\"GB0032452392\",\"Side\":\"1\",\"Symbol\":\"[N/A]\",\"TransactTime\":\"20130321-15:21:23\",\"SettlDate\":\"20130322\",\"TradeDate\":\"20130321\",\"Issuer\":\"UK TSY 4 1/4% 2036\",\"NetMoney\":\"2436321.85\",\"ExecType\":\"F\",\"LeavesQty\":\"0\",\"NumDaysInterest\":\"15\",\"AccruedInterestAmt\":\"3447.35\",\"OrderQty2\":\"0\",\"SecondaryOrderID\":\"3739:20130321:50018:5\",\"CouponRate\":\"0.0425\",\"Factor\":\"1\",\"Yield\":\"0.0291371041\",\"Concession\":\"0\",\"GrossTradeAmt\":\"2432874.5\",\"PriceType\":\"1\",\"CountryOfIssue\":\"GB\",\"MaturityDate\":\"20360307\",\"NoPartyIDs\":[{\"PartyIDSource\":\"D\",\"PartyID\":\"VCON\",\"PartyRole\":\"1\",\"NoPartySubIDs\":[{\"PartySubID\":\"14\",\"PartySubIDType\":\"4\"}]},{\"PartyIDSource\":\"D\",\"PartyID\":\"TFOLIO:6804469\",\"PartyRole\":\"12\"},{\"PartyIDSource\":\"D\",\"PartyID\":\"TFOLIO\",\"PartyRole\":\"11\"},{\"PartyIDSource\":\"D\",\"PartyID\":\"THINKFOLIO LTD\",\"PartyRole\":\"13\"},{\"PartyIDSource\":\"D\",\"PartyID\":\"SXT\",\"PartyRole\":\"16\"},{\"PartyIDSource\":\"D\",\"PartyID\":\"TFOLIO:6804469\",\"PartyRole\":\"36\"}]},\"Trailer\":{}}";
+            Assert.AreEqual(expected, msg.ToJSON());
         }
     }
 }


### PR DESCRIPTION
Adds ToJSON() for serializing to FIX JSON Encoding, which is specified
here: https://github.com/FIXTradingCommunity/fix-json-encoding-spec

Also fixes a long-standing bug in ToXML().  The DataDictionary would
always be null, so lookups of field names always failed.
https://github.com/FIXTradingCommunity/fix-json-encoding-spec