### PR TITLE
Improve exception handling with session logging

### DIFF
--- a/QuickFIXn/AbstractInitiator.cs
+++ b/QuickFIXn/AbstractInitiator.cs
@@ -340,6 +340,16 @@ namespace QuickFix
                 }
             }
         }
+        
+        protected string GetLogPath()
+        {
+            lock (sync_)
+            {
+                return _settings.Get().Has(SessionSettings.FILE_LOG_PATH) 
+                    ? _settings.Get().GetString(SessionSettings.FILE_LOG_PATH) 
+                    : ".";
+            }
+        }
 
         protected bool IsPending(SessionID sessionID)
         {


### PR DESCRIPTION
Refactored the way that exceptions during a disposed session are handled. Instead of writing it directly to a generic local file, it now writes it to a file located in the defined log path of the Initiator. This will make management easier and more consistent. Furthermore, the code block has been simplified, reducing its overhead.

In Addition, a method GetLogPath() was added to the AbstractInitiator class. This encapsulates the logic to fetch the log file path and allows the subclasses to reuse this method. If the FILE_LOG_PATH is not defined in session settings, a default current directory path (".") is returned.