### PR TITLE
[Rebase #870 + more] Update target to net 8.0 + Replace deprecated US timezone (issue #883)

### DIFF
--- a/AcceptanceTest/AcceptanceTest.csproj
+++ b/AcceptanceTest/AcceptanceTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <Nullable>enable</Nullable>

--- a/DDTool/DDTool/DDTool.csproj
+++ b/DDTool/DDTool/DDTool.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/DDTool/UnitTests/UnitTests.csproj
+++ b/DDTool/UnitTests/UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Examples/Executor/Examples.Executor.csproj
+++ b/Examples/Executor/Examples.Executor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Executor</RootNamespace>
     <AssemblyName>Executor</AssemblyName>
     <Copyright>Copyright © Connamara Systems, LLC 2011</Copyright>

--- a/Examples/FixToJson/Examples.FixToJson.csproj
+++ b/Examples/FixToJson/Examples.FixToJson.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <Copyright>Copyright © Connamara Systems, LLC 2022</Copyright>
     <Company>Connamara Systems, LLC</Company>

--- a/Examples/JsonToFix/Examples.JsonToFix.csproj
+++ b/Examples/JsonToFix/Examples.JsonToFix.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <Copyright>Copyright © Connamara Systems, LLC 2022</Copyright>
     <Company>Connamara Systems, LLC</Company>

--- a/Examples/SimpleAcceptor/Examples.SimpleAcceptor.csproj
+++ b/Examples/SimpleAcceptor/Examples.SimpleAcceptor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>SimpleAcceptor</RootNamespace>
     <AssemblyName>SimpleAcceptor</AssemblyName>
     <Copyright>Copyright © Connamara Systems, LLC 2011</Copyright>

--- a/Examples/Standalone/SerilogLog/SerilogLog.csproj
+++ b/Examples/Standalone/SerilogLog/SerilogLog.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Examples/Standalone/SerilogLog/UnitTests/UnitTests.csproj
+++ b/Examples/Standalone/SerilogLog/UnitTests/UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Examples/Standalone/SerilogLog/UnitTests/UnitTests.csproj
+++ b/Examples/Standalone/SerilogLog/UnitTests/UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Examples/TradeClient/Examples.TradeClient.csproj
+++ b/Examples/TradeClient/Examples.TradeClient.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>TradeClient</RootNamespace>
     <AssemblyName>TradeClient</AssemblyName>
     <Copyright>Copyright © Connamara Systems, LLC 2011</Copyright>

--- a/Messages/FIX40/QuickFix.FIX40.csproj
+++ b/Messages/FIX40/QuickFix.FIX40.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <GenerateAppxPackageOnBuild>true</GenerateAppxPackageOnBuild>
     <Title>QuickFIX/n FIX4.0 Messages</Title>
     <PackageId>QuickFIXn.FIX4.0</PackageId>

--- a/Messages/FIX40/QuickFix.FIX40.csproj
+++ b/Messages/FIX40/QuickFix.FIX40.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateAppxPackageOnBuild>true</GenerateAppxPackageOnBuild>
     <Title>QuickFIX/n FIX4.0 Messages</Title>
     <PackageId>QuickFIXn.FIX4.0</PackageId>

--- a/Messages/FIX41/QuickFix.FIX41.csproj
+++ b/Messages/FIX41/QuickFix.FIX41.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <GenerateAppxPackageOnBuild>true</GenerateAppxPackageOnBuild>
     <Title>QuickFIX/n FIX4.1 Messages</Title>
     <PackageId>QuickFIXn.FIX4.1</PackageId>

--- a/Messages/FIX41/QuickFix.FIX41.csproj
+++ b/Messages/FIX41/QuickFix.FIX41.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateAppxPackageOnBuild>true</GenerateAppxPackageOnBuild>
     <Title>QuickFIX/n FIX4.1 Messages</Title>
     <PackageId>QuickFIXn.FIX4.1</PackageId>

--- a/Messages/FIX42/QuickFix.FIX42.csproj
+++ b/Messages/FIX42/QuickFix.FIX42.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <GenerateAppxPackageOnBuild>true</GenerateAppxPackageOnBuild>
     <Title>QuickFIX/n FIX4.2 Messages</Title>
     <PackageId>QuickFIXn.FIX4.2</PackageId>

--- a/Messages/FIX42/QuickFix.FIX42.csproj
+++ b/Messages/FIX42/QuickFix.FIX42.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateAppxPackageOnBuild>true</GenerateAppxPackageOnBuild>
     <Title>QuickFIX/n FIX4.2 Messages</Title>
     <PackageId>QuickFIXn.FIX4.2</PackageId>

--- a/Messages/FIX43/QuickFix.FIX43.csproj
+++ b/Messages/FIX43/QuickFix.FIX43.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <GenerateAppxPackageOnBuild>true</GenerateAppxPackageOnBuild>
     <Title>QuickFIX/n FIX4.3 Messages</Title>
     <PackageId>QuickFIXn.FIX4.3</PackageId>

--- a/Messages/FIX43/QuickFix.FIX43.csproj
+++ b/Messages/FIX43/QuickFix.FIX43.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateAppxPackageOnBuild>true</GenerateAppxPackageOnBuild>
     <Title>QuickFIX/n FIX4.3 Messages</Title>
     <PackageId>QuickFIXn.FIX4.3</PackageId>

--- a/Messages/FIX44/QuickFix.FIX44.csproj
+++ b/Messages/FIX44/QuickFix.FIX44.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateAppxPackageOnBuild>true</GenerateAppxPackageOnBuild>
     <Title>QuickFIX/n FIX4.4 Messages</Title>
     <PackageId>QuickFIXn.FIX4.4</PackageId>

--- a/Messages/FIX44/QuickFix.FIX44.csproj
+++ b/Messages/FIX44/QuickFix.FIX44.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <GenerateAppxPackageOnBuild>true</GenerateAppxPackageOnBuild>
     <Title>QuickFIX/n FIX4.4 Messages</Title>
     <PackageId>QuickFIXn.FIX4.4</PackageId>

--- a/Messages/FIX50/QuickFix.FIX50.csproj
+++ b/Messages/FIX50/QuickFix.FIX50.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <GenerateAppxPackageOnBuild>true</GenerateAppxPackageOnBuild>
     <Title>QuickFIX/n FIX5.0 Messages</Title>
     <PackageId>QuickFIXn.FIX5.0</PackageId>

--- a/Messages/FIX50/QuickFix.FIX50.csproj
+++ b/Messages/FIX50/QuickFix.FIX50.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateAppxPackageOnBuild>true</GenerateAppxPackageOnBuild>
     <Title>QuickFIX/n FIX5.0 Messages</Title>
     <PackageId>QuickFIXn.FIX5.0</PackageId>

--- a/Messages/FIX50SP1/QuickFix.FIX50SP1.csproj
+++ b/Messages/FIX50SP1/QuickFix.FIX50SP1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateAppxPackageOnBuild>true</GenerateAppxPackageOnBuild>
     <Title>QuickFIX/n FIX5.0 SP1 Messages</Title>
     <PackageId>QuickFIXn.FIX5.0SP1</PackageId>

--- a/Messages/FIX50SP1/QuickFix.FIX50SP1.csproj
+++ b/Messages/FIX50SP1/QuickFix.FIX50SP1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <GenerateAppxPackageOnBuild>true</GenerateAppxPackageOnBuild>
     <Title>QuickFIX/n FIX5.0 SP1 Messages</Title>
     <PackageId>QuickFIXn.FIX5.0SP1</PackageId>

--- a/Messages/FIX50SP2/QuickFix.FIX50SP2.csproj
+++ b/Messages/FIX50SP2/QuickFix.FIX50SP2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateAppxPackageOnBuild>true</GenerateAppxPackageOnBuild>
     <Title>QuickFIX/n FIX5.0 SP2 Messages</Title>
     <PackageId>QuickFIXn.FIX5.0SP2</PackageId>

--- a/Messages/FIX50SP2/QuickFix.FIX50SP2.csproj
+++ b/Messages/FIX50SP2/QuickFix.FIX50SP2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <GenerateAppxPackageOnBuild>true</GenerateAppxPackageOnBuild>
     <Title>QuickFIX/n FIX5.0 SP2 Messages</Title>
     <PackageId>QuickFIXn.FIX5.0SP2</PackageId>

--- a/Messages/FIXT11/QuickFix.FIXT11.csproj
+++ b/Messages/FIXT11/QuickFix.FIXT11.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <GenerateAppxPackageOnBuild>true</GenerateAppxPackageOnBuild>
     <Title>QuickFIX/n FIXT1.1 Messages</Title>
     <PackageId>QuickFIXn.FIXT1.1</PackageId>

--- a/Messages/FIXT11/QuickFix.FIXT11.csproj
+++ b/Messages/FIXT11/QuickFix.FIXT11.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateAppxPackageOnBuild>true</GenerateAppxPackageOnBuild>
     <Title>QuickFIX/n FIXT1.1 Messages</Title>
     <PackageId>QuickFIXn.FIXT1.1</PackageId>

--- a/QuickFIXn/DataDictionary/DictionaryParseException.cs
+++ b/QuickFIXn/DataDictionary/DictionaryParseException.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace QuickFix
 {
@@ -12,9 +9,5 @@ namespace QuickFix
             : base(message) { }
         public DictionaryParseException(string message, System.Exception inner)
             : base(message, inner) { }
-        protected DictionaryParseException(
-            System.Runtime.Serialization.SerializationInfo info,
-            System.Runtime.Serialization.StreamingContext context)
-            : base(info, context) { }
     }
 }

