### PR TITLE
get rid of IOIQty enums in FIX5 DDs, allow free string

### DIFF
--- a/QuickFIXn/Fields/Fields.cs
+++ b/QuickFIXn/Fields/Fields.cs
@@ -7900,13 +7900,6 @@ namespace QuickFix.Fields
         public IOIQty(string val)
             :base(Tags.IOIQty, val) {}
 
-
-        // Field Enumerations
-        public const string VAL_1000000000 = "0";
-        public const string SMALL = "S";
-        public const string MEDIUM = "M";
-        public const string LARGE = "L";
-        public const string UNDISCLOSED_QUANTITY = "U";
     }
 
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -57,6 +57,7 @@ What's New
 * #767 - avoid string conversions in FieldMap.Get{FieldType} where possible (Rob-Hague)
 * #785 - use correct SocketError "Shutdown" code when socket is deliberately shutdown (oclancy)
 * #711 - fix explicit 0.0.0.0 address binding (bohdanstefaniuk)
+* #823 - get rid of IOIQty enums in FIX5 DDs, allow free string (gbirchmeier)
 
 ### v1.11.2:
 * same as v1.11.1, but I fixed the readme in the pushed nuget packages

--- a/spec/fix/FIX50.xml
+++ b/spec/fix/FIX50.xml
@@ -4560,13 +4560,7 @@
    <value enum='M' description='MEDIUM' />
   </field>
   <field number='26' name='IOIRefID' type='STRING' />
-  <field number='27' name='IOIQty' type='STRING'>
-   <value enum='0' description='1000000000' />
-   <value enum='S' description='SMALL' />
-   <value enum='M' description='MEDIUM' />
-   <value enum='L' description='LARGE' />
-   <value enum='U' description='UNDISCLOSED_QUANTITY' />
-  </field>
+  <field number='27' name='IOIQty' type='STRING' />
   <field number='28' name='IOITransType' type='CHAR'>
    <value enum='C' description='CANCEL' />
    <value enum='N' description='NEW' />

--- a/spec/fix/FIX50SP1.xml
+++ b/spec/fix/FIX50SP1.xml
@@ -5295,13 +5295,7 @@
    <value enum='M' description='MEDIUM' />
   </field>
   <field number='26' name='IOIRefID' type='STRING' />
-  <field number='27' name='IOIQty' type='STRING'>
-   <value enum='0' description='1000000000' />
-   <value enum='S' description='SMALL' />
-   <value enum='M' description='MEDIUM' />
-   <value enum='L' description='LARGE' />
-   <value enum='U' description='UNDISCLOSED_QUANTITY' />
-  </field>
+  <field number='27' name='IOIQty' type='STRING' />
   <field number='28' name='IOITransType' type='CHAR'>
    <value enum='C' description='CANCEL' />
    <value enum='N' description='NEW' />

--- a/spec/fix/FIX50SP2.xml
+++ b/spec/fix/FIX50SP2.xml
@@ -5755,13 +5755,7 @@
    <value enum='M' description='MEDIUM' />
   </field>
   <field number='26' name='IOIRefID' type='STRING' />
-  <field number='27' name='IOIQty' type='STRING'>
-   <value enum='0' description='1000000000' />
-   <value enum='S' description='SMALL' />
-   <value enum='M' description='MEDIUM' />
-   <value enum='L' description='LARGE' />
-   <value enum='U' description='UNDISCLOSED_QUANTITY' />
-  </field>
+  <field number='27' name='IOIQty' type='STRING' />
   <field number='28' name='IOITransType' type='CHAR'>
    <value enum='C' description='CANCEL' />
    <value enum='N' description='NEW' />


### PR DESCRIPTION
see discussion in #823

resolves #823 