### PR TITLE
Fix positive UTC offset parsing in DateTimeConverter

### DIFF
--- a/QuickFIXn/Fields/Converters/DateTimeConverter.cs
+++ b/QuickFIXn/Fields/Converters/DateTimeConverter.cs
@@ -71,8 +71,8 @@ namespace QuickFix.Fields.Converters
             {
                 // GMT offset
                 int n = dec.Contains("+") ? dec.IndexOf('+') : dec.IndexOf('-');
-                kind = System.DateTimeKind.Utc;
-                offset = int.Parse(dec.Substring(n + 1));
+                kind = System.DateTimeKind.Unspecified;
+                offset = int.Parse(dec.Substring(n));
                 dec = dec.Substring(0, n);
             }
             else
@@ -87,7 +87,7 @@ namespace QuickFix.Fields.Converters
             // apply GMT offset
             if (offset != 0)
             {
-                d = new System.DateTimeOffset(d).ToOffset(System.TimeSpan.FromHours(offset)).DateTime;
+                d = new System.DateTimeOffset(d, System.TimeSpan.FromHours(offset)).UtcDateTime;
             }
 
             long ticks = frac / NanosecondsPerTick;

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -20,6 +20,7 @@ What's New
 * #811 - convert AT platform to be NUnit-based, get rid of Ruby runner (Rob-Hague)
 * #813 - fix incorrect logging of acceptor heartbeat (gbirchmeier)
 * #815 - update broken/neglected example apps & docs (gbirchmeier)
+* #764 - fix positive UTC offset parsing in DateTimeConverter (Rob-Hague)
 
 ### v1.11.2:
 * same as v1.11.1, but I fixed the readme in the pushed nuget packages

--- a/UnitTests/ConverterTests.cs
+++ b/UnitTests/ConverterTests.cs
@@ -178,7 +178,7 @@ namespace UnitTests
             Assert.That(DateTimeConverter.ConvertToDateTime("20021201-11:03:05.231116500Z", TimeStampPrecision.Nanosecond), Is.EqualTo(dt));
 
             // convert nanosecond time with non-UTC positive offset time zone to full DateTime
-            Assert.That(DateTimeConverter.ConvertToDateTime("20021201-06:03:05.231116500+05", TimeStampPrecision.Nanosecond), Is.EqualTo(dt));
+            Assert.That(DateTimeConverter.ConvertToDateTime("20021201-16:03:05.231116500+05", TimeStampPrecision.Nanosecond), Is.EqualTo(dt));
 
             // convert nanosecond time with non-UTC negative offset time zone to full DateTime
             Assert.That(DateTimeConverter.ConvertToDateTime("20021201-08:03:05.231116500-03", TimeStampPrecision.Nanosecond), Is.EqualTo(dt));


### PR DESCRIPTION
The sign of the offset was not being considered which happened to work for negative offsets. Positive offsets would be adjusted in the wrong direction which was not caught due to an incorrect test.

I have a larger change/proposal coming in a separate PR (edit: #765). This one is a bit easier to digest.