### PR TITLE
Span-ify Parser

### DIFF
--- a/QuickFIXn/Parser.cs
+++ b/QuickFIXn/Parser.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.Text;
 
 namespace QuickFix
 {
@@ -7,144 +10,184 @@ namespace QuickFix
     /// </summary>
     public class Parser
     {
-        private byte[] buffer_ = new byte[512];
-        int usedBufferLength = 0;
+        private readonly Encoding _encoding;
+        private readonly byte[] _beginStringBytes;
+        private readonly byte[] _bodyLengthBytes;
+        private readonly byte[] _checkSumBytes;
+
+        private byte[] _buffer = new byte[512];
+        private int _usedBufferLength = 0;
+        private int _bufferStartIndex = 0;
+
+        public Parser() : this(CharEncoding.DefaultEncoding)
+        { }
+
+        public Parser(Encoding encoding)
+        {
+            _encoding = encoding;
+            _beginStringBytes = encoding.GetBytes("8=");
+            _bodyLengthBytes = encoding.GetBytes('\u0001' + "9=");
+            _checkSumBytes = encoding.GetBytes('\u0001' + "10=");
+        }
 
         public void AddToStream(byte[] data, int bytesAdded)
+            => AddToStream(data.AsSpan(0, bytesAdded));
+
+        public void AddToStream(Span<byte> data)
         {
-            if (buffer_.Length < usedBufferLength + bytesAdded)
-                Array.Resize(ref buffer_, (usedBufferLength + bytesAdded));
-            Buffer.BlockCopy(data, 0, buffer_, usedBufferLength , bytesAdded);
-            usedBufferLength += bytesAdded;
+            // We attempt to copy the new bytes into the existing buffer.
+            if (data.TryCopyTo(_buffer.AsSpan(_bufferStartIndex + _usedBufferLength)))
+            {
+                _usedBufferLength += data.Length;
+            }
+            else
+            {
+                // There is not enough space at the end of the buffer.
+                // If the new length is less than the length of the existing buffer,
+                // then we can just move the existing data to the start of the buffer
+                // and copy the new bytes in successfully. Otherwise we allocate a
+                // larger buffer and copy everything in.
+                // This avoids allocating a new array in all but the last case.
+                int requiredLength = _usedBufferLength + data.Length;
+                byte[] buffer = (uint)requiredLength <= _buffer.Length ? _buffer : new byte[requiredLength * 2]; // Allocate double to reduce subsequent resizes
+
+                _buffer.AsSpan(_bufferStartIndex, _usedBufferLength).CopyTo(buffer);
+                data.CopyTo(buffer.AsSpan(_usedBufferLength));
+                _buffer = buffer;
+                _bufferStartIndex = 0;
+                _usedBufferLength = requiredLength;
+            }
         }
 
         public bool ReadFixMessage(out string msg)
         {
             msg = "";
 
-            if(buffer_.Length < 2)
-                return false;
-            
-            int pos = 0;
-            pos = IndexOf(buffer_, "8=", 0);
-            if(-1 == pos)
-                return false;
+            Span<byte> buffer = _buffer.AsSpan(_bufferStartIndex, _usedBufferLength);
 
-            buffer_ = Remove(buffer_, pos);
-            pos = 0;
+            int pos;
 
-            int length = 0;
-
-            try
+            if ((pos = buffer.IndexOf(_beginStringBytes)) < 0)
             {
-                if (!ExtractLength(out length, out pos, buffer_))
-                    return false;
-
-                // pos is at first character past the BodyLength field (tag 9)
-
-                pos += length;
-                if (buffer_.Length < pos)
-                    return false;
-
-                pos = IndexOf(buffer_, "\x01" + "10=", pos - 1);
-                if (-1 == pos)
-                    return false; // no tag 10 received yet
-                pos += 4; // pos now just after "10="
-
-                pos = IndexOf(buffer_, "\x01", pos);
-                if (-1 == pos)
-                    return false;
-                pos += 1;
-
-                msg = Substring(buffer_, 0, pos);
-                buffer_ = Remove(buffer_, pos);
-                return true;
-            }
-            catch (MessageParseError e)
-            {
-                if ((length > 0) && (pos <= buffer_.Length))
-                    buffer_ = Remove(buffer_, pos);
-                else
-                    buffer_ = Remove(buffer_, buffer_.Length);
-                throw e;
-            }
-        }
-
-        public bool ExtractLength(out int length, out int pos, string buf)
-        {
-            return ExtractLength(out length, out pos, CharEncoding.DefaultEncoding.GetBytes(buf));
-        }
-
-        public bool ExtractLength(out int length, out int pos, byte[] buf)
-        {
-            length = 0;
-            pos = 0;
-
-            if (buf.Length < 1)
+                // BeginString (e.g. 8=) not yet found
                 return false;
-
-            int startPos = IndexOf(buf, "\x01" + "9=", 0);
-            if(-1 == startPos)
-                return false;
-            startPos +=3;
-
-            int endPos = IndexOf(buf, "\x01", startPos);
-            if(-1 == endPos)
-                return false;
-
-            string strLength = Substring(buf, startPos, endPos - startPos);
-            try
-            {
-                length = Fields.Converters.IntConverter.Convert(strLength);
-                if(length < 0)
-                    throw new MessageParseError("Invalid BodyLength (" + length + ")");
-            }
-            catch(FieldConvertError e)
-            {
-                throw new MessageParseError(e.Message, e);
             }
 
-            pos = endPos + 1;
+            // Discard everything in the buffer up to the first BeginString tag
+            _bufferStartIndex += pos;
+            _usedBufferLength -= pos;
+
+            buffer = _buffer.AsSpan(_bufferStartIndex, _usedBufferLength);
+
+            Debug.Assert(buffer.StartsWith(_beginStringBytes));
+
+            if (!ExtractLength(out int bodyLength, out int bytesConsumed, buffer))
+            {
+                // BodyLength tag and value (e.g. |9=YY|) not yet found
+                return false;
+            }
+
+            buffer = buffer.Slice(--bytesConsumed);
+
+            // buffer starts at the terminating SOH of the BodyLength (9) field
+            // e.g.
+            // 8=XX|9=YY|......
+            //          ^
+            //          |
+
+            Debug.Assert(buffer[0] == 1);
+            Debug.Assert(bodyLength >= 0);
+
+            if (buffer.Length < bodyLength)
+            {
+                return false;
+            }
+
+            buffer = buffer.Slice(bodyLength);
+            bytesConsumed += bodyLength;
+
+            if ((pos = buffer.IndexOf(_checkSumBytes)) < 0)
+            {
+                // CheckSum (e.g. |10=) not yet found
+                return false;
+            }
+
+            Debug.Assert(_buffer.AsSpan(_bufferStartIndex + bytesConsumed + pos).StartsWith(_checkSumBytes));
+
+            buffer = buffer.Slice(pos + _checkSumBytes.Length);
+            bytesConsumed += pos + _checkSumBytes.Length;
+
+            // buffer starts at the first byte of the CheckSum value
+            // e.g.
+            // 8=XX|9=YY|.........|10=......
+            //                        ^
+            //                        |
+
+            if ((pos = buffer.IndexOf((byte)1)) < 0)
+            {
+                // No terminating SOH found yet
+                return false;
+            }
+
+            Debug.Assert(_buffer[_bufferStartIndex + bytesConsumed + pos] == 1);
+
+            bytesConsumed += pos + 1; // +1 to include the terminating SOH
+
+            msg = _encoding.GetString(_buffer, _bufferStartIndex, bytesConsumed);
+
+            // Discard this message in the buffer
+            _bufferStartIndex += bytesConsumed;
+            _usedBufferLength -= bytesConsumed;
+
             return true;
         }
 
-        private int IndexOf(byte[] arrayToSearchThrough, string stringPatternToFind, int offset)
+        public bool ExtractLength(out int bodyLength, out int bytesConsumed, string buf)
         {
-            byte[] patternToFind = CharEncoding.DefaultEncoding.GetBytes(stringPatternToFind);
-            if (patternToFind.Length > arrayToSearchThrough.Length)
-                return -1;
-            for (int i = offset; i <= arrayToSearchThrough.Length - patternToFind.Length; i++)
+            return ExtractLength(out bodyLength, out bytesConsumed, _encoding.GetBytes(buf));
+        }
+
+        public bool ExtractLength(out int bodyLength, out int bytesConsumed, Span<byte> buffer)
+        {
+            bodyLength = 0;
+            bytesConsumed = 0;
+
+            int pos;
+
+            if ((pos = buffer.IndexOf(_bodyLengthBytes)) < 0)
             {
-                bool found = true;
-                for (int j = 0; j < patternToFind.Length; j++)
-                {
-                    if (arrayToSearchThrough[i + j] != patternToFind[j])
-                    {
-                        found = false;
-                        break;
-                    }
-                }
-                if (found)
-                {
-                    return i;
-                }
+                // No BodyLength tag (|9=) found yet
+                return false;
             }
-            return -1;
-        }
 
-        private byte[] Remove(byte[] array, int count)
-        {
-            byte[] returnByte = new byte[array.Length - count];
-            Buffer.BlockCopy(array, count, returnByte, 0, array.Length - count);
-            usedBufferLength -= count;
-            return returnByte;
-        }
+            bytesConsumed = pos + _bodyLengthBytes.Length;
 
-        private string Substring(byte[] array, int startIndex, int length)
-        {
-            byte[] returnByte = new byte[length];
-            Buffer.BlockCopy(array, startIndex, returnByte, 0, length);
-            return CharEncoding.DefaultEncoding.GetString(returnByte);
+            buffer = buffer.Slice(bytesConsumed);
+
+            if ((pos = buffer.IndexOf((byte)1)) < 0)
+            {
+                // No terminating SOH found yet
+                bytesConsumed = 0;
+                return false;
+            }
+
+            // The longest string representation of an Int32 with NumberStyles.None is 10.
+            Span<char> bodyLengthChars = stackalloc char[10];
+            int charsWritten = _encoding.GetChars(buffer.Slice(0, pos), bodyLengthChars);
+
+            if (!int.TryParse(bodyLengthChars.Slice(0, charsWritten), NumberStyles.None, CultureInfo.InvariantCulture, out bodyLength))
+            {
+                // Bad BodyLength value. Discard the data in the buffer up to this point.
+                bytesConsumed += pos + 1; // +1 to include the terminating SOH
+                _bufferStartIndex += bytesConsumed;
+                _usedBufferLength -= bytesConsumed;
+                bytesConsumed = 0;
+                throw new MessageParseError($"Invalid BodyLength value \"{bodyLengthChars.Slice(0, charsWritten)}\"");
+            }
+
+            bytesConsumed += pos + 1; // +1 to include the terminating SOH
+
+            return true;
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ For more information:
 
 AcceptanceTest logs are output to `bin/Debug/net6.0/log`.
 
+
 Credits
 -------
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,11 @@ What's New
 **CAUTION: There are breaking changes between 1.10 and 1.11!  Please review the 1.11.0 notes below.**
 
 ### NEXT RELEASE
+
+**Breaking change**
+* #768 - span-ify parser (Rob-Hague) - makes a change to QuickFix.Parser interface, which isn't likely to affect users
+
+**Non-breaking changes**
 * #400 - added DDTool, a C#-based codegen, and deleted Ruby-based generator (gbirchmeier)
 * #811 - convert AT platform to be NUnit-based, get rid of Ruby runner (Rob-Hague)
 * #813 - fix incorrect logging of acceptor heartbeat (gbirchmeier)

--- a/UnitTests/ParserTest.cs
+++ b/UnitTests/ParserTest.cs
@@ -1,6 +1,8 @@
 ﻿using NUnit.Framework;
 using QuickFix;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace UnitTests
 {
@@ -10,6 +12,7 @@ namespace UnitTests
         const string normalLength   = "8=FIX.4.2\x01" + "9=12\x01" + "35=A\x01" + " 108=30\x01" + "10=31\x01";
         const string badLength      = "8=FIX.4.2\x01" + "9=A\x01"  + "35=A\x01" + "108=30\x01"  + "10=31\x01";
         const string negativeLength = "8=FIX.4.2\x01" + "9=-1\x01" + "35=A\x01" + "108=30\x01"  + "10=31\x01";
+        const string zeroLength     = "8=FIX.4.2\x01" + "9=0\x01" + "35=A\x01" + "108=30\x01"  + "10=31\x01";
         const string incomplete_1   = "8=FIX.4.2";
         const string incomplete_2   = "8=FIX.4.2\x01" + "9=12";
 
@@ -29,64 +32,92 @@ namespace UnitTests
             Assert.AreEqual(12, len);
             Assert.AreEqual(15, pos);
 
-            pos = 0;
+            Assert.True(parser.ExtractLength(out len, out pos, zeroLength));
+            Assert.AreEqual(0, len);
+            Assert.AreEqual(14, pos);
+
             Assert.Throws<QuickFix.MessageParseError>(delegate { parser.ExtractLength(out len, out pos, badLength); });
-
             Assert.AreEqual(0, pos);
+
             Assert.Throws<QuickFix.MessageParseError>(delegate { parser.ExtractLength(out len, out pos, negativeLength); });
-
             Assert.AreEqual(0, pos);
-            parser.ExtractLength(out len, out pos, incomplete_1);
 
-            parser.ExtractLength(out len, out pos, incomplete_2);
+            Assert.False(parser.ExtractLength(out len, out pos, incomplete_1));
+            Assert.AreEqual(0, pos);
+
+            Assert.False(parser.ExtractLength(out len, out pos, incomplete_2));
             Assert.AreEqual(0, pos);
 
             Assert.False(parser.ExtractLength(out len, out pos, ""));
+            Assert.AreEqual(0, pos);
         }
 
         [Test]
-        public void ReadCompleteFixMessages()
+        [TestCase(100, 1)]
+        [TestCase(10, 10)]
+        public void ReadCompleteFixMessages(int batchSize, int numBatches)
         {
             const string fixMsg1 = "8=FIX.4.2\x01" + "9=12\x01" + "35=A\x01" + "108=30\x01" + "10=31\x01";
             const string fixMsg2 = "8=FIX.4.2\x01" + "9=17\x01" + "35=4\x01" + "36=88\x01"  + "123=Y\x01"  + "10=34\x01";
             const string fixMsg3 = "8=FIX.4.2\x01" + "9=19\x01" + "35=A\x01" + "108=30\x01" + "9710=8\x01" + "10=31\x01";
 
             Parser parser = new Parser();
-            byte[] combined = StrToBytes(fixMsg1 + fixMsg2 + fixMsg3);
-            parser.AddToStream(combined, combined.Length);
 
-            string readFixMsg1;
-            Assert.True(parser.ReadFixMessage(out readFixMsg1));
-            Assert.AreEqual(fixMsg1, readFixMsg1);
+            for (int batchNum = 0; batchNum < numBatches; batchNum++)
+            {
+                List<string> batch = new();
 
-            string readFixMsg2;
-            Assert.True(parser.ReadFixMessage(out readFixMsg2));
-            Assert.AreEqual(fixMsg2, readFixMsg2);
+                for (int i = 0; i < batchSize; i++)
+                {
+                    string message = (i % 3) switch
+                    {
+                        0 => fixMsg1,
+                        1 => fixMsg2,
+                        _ => fixMsg3
+                    };
 
-            string readFixMsg3;
-            Assert.True(parser.ReadFixMessage(out readFixMsg3));
-            Assert.AreEqual(fixMsg3, readFixMsg3);
+                    batch.Add(message);
+                    parser.AddToStream(CharEncoding.DefaultEncoding.GetBytes(message));
+                }
+
+                for (int i = 0; i < batchSize; i++)
+                {
+                    Assert.True(parser.ReadFixMessage(out string message));
+                    Assert.AreEqual(batch[i], message);
+                }
+
+                Assert.False(parser.ReadFixMessage(out _));
+            }
         }
 
         [Test]
         public void ReadPartialFixMessage()
         {
-            string partFixMsg1 = "8=FIX.4.2\x01" + "9=17\x01" + "35=4\x01" + "36=";
-            string partFixMsg2 = "88\x01" + "123=Y\x01" + "10=34\x01";
+            List<string> messageParts = new()
+            {
+                "abcdef8", // Junk
+                "8", // No BeginString found yet
+                "=FIX.4.2", // No BodyLength tag found yet
+                '\x01' + "9=17", // No BodyLength terminating SOH found yet
+                '\x01' + "35=4", // Message smaller than BodyLength value
+                '\x01' + "36=88\x01" + "123=Y\x01" + "10", // no CheckSum tag found yet
+                "=34", // No CheckSum terminating SOH found yet
+                "\x01"
+            };
 
-            byte[] partBytes1 = CharEncoding.DefaultEncoding.GetBytes(partFixMsg1);
-            byte[] partBytes2 = CharEncoding.DefaultEncoding.GetBytes(partFixMsg2);
+            Parser parser = new();
 
-            Parser parser = new Parser();
-            string readPartFixMsg;
+            for(int i = 0; i < messageParts.Count - 1; i++)
+            {
+                parser.AddToStream(CharEncoding.DefaultEncoding.GetBytes(messageParts[i]));
+                Assert.False(parser.ReadFixMessage(out _));
+            }
 
-            parser.AddToStream(partBytes1, partBytes1.Length);
-            Assert.False(parser.ReadFixMessage(out readPartFixMsg));
+            string expectedMessage = string.Join("", messageParts.Skip(1));
 
-            parser.AddToStream(partBytes2, partBytes2.Length);
-            Assert.True(parser.ReadFixMessage(out readPartFixMsg));
-
-            Assert.AreEqual(partFixMsg1 + partFixMsg2, readPartFixMsg);
+            parser.AddToStream(CharEncoding.DefaultEncoding.GetBytes(messageParts[^1]));
+            Assert.True(parser.ReadFixMessage(out string actualMessage));
+            Assert.AreEqual(expectedMessage, actualMessage);
         }
 
         [Test]
@@ -95,13 +126,14 @@ namespace UnitTests
             byte[] fixMsg = StrToBytes("8=TEST\x01" + "9=TEST\x01" + "35=TEST\x01" + "49=SS1\x01" + "56=RORE\x01" + "34=3\x01" + "52=20050222-16:45:53\x01" + "10=TEST\x01");
 
             Parser parser = new Parser();
-            parser.AddToStream(fixMsg, fixMsg.Length);
+            parser.AddToStream(fixMsg);
+            parser.AddToStream(StrToBytes(normalLength));
 
-            string readFixMsg;
-            Assert.Throws<QuickFix.MessageParseError>(delegate { parser.ReadFixMessage(out readFixMsg); });
+            Assert.Throws<QuickFix.MessageParseError>(delegate { parser.ReadFixMessage(out _); });
             
             // nothing thrown now because the previous call removes bad data from buffer:
-            Assert.DoesNotThrow(delegate { parser.ReadFixMessage(out readFixMsg); });
+            Assert.True(parser.ReadFixMessage(out string readFixMsg));
+            Assert.AreEqual(normalLength, readFixMsg);
         }
 
         [Test]


### PR DESCRIPTION
Use `Span` and some improved buffer management to eliminate all allocations apart from the returned string (and any buffer resizes).


Before:

|        Method |       Mean |   Error |  StdDev |   Gen0 | Allocated |
|-------------- |-----------:|--------:|--------:|-------:|----------:|
|   ReadMessage |   285.3 ns | 1.14 ns | 0.95 ns | 0.3672 |     768 B |
| Read5Messages | 1,561.8 ns | 7.86 ns | 7.35 ns | 2.9984 |    6272 B |

After:

|        Method |     Mean |   Error |  StdDev |   Gen0 | Allocated |
|-------------- |---------:|--------:|--------:|-------:|----------:|
|   ReadMessage | 106.3 ns | 0.83 ns | 0.77 ns | 0.0880 |     184 B |
| Read5Messages | 539.1 ns | 4.75 ns | 4.44 ns | 0.4396 |     920 B |

``` ini

BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.22621.1413/22H2/2022Update/SunValley2)
AMD Ryzen 7 5700U with Radeon Graphics, 1 CPU, 16 logical and 8 physical cores
.NET SDK=7.0.202
  [Host]     : .NET 6.0.15 (6.0.1523.11507), X64 RyuJIT AVX2
  DefaultJob : .NET 6.0.15 (6.0.1523.11507), X64 RyuJIT AVX2

```

```csharp

[MemoryDiagnoser]
public class Benchmark
{
    private readonly Parser _parser = new();
    private readonly byte[] _messageBytes = CharEncoding.DefaultEncoding.GetBytes(
        "8=FIX.4.4\u00019=61\u000135=A\u000134=1\u000149=ISLD\u000152=00000000-00:00:00.000\u000156=TW\u000198=0\u0001108=30\u000110=0\u0001");

    [Benchmark]
    public string ReadMessage()
    {
        _parser.AddToStream(_messageBytes, _messageBytes.Length);
        _parser.ReadFixMessage(out string message);
        return message;
    }
    
    [Benchmark]
    public string Read5Messages()
    {
        for (int i = 0; i < 5; i++)
        {
            _parser.AddToStream(_messageBytes, _messageBytes.Length);
        }

        string message;

        while (_parser.ReadFixMessage(out message))
        { }

        return message;
    }
}

```

</details>