### PR TITLE
ScreenLog adjustments

### DIFF
--- a/Examples/TradeClient/tradeclient.cfg
+++ b/Examples/TradeClient/tradeclient.cfg
@@ -14,6 +14,10 @@ LogoutTimeout=5
 ResetOnLogon=Y
 ResetOnDisconnect=Y
 
+ScreenLogShowIncoming=Y
+ScreenLogShowOutgoing=Y
+ScreenLogShowEvents=Y
+
 [SESSION]
 # inherit ConnectionType, ReconnectInterval and SenderCompID from default
 BeginString=FIX.4.4

--- a/QuickFIXn/Logger/ScreenLog.cs
+++ b/QuickFIXn/Logger/ScreenLog.cs
@@ -31,7 +31,7 @@ public class ScreenLog : ILog
 
         lock (_sync)
         {
-            System.Console.WriteLine("<incoming> " + msg);
+            System.Console.WriteLine("<incoming> " + msg.Replace(Message.SOH, '|'));
         }
     }
 
@@ -42,7 +42,7 @@ public class ScreenLog : ILog
 
         lock (_sync)
         {
-            System.Console.WriteLine("<outgoing> " + msg);
+            System.Console.WriteLine("<outgoing> " + msg.Replace(Message.SOH, '|'));
         }
     }
 

--- a/QuickFIXn/Logger/ScreenLogFactory.cs
+++ b/QuickFIXn/Logger/ScreenLogFactory.cs
@@ -10,27 +10,38 @@ public class ScreenLogFactory : ILogFactory
 
     private readonly SessionSettings _settings;
 
+    private readonly bool _logIncoming = false;
+    private readonly bool _logOutgoing = false;
+    private readonly bool _logEvent = false;
+
     public ScreenLogFactory(SessionSettings settings)
     {
         _settings = settings;
     }
 
+    public ScreenLogFactory(bool logIncoming, bool logOutgoing, bool logEvent)
+    {
+        _logIncoming = logIncoming;
+        _logOutgoing = logOutgoing;
+        _logEvent    = logEvent;
+
+        _settings = new SessionSettings();
+    }
+
     #region LogFactory Members
 
     public ILog Create(SessionID sessionId) {
-        bool logIncoming = false;
-        bool logOutgoing = false;
-        bool logEvent = false;
+        bool logIncoming = _logIncoming;
+        bool logOutgoing = _logOutgoing;
+        bool logEvent = _logEvent;
 
         if(_settings.Has(sessionId))
         {
             SettingsDictionary dict = _settings.Get(sessionId);
-            if (dict.Has(SCREEN_LOG_SHOW_INCOMING))
-                logIncoming = dict.GetBool(SCREEN_LOG_SHOW_INCOMING);
-            if (dict.Has(SCREEN_LOG_SHOW_OUTGOING))
-                logOutgoing = dict.GetBool(SCREEN_LOG_SHOW_OUTGOING);
-            if (dict.Has(SCREEN_LOG_SHOW_EVENTS))
-                logEvent = dict.GetBool(SCREEN_LOG_SHOW_EVENTS);
+
+            logIncoming = _logIncoming || dict.IsBoolPresentAndTrue(SCREEN_LOG_SHOW_INCOMING);
+            logOutgoing = _logOutgoing || dict.IsBoolPresentAndTrue(SCREEN_LOG_SHOW_OUTGOING);
+            logEvent = _logEvent || dict.IsBoolPresentAndTrue(SCREEN_LOG_SHOW_EVENTS);
         }
 
         return new ScreenLog(logIncoming, logOutgoing, logEvent);

--- a/QuickFIXn/SettingsDictionary.cs
+++ b/QuickFIXn/SettingsDictionary.cs
@@ -141,6 +141,15 @@ public class SettingsDictionary : System.Collections.IEnumerable
         }
     }
 
+    /// <summary>
+    /// Return true if key is present AND value is true, else false
+    /// </summary>
+    /// <param name="key"></param>
+    /// <returns></returns>
+    public bool IsBoolPresentAndTrue(string key) {
+        return Has(key) && GetBool(key);
+    }
+
     public DayOfWeek GetDay(string key) {
         string abbr = GetString(key).Substring(0, 2).ToUpperInvariant();
         return abbr switch

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -49,7 +49,7 @@ What's New
      * Move all store classes to new QuickFix.Store namespace
      * FileLog: remove the single-param ctor, no reason for anyone to use it
      * ScreenLog ctor: removed unused sessionId param
-     * ScreenLogFactory: remove public vars and a ctor that no one should be using
+     * ScreenLogFactory: remove unused public vars
 * #708 - In FIX50, rename field SecurityStat to SecurityStatus, to match SP1 and SP2 (gbirchmeier)
 * #639 - address Dictionary ctor bug, then cleanup/nullable-ize (gbirchmeier)
      * rename to SettingsDictionary to reduce name confusion with System.Collections.Generic.Dictionary
@@ -77,6 +77,7 @@ What's New
     * Perform socket read operations according to Task-based asynchronous pattern (TAP) instead of Asynchronous
       Programming Model (APM), in order to catch unobserved SocketExceptions (nmandzyk)
     * Cleanup/nullable-ize SocketInitiatorThread (gbirchmeier)
+* #839 - change ScreenLog to output FIX messages with "|" instead of non-visible SOH (gbirchmeier)
 
 ### v1.11.2:
 * same as v1.11.1, but I fixed the readme in the pushed nuget packages

--- a/UnitTests/SettingsDictionaryTests.cs
+++ b/UnitTests/SettingsDictionaryTests.cs
@@ -85,6 +85,16 @@ public class SettingsDictionaryTests
     }
 
     [Test]
+    public void IsBoolPresentAndTrue() {
+        SettingsDictionary d = new();
+        d.SetBool("BOOLKEY-T", true);
+        d.SetBool("BOOLKEY-F", false);
+        Assert.IsTrue(d.IsBoolPresentAndTrue("BOOLKEY-T"));
+        Assert.IsFalse(d.IsBoolPresentAndTrue("BOOLKEY-F"));
+        Assert.IsFalse(d.IsBoolPresentAndTrue("nonexistent key"));
+    }
+
+    [Test]
     public void SetGetDay()
     {
         SettingsDictionary d = new();


### PR DESCRIPTION
* restore ScreenLogFactory three-bool constructor (was removed in #831, but I changed my mind)
* screen log output now replaces NUL with "|"
* new SettingsDictionary::IsBoolPresentAndTrue() function
* added ScreenLog settings to tradeclient config