--- a/QuickFIXn/DataDictionary/InvalidMessageTypeException.cs
+++ b/QuickFIXn/DataDictionary/InvalidMessageTypeException.cs
@@ -1,20 +1,19 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace QuickFix
 {
+    [Obsolete("This class will be removed in a future release (because it's unused)")]
     public class InvalidMessageTypeException : ApplicationException
     {
+        [Obsolete("This class will be removed in a future release (because it's unused)")]
         public InvalidMessageTypeException() { }
+
+        [Obsolete("This class will be removed in a future release (because it's unused)")]
         public InvalidMessageTypeException(string message)
             : base(message) { }
+
+        [Obsolete("This class will be removed in a future release (because it's unused)")]
         public InvalidMessageTypeException(string message, System.Exception inner)
             : base(message, inner) { }
-        protected InvalidMessageTypeException(
-            System.Runtime.Serialization.SerializationInfo info,
-            System.Runtime.Serialization.StreamingContext context)
-            : base(info, context) { }
     }
 }

--- a/QuickFIXn/DataDictionary/MissingRequiredFieldException.cs
+++ b/QuickFIXn/DataDictionary/MissingRequiredFieldException.cs
@@ -7,18 +7,22 @@ using System.Text;
 
 namespace QuickFix
 {
+    [Obsolete("This class will be removed in a future release (because it's unused)")]
     public sealed class MissingRequiredFieldException : ApplicationException
     {
+        [Obsolete("This class will be removed in a future release (because it's unused)")]
         public MissingRequiredFieldException() { }
+
+        [Obsolete("This class will be removed in a future release (because it's unused)")]
         public MissingRequiredFieldException(int field)
             : base("Missing required field: " + field.ToString()) { }
+
+        [Obsolete("This class will be removed in a future release (because it's unused)")]
         public MissingRequiredFieldException(string message)
             : base(message) { }
+
+        [Obsolete("This class will be removed in a future release (because it's unused)")]
         public MissingRequiredFieldException(string message, System.Exception inner)
             : base(message, inner) { }
-        protected MissingRequiredFieldException(
-            System.Runtime.Serialization.SerializationInfo info,
-            System.Runtime.Serialization.StreamingContext context)
-            : base(info, context) { }
     }
 }

