### PR TITLE
Update SocketReader::ReadSome SocketError when socket closed

### DIFF
--- a/QuickFIXn/SocketReader.cs
+++ b/QuickFIXn/SocketReader.cs
@@ -97,7 +97,7 @@ namespace QuickFix
 
                     int bytesRead = stream_.EndRead(request);
                     if (0 == bytesRead)
-                        throw new SocketException(System.Convert.ToInt32(SocketError.ConnectionReset));
+                        throw new SocketException(System.Convert.ToInt32(SocketError.Shutdown));
 
                     return bytesRead;
                 }


### PR DESCRIPTION
If 0 bytes are read it means the socket has been shutdown not reset. Had this issue in a production system reporting "Connection reset by peer" (the error message for SocketError.SocketReset), but using wireshark no RST packet was seen. 
However we did see the FIN and FIN,ACK packets which means the socket was being deliberately shutdown.  Turned out the venue had a maintenance job that shutdown the network connections.

Tldr; Setting to SocketError.Shutdown is the correct message for this scenario.