### PR TITLE
stop capitalizing TimestampPrecision wrong

### DIFF
--- a/QuickFIXn/SessionFactory.cs
+++ b/QuickFIXn/SessionFactory.cs
@@ -114,7 +114,7 @@ namespace QuickFix
 
             if (settings.Has("MillisecondsInTimeStamp")) {
                 throw new ApplicationException(
-                    "Setting 'MillisecondsInTimeStamp' was removed.  Use 'TimeStampPrecision=Milliseconds' instead.");
+                    "Setting 'MillisecondsInTimeStamp' was removed.  Use 'TimestampPrecision=Milliseconds' instead.");
             }
 
             if (settings.Has(SessionSettings.SEND_REDUNDANT_RESENDREQUESTS))

--- a/QuickFIXn/SessionSettings.cs
+++ b/QuickFIXn/SessionSettings.cs
@@ -55,7 +55,7 @@ namespace QuickFix
         public const string LOGOUT_TIMEOUT = "LogoutTimeout";
         public const string SEND_REDUNDANT_RESENDREQUESTS = "SendRedundantResendRequests";
         public const string RESEND_SESSION_LEVEL_REJECTS = "ResendSessionLevelRejects";
-        public const string TIMESTAMP_PRECISION = "TimeStampPrecision";
+        public const string TIMESTAMP_PRECISION = "TimestampPrecision";
         public const string ENABLE_LAST_MSG_SEQ_NUM_PROCESSED = "EnableLastMsgSeqNumProcessed";
         public const string MAX_MESSAGES_IN_RESEND_REQUEST = "MaxMessagesInResendRequest";
         public const string SEND_LOGOUT_BEFORE_TIMEOUT_DISCONNECT = "SendLogoutBeforeDisconnectFromTimeout";

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -59,7 +59,7 @@ What's New
 * #842 - Fix nano-datetime-to-string bug (gbirchmeier)
      * Also refactor the heck out of DateTimeConverter & tests: many functions renamed/deprecated
 * #847 - remove setting MillisecondsInTimeStamp (gbirchmeier)
-     * Use TimeStampPrecision instead (same as QF/j)
+     * Use TimestampPrecision instead (same as QF/j)
 
 **Non-breaking changes**
 * #400 - added DDTool, a C#-based codegen, and deleted Ruby-based generator (gbirchmeier)


### PR DESCRIPTION
it's not "TimeStamp", argh

I'm only fixing it in messages and docs.
I'm not going to change var/constant names
right now even though I kind of want to.

addendum to issue #847, pr #851