--- a/QuickFIXn/Exceptions.cs
+++ b/QuickFIXn/Exceptions.cs
@@ -1,5 +1,4 @@
-﻿
-using System;
+﻿using System;
 
 namespace QuickFix
 {
@@ -15,10 +14,6 @@ namespace QuickFix
 
         public QuickFIXException(string msg, System.Exception innerException)
             : base(msg, innerException)
-        { }
-
-        public QuickFIXException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
-            : base(info, context)
         { }
     }
 
@@ -108,10 +103,6 @@ namespace QuickFix
 
         public InvalidMessage(string msg, System.Exception innerException)
             : base("Invalid message: " + msg, innerException)
-        { }
-
-        public InvalidMessage(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
-            : base(info, context)
         { }
     }
 

--- a/QuickFIXn/Message/FieldNotFoundException.cs
+++ b/QuickFIXn/Message/FieldNotFoundException.cs
@@ -24,11 +24,5 @@ namespace QuickFix
         public FieldNotFoundException(string message, System.Exception inner)
             : base(message, inner)
         { Field = -1; }
-
-        protected FieldNotFoundException(
-            System.Runtime.Serialization.SerializationInfo info,
-            System.Runtime.Serialization.StreamingContext context)
-            : base(info, context)
-        { }
     }
 }

