### PR TITLE
Revert "remove AllowUnknownFieldValues support"

### DIFF
--- a/QuickFIXn/DataDictionary/DataDictionary.cs
+++ b/QuickFIXn/DataDictionary/DataDictionary.cs
@@ -24,6 +24,7 @@ namespace QuickFix.DataDictionary
         public bool CheckFieldsOutOfOrder { get; set; }
         public bool CheckFieldsHaveValues { get; set; }
         public bool CheckUserDefinedFields { get; set; }
+        public bool AllowUnknownFieldValues { get; set; }
         public bool AllowUnknownMessageFields { get; set; }
 
         public DDMap Header = new DDMap();
@@ -352,6 +353,8 @@ namespace QuickFix.DataDictionary
         /// <param name="field"></param>
         public void CheckValue(Fields.IField field)
         {
+            if (AllowUnknownFieldValues)
+                return;
             if (FieldsByTag.TryGetValue(field.Tag, out var fld))
             {
                 if (fld.HasEnums())

--- a/QuickFIXn/SessionFactory.cs
+++ b/QuickFIXn/SessionFactory.cs
@@ -184,6 +184,8 @@ namespace QuickFix
                 ddCopy.CheckFieldsHaveValues = settings.GetBool(SessionSettings.VALIDATE_FIELDS_HAVE_VALUES);
             if (settings.Has(SessionSettings.VALIDATE_USER_DEFINED_FIELDS))
                 ddCopy.CheckUserDefinedFields = settings.GetBool(SessionSettings.VALIDATE_USER_DEFINED_FIELDS);
+            if (settings.Has(SessionSettings.ALLOW_UNKNOWN_FIELD_VALUES))
+	            ddCopy.AllowUnknownFieldValues = settings.GetBool(SessionSettings.ALLOW_UNKNOWN_FIELD_VALUES);
             if (settings.Has(SessionSettings.ALLOW_UNKNOWN_MSG_FIELDS))
                 ddCopy.AllowUnknownMessageFields = settings.GetBool(SessionSettings.ALLOW_UNKNOWN_MSG_FIELDS);
 

--- a/QuickFIXn/SessionSettings.cs
+++ b/QuickFIXn/SessionSettings.cs
@@ -46,6 +46,7 @@ namespace QuickFix
         public const string VALIDATE_FIELDS_HAVE_VALUES = "ValidateFieldsHaveValues";
         public const string VALIDATE_USER_DEFINED_FIELDS = "ValidateUserDefinedFields";
         public const string VALIDATE_LENGTH_AND_CHECKSUM = "ValidateLengthAndChecksum";
+        public const string ALLOW_UNKNOWN_FIELD_VALUES = "AllowUnknownFieldValues";
         public const string ALLOW_UNKNOWN_MSG_FIELDS = "AllowUnknownMsgFields";
         public const string DATA_DICTIONARY = "DataDictionary";
         public const string TRANSPORT_DATA_DICTIONARY = "TransportDataDictionary";


### PR DESCRIPTION
This PR serves the same purpose as https://github.com/connamara/quickfixn/pull/646 and brings back the functionality implemented in https://github.com/connamara/quickfixn/pull/543.

I fully agree with all the commenters that it is very important to be able to disable various dictionary checks, including enum value validation.

IMO, naming is better in #543 and better matches the `AllowUnknownMessageFields` setting.

This was a long time ago, so I think it's a good idea to revisit this :)
https://github.com/connamara/quickfixn/pull/646#issuecomment-680299264:
> the submitters "appealed" to me, then I said that I'd consider it, then... I forgot about it. (Sorry guys!)
> I will take another look later this week.

---

This reverts commit 24bb28c89e28048fe3a8b260bcf7c75ba56879d9.
```
# Conflicts:
#	QuickFIXn/DataDictionary/DataDictionary.cs
```