### PR TITLE
Add code coverage report generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ This project requires the following:
 **To build and run tests**
 
 * [Ruby (2.5+ recommended)](http://rubyinstaller.org/) (used to generate message and field classes from the DataDictionary xml file)
-* From the command-line: dotnet 2.0.0 or higher
-* From Visual Studio: version 2017 or higher
+* From the command-line: dotnet 6.0 or higher
+* From Visual Studio: version 2022 or higher
 
 Code Generation
 ---------------
@@ -32,16 +32,16 @@ Build
 To build the project, run:
 
 ```
-build.bat
+build.ps1
 ```
 
 You can also override the default configuration (Release) by giving a command line argument:
 
 ```
-build.bat Debug
+build.ps1 Debug
 ```
 
-The build.bat script expects dotnet to be on your PATH.
+The build.ps1 script expects dotnet to be on your PATH.
 
 Alternatively, simply use the dotnet tools.
 
@@ -50,12 +50,12 @@ Unit Tests
 To run the NUnit tests, run:
 
 ```
-unit_test.bat
+unit_test.ps1
 ```
 
 (This script expects `dotnet` to be on your PATH.)
 
-TRX reports of the test results (one each for NET Framework 4.5.2 and NET Standard 2.0) will then be available here:
+TRX and code coverage reports of the test results will then be available here:
 
 ```
 UnitTests\TestResults

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -15,9 +15,14 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="ReportGenerator" Version="5.1.19" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/UnitTests/coverlet.runsettings
+++ b/UnitTests/coverlet.runsettings
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<RunSettings>
+    <DataCollectionRunSettings>
+        <DataCollectors>
+            <DataCollector friendlyName="XPlat code coverage">
+                <Configuration>
+                    <!--
+                    Exclude the generated QuickFix assemblies and Field files from the code coverage collection.
+                    If they are included they massively slow the tests and increase the size of the generated reports
+                    -->
+                    <Exclude>[QuickFix.FIX*]*</Exclude> <!-- [Assembly-Filter]Type-Filter -->
+                    <ExcludeByFile>**/QuickFIXn/Fields/Fields.cs,**/QuickFIXn/Fields/FieldTags.cs</ExcludeByFile> <!-- Globbing filter -->
+                </Configuration>
+            </DataCollector>
+        </DataCollectors>
+    </DataCollectionRunSettings>
+</RunSettings>

--- a/unit_test.ps1
+++ b/unit_test.ps1
@@ -1,11 +1,39 @@
+<#
+This file will run unit tests and produce a .trx file as well as code coverage reporting.
+
+When using --logger the coverage.cobertura.xml file is written twice - once in TestResults/{GUID}
+and once in TestResults/{TRXFILENAME} where TRXFILENAME is the name of the generated .trx file
+(see https://github.com/microsoft/vstest/issues/2334).
+
+After generating the html coverage report in TestResults/{TRXFILENAME}/CoverageReport we then delete
+the TestResults/{GUID} directory containing the duplicate xml to keep things a bit cleaner.
+#>
+
 Param (
 	[Parameter(Position=0, ValueFromPipeline)]
 	[ValidateSet('debug','release')]
-	[string[]]$Configuration = 'release'
+	[string]$Configuration = 'release'
 )
 
-foreach ($c in $Configuration) {
-	Write-Host "Running unit tests with config: $Configuration"
-	dotnet test -c $Configuration --no-build --no-restore UnitTests --logger trx
-}
 
+# Run the unit tests and store the console output in $TestOutput.
+dotnet test -c $Configuration --logger trx --settings UnitTests/coverlet.runsettings | Tee-Object -variable TestOutput
+
+# Find the string 
+# "Results File: C:\[...]\gitrepos\quickfixn\UnitTests\TestResults\[...].trx"
+# in the output and extract the filepath.
+$TrxFilePath = $TestOutput | Select-String .trx | Select -First 1 | %{$_.Line.TrimStart("Results File: ")}
+
+# Remove the ".trx" extension to get path of the generated directory
+$TestRunDirPath = $TrxFilePath.Substring(0, $TrxFilePath.Length - 4)
+
+# Generate the html report in the generated directory whose name matches the .trx file.
+# The reportgenerator version should match that specified in UnitTests.csproj.
+&"$env:UserProfile\.nuget\packages\reportgenerator\5.1.19\tools\net6.0\ReportGenerator.exe" -reports:"$TestRunDirPath\**\coverage.cobertura.xml" -targetdir:"$TestRunDirPath\CoverageReport" -historydir:UnitTests\TestResults\CoverageHistory
+
+# Find the duplicate generated coverage filepaths from the output and delete their directories,
+# e.g. extract the string
+# "C:\[...]\gitrepos\quickfixn\UnitTests\TestResults\71e26483-0757-48ab-9b0c-8b35a62ec891\coverage.cobertura.xml"
+# and then delete the directory
+# C:\[...]\gitrepos\quickfixn\UnitTests\TestResults\71e26483-0757-48ab-9b0c-8b35a62ec891
+$TestOutput | Select-String coverage.cobertura.xml | ForEach-Object { [System.IO.Path]::GetDirectoryName($_.Line.Trim()) } | Remove-Item -Recurse


### PR DESCRIPTION
When testing via unit_test.ps1, generate code coverage reports via coverlet (xml) and reportgenerator (html) in the UnitTests/TestResults directory. Include some additional logic for keeping the TestResults directory a bit cleaner due to the coverlet reports being written twice (see comments in unit_test.ps1 for details).

I found this helpful when experimenting with some parts of the code. It does change the `$Configuration` arg in unit_test.ps1 from `string[]` to `string` so that only one configuration can be run at a time.