--- a/QuickFIXn/QuickFix.csproj
+++ b/QuickFIXn/QuickFix.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <Title>QuickFIX/n</Title>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GenerateAppxPackageOnBuild>true</GenerateAppxPackageOnBuild>

--- a/QuickFIXn/QuickFix.csproj
+++ b/QuickFIXn/QuickFix.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <Title>QuickFIX/n</Title>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GenerateAppxPackageOnBuild>true</GenerateAppxPackageOnBuild>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,13 +9,16 @@ What's New
 ----------
 
 **CAUTION:**  
+* **1.13.0 has moved to .NET 8 (as Microsoft is ending .NET 6 support on Nov 12, 2024)
+* **There are breaking changes between 1.12 and 1.13!  Please review the 1.12.0 notes below.**
 * **There are breaking changes between 1.11 and 1.12!  Please review the 1.12.0 notes below.**
 * **There are breaking changes between 1.10 and 1.11!  Please review the 1.11.0 notes below.**
 
 
-### (next release)
+### upcoming v1.13.0
 
 **Breaking changes**
+* #883 - Moved to .NET 8
 * #878 - corrections to tag 45 "Side" in various DDs (gbirchmeier) - most people won't notice, easy fix if they do
      * fix typo in FIX50 and FIX50SP1: `CROSS_SHORT_EXXMPT` fixed to `CROSS_SHORT_EXEMPT`
      * correction in FIX41 and FIX42: `D` to `UNDISCLOSED`

--- a/UnitTests/SessionScheduleTests.cs
+++ b/UnitTests/SessionScheduleTests.cs
@@ -19,7 +19,7 @@ namespace UnitTests
             {
                 return TimeZoneInfo.GetSystemTimeZones().Any(x => x.Id == "Eastern Standard Time")
                     ? "Eastern Standard Time"
-                    : "US/Eastern";
+                    : "America/New_York";
             }
         }
 
@@ -33,7 +33,7 @@ namespace UnitTests
             {
                 return TimeZoneInfo.GetSystemTimeZones().Any(x => x.Id == "Pacific Standard Time")
                     ? "Pacific Standard Time"
-                    : "US/Pacific";
+                    : "America/Los_Angeles";
             }
         }
         #endregion
@@ -75,7 +75,8 @@ namespace UnitTests
         }
 
         [Test]
