### PR TITLE
Update SocketReader::ReadSome SocketError when socket closed

### DIFF
--- a/QuickFIXn/SocketInitiatorThread.cs
+++ b/QuickFIXn/SocketInitiatorThread.cs
@@ -151,7 +151,7 @@ namespace QuickFix
 
                     int bytesRead = stream_.EndRead(request);
                     if (0 == bytesRead)
-                        throw new SocketException(System.Convert.ToInt32(SocketError.ConnectionReset));
+                        throw new SocketException(System.Convert.ToInt32(SocketError.Shutdown));
 
                     return bytesRead;
                 }

--- a/QuickFIXn/SocketReader.cs
+++ b/QuickFIXn/SocketReader.cs
@@ -94,7 +94,7 @@ namespace QuickFix
 
                     int bytesRead = _stream.EndRead(request);
                     if (0 == bytesRead)
-                        throw new SocketException(System.Convert.ToInt32(SocketError.ConnectionReset));
+                        throw new SocketException(System.Convert.ToInt32(SocketError.Shutdown));
 
                     return bytesRead;
                 }

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -44,7 +44,7 @@ What's New
 * #764 - fix positive UTC offset parsing in DateTimeConverter (Rob-Hague)
 * #766 - use ordinal string operations (Rob-Hague)
 * #767 - Avoid string conversions in FieldMap.Get{FieldType} where possible (Rob-Hague)
-
+* #785 - use correct SocketError "Shutdown" code when socket is deliberately shutdown (oclancy)
 
 ### v1.11.2:
 * same as v1.11.1, but I fixed the readme in the pushed nuget packages


### PR DESCRIPTION
Update SocketInitiatorThread::ReadSome SocketError when socket closed

If 0 bytes are read it means the socket has been shutdown not reset. Had this issue in a production system reporting "Connection reset by peer" (the error message for SocketError.SocketReset), but using wireshark no RST packet was seen. However we did see the FIN and FIN,ACK packets which means the socket was being deliberately shutdown. Turned out the venue had a maintenance job that shutdown the network connections.

Tldr; Setting to SocketError.Shutdown is the correct message for this scenario.