### PR TITLE
fix DefaultMessageFactory thread-race issue

### DIFF
--- a/QuickFIXn/DefaultMessageFactory.cs
+++ b/QuickFIXn/DefaultMessageFactory.cs
@@ -121,9 +121,6 @@ namespace QuickFix
 
         private static void LoadLocalDlls()
         {
-            if (_dllsAreLoaded)
-                return;
-
             lock (_dllLoadSync)
             {
                 // check again in case the load happened while this thread was waiting for the lock

--- a/QuickFIXn/DefaultMessageFactory.cs
+++ b/QuickFIXn/DefaultMessageFactory.cs
@@ -1,9 +1,9 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Threading;
 using QuickFix.Fields;
 
 namespace QuickFix
@@ -18,7 +18,7 @@ namespace QuickFix
         /// </summary>
         private readonly IReadOnlyDictionary<string, IMessageFactory> _factories;
 
-        private QuickFix.Fields.ApplVerID _defaultApplVerId;
+        private readonly QuickFix.Fields.ApplVerID _defaultApplVerId;
         
         /// <summary>
         /// This constructor will
@@ -41,8 +41,10 @@ namespace QuickFix
         /// 2. Use them based on begin strings they support
         /// </summary>
         /// <param name="assemblies">Assemblies that may contain IMessageFactory implementations</param>
-        public DefaultMessageFactory(IEnumerable<Assembly> assemblies)
+        /// <param name="defaultApplVerId">ApplVerID value used by default in Create methods that don't explicitly specify it (only relevant for FIX5+)</param>
+        public DefaultMessageFactory(IEnumerable<Assembly> assemblies, string defaultApplVerId = QuickFix.FixValues.ApplVerID.FIX50SP2)
         {
+            _defaultApplVerId = new ApplVerID(defaultApplVerId);
             var factories = GetMessageFactories(assemblies);
             _factories = ConvertToDictionary(factories);
         }
@@ -59,21 +61,19 @@ namespace QuickFix
             return Create(beginString, _defaultApplVerId, msgType);
         }
 
-        public Message Create(string beginString, QuickFix.Fields.ApplVerID applVerID, string msgType)
+        public Message Create(string beginString, QuickFix.Fields.ApplVerID applVerId, string msgType)
         {
-            _factories.TryGetValue(beginString, out IMessageFactory messageFactory);
+            _factories.TryGetValue(beginString, out IMessageFactory? messageFactory);
 
             if (beginString == QuickFix.Values.BeginString_FIXT11 && !Message.IsAdminMsgType(msgType))
             {
-                if (applVerID == null)
-                    applVerID = _defaultApplVerId;
                 _factories.TryGetValue(
-                    QuickFix.FixValues.ApplVerID.ToBeginString(applVerID.Obj),
+                    QuickFix.FixValues.ApplVerID.ToBeginString(applVerId.Obj),
                     out messageFactory);
             }
 
             if (messageFactory != null)
-                return messageFactory.Create(beginString, applVerID, msgType);
+                return messageFactory.Create(beginString, applVerId, msgType);
 
             // didn't find a factory, so return a generic Message object
             var message = new Message();
@@ -85,24 +85,23 @@ namespace QuickFix
         {
             string key = beginString;
             if(beginString.Equals(FixValues.BeginString.FIXT11))
-            {
                 key = QuickFix.FixValues.ApplVerID.ToBeginString(_defaultApplVerId.getValue());
-            }
 
-            if (_factories.TryGetValue(key, out var factory))
-            {
+            if (_factories.TryGetValue(key, out IMessageFactory? factory))
                 return factory.Create(beginString, msgType, groupCounterTag);
-            }
-            else
-            {
-                throw new UnsupportedVersion(beginString);
-            }
+
+            throw new UnsupportedVersion(beginString);
         }
 
         #endregion
 
         #region Dynamic assembly load related methods
 
+        /// <summary>
+        /// Creates a dictionary keyed by each IMessageFactory's supported BeginStrings
+        /// </summary>
+        /// <param name="factories"></param>
+        /// <returns></returns>
         private static Dictionary<string, IMessageFactory> ConvertToDictionary(IEnumerable<IMessageFactory> factories)
         {
             var dict = new Dictionary<string, IMessageFactory>();
@@ -118,7 +117,7 @@ namespace QuickFix
         }
 
         private static bool _dllsAreLoaded = false;
-        private static object _dllLoadSync = new object();
+        private static readonly object _dllLoadSync = new object();
 
         private static void LoadLocalDlls()
         {
@@ -135,21 +134,15 @@ namespace QuickFix
                 {
                     var assemblyLocation = Assembly.GetExecutingAssembly().Location;
                     if (String.IsNullOrWhiteSpace(assemblyLocation))
-                    {
                         return;
-                    }
 
                     var directory = Path.GetDirectoryName(assemblyLocation);
                     if (String.IsNullOrWhiteSpace(directory))
-                    {
                         return;
-                    }
 
                     var dlls = Directory.GetFiles(directory, "QuickFix.*.dll");
                     foreach (var path in dlls)
-                    {
                         Assembly.LoadFrom(path);
-                    }
 
                     _dllsAreLoaded = true;
                 }
@@ -170,7 +163,7 @@ namespace QuickFix
             var factories = new List<IMessageFactory>();
             foreach (var factoryType in factoryTypes)
             {
-                var factory = (IMessageFactory)Activator.CreateInstance(factoryType);
+                var factory = (IMessageFactory)Activator.CreateInstance(factoryType)!;
                 factories.Add(factory);
             }
 
@@ -183,7 +176,7 @@ namespace QuickFix
             var assemblies = AppDomain
                 .CurrentDomain
                 .GetAssemblies()
-                .Where(assembly => !assembly.IsDynamic && assembly.GetName().Name.StartsWith("QuickFix", StringComparison.Ordinal))
+                .Where(assembly => !assembly.IsDynamic && assembly.GetName().Name!.StartsWith("QuickFix", StringComparison.Ordinal))
                 .ToList();
             return assemblies;
         }

--- a/QuickFIXn/IMessageFactory.cs
+++ b/QuickFIXn/IMessageFactory.cs
@@ -14,7 +14,9 @@ namespace QuickFix
         ICollection<string> GetSupportedBeginStrings();
         
         /// <summary>
-        /// Creates a message for a specified type and FIX version
+        /// Creates a message for a specified type and FIX version.
+        /// (FIXT11 apps should use the other Create method with explicit applVerId,
+        /// or devise some other way of specifying the FIX version)
         /// </summary>
         /// <param name="beginString">the FIX version (e.g. "FIX.4.2")</param>
         /// <param name="msgType">the FIX message type (e.g. "D" for a NewOrderSingle)</param>
@@ -25,7 +27,7 @@ namespace QuickFix
         /// Creates a message for a specified type, FIX version, and ApplVerID
         /// </summary>
         /// <param name="beginString">the FIX version (e.g. "FIX.4.2")</param>
-        /// <param name="applVerId">the ApplVerID (for example "6" for FIX44)</param>
+        /// <param name="applVerId">the ApplVerID to use if the BeginString is not specific enough (e.g. if it's FIXT11)</param>
         /// <param name="msgType">the FIX message type (e.g. "D" for a NewOrderSingle)</param>
         /// <returns>a message instance of proper derived type</returns>
         Message Create(string beginString, QuickFix.Fields.ApplVerID applVerId, string msgType);

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -89,6 +89,10 @@ What's New
 * #839 - change ScreenLog to output FIX messages with "|" instead of non-visible SOH (gbirchmeier)
 * #844 - implement "Weekdays" setting (MichalUssuri/gbirchmeier)
 * #859 - implement proper path searching for CA certs in config (gbirchmeier)
+* #864 - when multiple threads race to init DefaultMessageFactory,
+         fix it so that later threads do not return before the first thread
+         finishes loading all the dlls (gbirchmeier, with thanks to diagnosis by Brian Leach aka baffled)
+         (Note: this may be the cause of spurious "incorrect BeginString" issues that have been observed)
 
 ### v1.11.2:
 * same as v1.11.1, but I fixed the readme in the pushed nuget packages


### PR DESCRIPTION
When multiple threads race to init `DefaultMessageFactory`, fix it so that later threads do not return before the first thread finishes loading all the dlls.

resolves #864 

attn @baffled 