-        public void TestCtor_WeekdaysSession() {
+        public void TestCtor_WeekdaysSession()
+        {
             SettingsDictionary settings = new SettingsDictionary();
             settings.SetString(SessionSettings.WEEKDAYS, "Sun,Tue,Fri");
 
@@ -92,7 +93,8 @@ namespace UnitTests
         }
 
         [Test]
-        public void TestCtor_NonStopSession() {
+        public void TestCtor_NonStopSession()
+        {
             SettingsDictionary settings = new SettingsDictionary();
             settings.SetBool(SessionSettings.NON_STOP_SESSION, true);
             Assert.DoesNotThrow(delegate { new SessionSchedule(settings); });
@@ -133,7 +135,7 @@ namespace UnitTests
             settings.SetDay(SessionSettings.START_DAY, DayOfWeek.Monday);
             settings.SetDay(SessionSettings.END_DAY, DayOfWeek.Monday);
             SessionSchedule sched = new SessionSchedule(settings);
-	    
+
             //a sunday
             Assert.IsTrue(sched.IsSessionTime(new DateTime(2011, 10, 16, 9, 43, 0, DateTimeKind.Utc)));
             Assert.IsTrue(sched.IsSessionTime(new DateTime(2011, 10, 16, 23, 59, 59, DateTimeKind.Utc)));
@@ -159,7 +161,7 @@ namespace UnitTests
             settings.SetDay(SessionSettings.START_DAY, DayOfWeek.Monday);
             settings.SetDay(SessionSettings.END_DAY, DayOfWeek.Monday);
             SessionSchedule sched = new SessionSchedule(settings);
-	    
+
             //a sunday
             Assert.IsTrue(sched.IsSessionTime(new DateTime(2011, 10, 16, 23, 59, 59, DateTimeKind.Utc)));
             Assert.IsTrue(sched.IsSessionTime(new DateTime(2011, 10, 16, 0, 0, 0, DateTimeKind.Utc)));
@@ -184,7 +186,7 @@ namespace UnitTests
             settings.SetDay(SessionSettings.START_DAY, DayOfWeek.Monday);
             settings.SetDay(SessionSettings.END_DAY, DayOfWeek.Monday);
             SessionSchedule sched = new SessionSchedule(settings);
-	    
+
             //a sunday
             Assert.IsFalse(sched.IsSessionTime(new DateTime(2011, 10, 16, 23, 59, 59, DateTimeKind.Utc)));
             Assert.IsFalse(sched.IsSessionTime(new DateTime(2011, 10, 16, 0, 0, 0, DateTimeKind.Utc)));
@@ -310,7 +312,7 @@ namespace UnitTests
             Assert.IsFalse(sched.IsSessionTime(new DateTime(2011, 10, 22, 7, 00, 1, DateTimeKind.Utc)));
             Assert.IsFalse(sched.IsSessionTime(new DateTime(2011, 10, 22, 15, 30, 0, DateTimeKind.Utc)));
         }
-        
+
 
         [Test]
         public void TestDailyIsSessionTime()
@@ -355,7 +357,7 @@ namespace UnitTests
             settings.SetString(SessionSettings.END_TIME, "00:12:00");
             settings.SetString(SessionSettings.TIME_ZONE, "Doh");
 
-            Assert.Throws(typeof (TimeZoneNotFoundException), delegate { new SessionSchedule(settings); });
+            Assert.Throws(typeof(TimeZoneNotFoundException), delegate { new SessionSchedule(settings); });
         }
 
         [Test]
@@ -368,7 +370,7 @@ namespace UnitTests
             settings.SetString(SessionSettings.USE_LOCAL_TIME, "Y");
             settings.SetString(SessionSettings.TIME_ZONE, EasternStandardTimeZoneId);
 
-            Assert.Throws(typeof (ConfigError), delegate { new SessionSchedule(settings); });
+            Assert.Throws(typeof(ConfigError), delegate { new SessionSchedule(settings); });
         }
 
         [Test]

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Platforms>AnyCPU;x64</Platforms>
     <IsPackable>false</IsPackable>

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Platforms>AnyCPU;x64</Platforms>
     <IsPackable>false</IsPackable>

