### PR TITLE
Capture inner exception messages when handling authentication exceptions

### DIFF
--- a/QuickFIXn/Transport/SocketInitiator.cs
+++ b/QuickFIXn/Transport/SocketInitiator.cs
@@ -1,13 +1,14 @@
 ﻿#nullable enable
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Net.Sockets;
-using System.Net;
-using System.Threading;
 using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
 using QuickFix.Logger;
 using QuickFix.Store;
+using QuickFix.Util;
 
 namespace QuickFix.Transport
 {
@@ -73,7 +74,7 @@ namespace QuickFix.Transport
                 }
                 catch (System.Security.Authentication.AuthenticationException ex) // some certificate problems
                 {
-                    exceptionEvent = $"Connection failed (AuthenticationException): {ex.Message}";
+                    exceptionEvent = $"Connection failed (AuthenticationException): {ex.GetFullMessage()}";
                 }
                 catch (Exception ex)
                 {

--- a/QuickFIXn/Transport/StreamFactory.cs
+++ b/QuickFIXn/Transport/StreamFactory.cs
@@ -1,15 +1,16 @@
 ﻿#nullable enable
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.IO;
-using System.Net.Sockets;
-using System.Security.Cryptography.X509Certificates;
-using System.Net.Security;
 using System.Diagnostics;
+using System.IO;
+using System.Linq;
 using System.Net;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Text;
+using System.Security.Cryptography.X509Certificates;
 using QuickFix.Logger;
+using QuickFix.Util;
 
 namespace QuickFix.Transport
 {
@@ -271,7 +272,7 @@ namespace QuickFix.Transport
                 }
                 catch (System.Security.Authentication.AuthenticationException ex)
                 {
-                    _log.OnEvent("Unable to perform authentication against server: " + ex.Message);
+                    _log.OnEvent("Unable to perform authentication against server: " + ex.GetFullMessage());
                     throw;
                 }
 
@@ -312,7 +313,7 @@ namespace QuickFix.Transport
                 }
                 catch (System.Security.Authentication.AuthenticationException ex)
                 {
-                    _log.OnEvent("Unable to perform authentication against server: " + ex.Message);
+                    _log.OnEvent("Unable to perform authentication against server: " + ex.GetFullMessage());
                     throw;
                 }
 

--- a/QuickFIXn/Util/ExceptionExtensions.cs
+++ b/QuickFIXn/Util/ExceptionExtensions.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace QuickFix.Util
+{
+    internal static class ExceptionExtensions
+    {
+        public static string GetFullMessage(this Exception ex)
+        {
+            return ex.InnerException == null
+                ? ex.Message
+                : ex.Message + " --> " + ex.InnerException.GetFullMessage();
+        }
+    }
+}

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -64,6 +64,7 @@ What's New
 * #823 - get rid of IOIQty enums in FIX5 DDs, allow free string (gbirchmeier)
 * #786 - rewrite HttpServer: better HTML, no crash on errors (gbirchmeier)
 * #697 - new SocketIgnoreProxy setting (ABSJ415)
+* #740 - Capture inner exception messages when handling authentication exceptions (rars)
 
 ### v1.11.2:
 * same as v1.11.1, but I fixed the readme in the pushed nuget packages

--- a/UnitTests/Util/ExceptionExtensionsTests.cs
+++ b/UnitTests/Util/ExceptionExtensionsTests.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using NUnit.Framework;
+using QuickFix.Util;
+
+namespace UnitTests.Util
+{
+    public sealed class ExceptionExtensionsTests
+    {
+        [Test]
+        public void WhenInnerExceptionShouldReturnJoinedInnerExceptionMessages()
+        {
+            var exception = new Exception(
+                "Outer exception, see inner exception",
+                new Exception("My inner exception message"));
+
+            Assert.AreEqual(
+                exception.GetFullMessage(),
+                "Outer exception, see inner exception --> My inner exception message");
+        }
+
+        [Test]
+        public void WhenNoInnerExceptionShouldReturnExceptionMessageUnmodified()
+        {
+            var exception = new Exception("My exception message");
+
+            Assert.AreEqual(exception.GetFullMessage(), "My exception message");
+        }
+    }
+}


### PR DESCRIPTION
Often the helpful information is contained in the inner exception's message rather than the message of the `AuthenticationException` which often just says 'see inner exception'. This helps improve the log output to diagnose reasons for authentication failures.