### PR TITLE
(rebase #782) Proper handling of length defined data fields

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -66,6 +66,7 @@ What's New
 * #697 - new SocketIgnoreProxy setting (ABSJ415)
 * #740 - Capture inner exception messages when handling authentication exceptions (rars)
 * #833 - Add Try/Catch logic to SocketInitiator.OnStart() (Falcz)
+* #782 - proper handling of XmlData field (larsope)
 
 ### v1.11.2:
 * same as v1.11.1, but I fixed the readme in the pushed nuget packages


### PR DESCRIPTION
See pr #782 for original discussion

attn @larsope @dominicpalmer @michal-ciechan @jpetrucciani -- (people wrote/commented/liked the previous PR) -- I rebased that fix into the current version, please have a quick look and let me know if you have any comments.

Note: I moved the UT from DataDictionaryTests.cs to MessageTests.cs (the behavior being tested is a Message function, not a DD function), and added a new UT to clarify what happens if 212/XmlDataLen isn't present.