--- a/scripts/Build-Zip-Release.ps1
+++ b/scripts/Build-Zip-Release.ps1
@@ -14,6 +14,8 @@ Param (
 )
 $ErrorActionPreference = "Stop"
 
+$dotNetVer = 'net8.0'
+
 $rootPath = Join-Path $PSScriptRoot '..' | Resolve-Path
 $zipContentPath = Join-Path $rootPath 'tmp' 'zip' "quickfixn-$NewVersion"
 $zipOutPath = Join-Path $rootPath 'tmp' 'zip' "quickfixn-$NewVersion.zip"
@@ -37,7 +39,7 @@ if (Test-Path $zipContentPath) {
 
 @(
     "bin"
-    "bin\net6.0"
+    "bin\$dotNetVer"
     "spec"
     "spec\fix"
     "config"
@@ -47,18 +49,18 @@ if (Test-Path $zipContentPath) {
 }
 
 @(
-    'QuickFIXn\bin\Release\net6.0\QuickFix.dll',
-    'Messages\FIXT11\bin\Release\net6.0\QuickFix.FIXT11.dll',
-    'Messages\FIX40\bin\Release\net6.0\QuickFix.FIX40.dll',
-    'Messages\FIX41\bin\Release\net6.0\QuickFix.FIX41.dll',
-    'Messages\FIX42\bin\Release\net6.0\QuickFix.FIX42.dll',
-    'Messages\FIX43\bin\Release\net6.0\QuickFix.FIX43.dll',
-    'Messages\FIX44\bin\Release\net6.0\QuickFix.FIX44.dll',
-    'Messages\FIX50\bin\Release\net6.0\QuickFix.FIX50.dll',
-    'Messages\FIX50SP1\bin\Release\net6.0\QuickFix.FIX50SP1.dll',
-    'Messages\FIX50SP2\bin\Release\net6.0\QuickFix.FIX50SP2.dll'
+    "QuickFIXn\bin\Release\$dotNetVer\QuickFix.dll",
+    "Messages\FIXT11\bin\Release\$dotNetVer\QuickFix.FIXT11.dll",
+    "Messages\FIX40\bin\Release\$dotNetVer\QuickFix.FIX40.dll",
+    "Messages\FIX41\bin\Release\$dotNetVer\QuickFix.FIX41.dll",
+    "Messages\FIX42\bin\Release\$dotNetVer\QuickFix.FIX42.dll",
+    "Messages\FIX43\bin\Release\$dotNetVer\QuickFix.FIX43.dll",
+    "Messages\FIX44\bin\Release\$dotNetVer\QuickFix.FIX44.dll",
+    "Messages\FIX50\bin\Release\$dotNetVer\QuickFix.FIX50.dll",
+    "Messages\FIX50SP1\bin\Release\$dotNetVer\QuickFix.FIX50SP1.dll",
+    "Messages\FIX50SP2\bin\Release\$dotNetVer\QuickFix.FIX50SP2.dll"
 ) | ForEach-Object {
-    $toPath = Join-Path $zipContentPath 'bin' 'net6.0'
+    $toPath = Join-Path $zipContentPath 'bin' $dotNetVer
 
     $dllPath = Join-Path $rootPath $_ | Resolve-Path
     Copy-Item $_ -Destination $toPath


### PR DESCRIPTION
resolve #883 

This is a rebase of #870 by @huypn12 , plus I added some more to it:

@huypn12's work:
* Update target to net 8.0
* Replace deprecated US timezone

My additions:
* updated the release script for .NET 8
* in csproj files, replaced `<TargetFrameworks>` with singular form
* remove some `Exception` ctor calls which are now deprecated in .NET 8
* deprecated some QF exceptions that I see are not being used
