### PR TITLE
Fix unobserved SocketException (rebase of PR 771, which addresses Issue 770)

### DIFF
--- a/QuickFIXn/Transport/SocketInitiator.cs
+++ b/QuickFIXn/Transport/SocketInitiator.cs
@@ -21,8 +21,6 @@ namespace QuickFix.Transport
         public const string SOCKET_CONNECT_PORT = "SocketConnectPort";
         public const string RECONNECT_INTERVAL  = "ReconnectInterval";
 
-        #region Private Members
-
         private volatile bool _shutdownRequested = false;
         private DateTime _lastConnectTimeDt = DateTime.MinValue;
         private int _reconnectInterval = 30;
@@ -31,8 +29,6 @@ namespace QuickFix.Transport
         private readonly Dictionary<SessionID, int> _sessionToHostNum = new();
         private readonly object _sync = new();
         
-        #endregion
-
         public SocketInitiator(
             IApplication application,
             IMessageStoreFactory storeFactory,
@@ -42,7 +38,7 @@ namespace QuickFix.Transport
             : base(application, storeFactory, settings, logFactoryNullable, messageFactoryNullable)
         { }
 
-        public static void SocketInitiatorThreadStart(object socketInitiatorThread)
+        public static void SocketInitiatorThreadStart(object? socketInitiatorThread)
         {
             SocketInitiatorThread? t = socketInitiatorThread as SocketInitiatorThread;
             if (t == null) return;

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -73,6 +73,10 @@ What's New
 * #740 - Capture inner exception messages when handling authentication exceptions (rars)
 * #833 - Add Try/Catch logic to SocketInitiator.OnStart() (Falcz)
 * #782 - proper handling of XmlData field (larsope)
+* #770 - fix unobserved SocketException
+    * Perform socket read operations according to Task-based asynchronous pattern (TAP) instead of Asynchronous
+      Programming Model (APM), in order to catch unobserved SocketExceptions (nmandzyk)
+    * Cleanup/nullable-ize SocketInitiatorThread (gbirchmeier)
 
 ### v1.11.2:
 * same as v1.11.1, but I fixed the readme in the pushed nuget packages


### PR DESCRIPTION
resolves #770 (original issue)
resolves #771 (original PR, this is a rebase)

Perform socket read operations according to Task-based asynchronous pattern (TAP) instead of Asynchronous Programming Model (APM)