### PR TITLE
change Message.ToString() to not change object state anymore

### DIFF
--- a/Examples/JsonToFix/Program.cs
+++ b/Examples/JsonToFix/Program.cs
@@ -11,7 +11,7 @@ namespace Examples.JsonToFix
         {
             var msg = new Message();
             msg.FromJson(json, true, sessionDataDictionary, appDataDictionary, msgFactory);
-            Console.WriteLine(msg.ToString());
+            Console.WriteLine(msg.ConstructString());
         }
 
         static void JsonToFix(string fname, QuickFix.DataDictionary.DataDictionary sessionDataDictionary, QuickFix.DataDictionary.DataDictionary appDataDictionary)

--- a/Examples/TradeClient/TradeClientApp.cs
+++ b/Examples/TradeClient/TradeClientApp.cs
@@ -27,7 +27,7 @@ namespace TradeClient
 
         public void FromApp(Message message, SessionID sessionID)
         {
-            Console.WriteLine("IN:  " + message.ToString());
+            Console.WriteLine("IN:  " + message.ConstructString());
             try
             {
                 Crack(message, sessionID);
@@ -57,7 +57,7 @@ namespace TradeClient
             { }
 
             Console.WriteLine();
-            Console.WriteLine("OUT: " + message.ToString());
+            Console.WriteLine("OUT: " + message.ConstructString());
         }
         #endregion
 

--- a/QuickFIXn/Fields/Converters/CheckSumConverter.cs
+++ b/QuickFIXn/Fields/Converters/CheckSumConverter.cs
@@ -1,13 +1,22 @@
-﻿
-namespace QuickFix.Fields.Converters
+﻿namespace QuickFix.Fields.Converters
 {
     public static class CheckSumConverter
     {
+        /// <summary>
+        /// Convert input string to int
+        /// </summary>
+        /// <param name="i"></param>
+        /// <returns></returns>
         public static int Convert(string i)
         {
             return IntConverter.Convert(i);
         }
 
+        /// <summary>
+        /// Convert input int to 3-character string
+        /// </summary>
+        /// <param name="i"></param>
+        /// <returns></returns>
         public static string Convert(int i)
         {
             return i.ToString("000");

--- a/QuickFIXn/Message/FieldMap.cs
+++ b/QuickFIXn/Message/FieldMap.cs
@@ -579,11 +579,21 @@ namespace QuickFix
             return total;
         }
 
+        /// <summary>
+        /// Creates a FIX (ish) string representation of this FieldMap (does not change the object state)
+        /// </summary>
+        /// <returns></returns>
         public virtual string CalculateString()
         {
             return CalculateString(new StringBuilder(), FieldOrder);
         }
 
+        /// <summary>
+        /// Creates a FIX (ish) string representation of this FieldMap (does not change the object state)
+        /// </summary>
+        /// <param name="sb"></param>
+        /// <param name="preFields"></param>
+        /// <returns></returns>
         public virtual string CalculateString(StringBuilder sb, int[] preFields)
         {
             HashSet<int> groupCounterTags = new HashSet<int>(_groups.Keys);

--- a/QuickFIXn/Message/Group.cs
+++ b/QuickFIXn/Message/Group.cs
@@ -63,6 +63,10 @@ namespace QuickFix
         /// </summary>
         public int Delim { get; }
 
+        /// <summary>
+        /// Creates a FIX (ish) string representation of this FieldMap (does not change the object state)
+        /// </summary>
+        /// <returns></returns>
         public override string CalculateString() {
             return base.CalculateString(new StringBuilder(), FieldOrder ?? new[] { Delim });
         }

--- a/QuickFIXn/Message/Header.cs
+++ b/QuickFIXn/Message/Header.cs
@@ -15,10 +15,20 @@ namespace QuickFix {
             : base(src) {
         }
 
+        /// <summary>
+        /// Creates a FIX (ish) string representation of this FieldMap (does not change the object state)
+        /// </summary>
+        /// <returns></returns>
         public override string CalculateString() {
             return base.CalculateString(new StringBuilder(), HEADER_FIELD_ORDER);
         }
 
+        /// <summary>
+        /// Creates a FIX (ish) string representation of this FieldMap (does not change the object state)
+        /// </summary>
+        /// <param name="sb"></param>
+        /// <param name="preFields"></param>
+        /// <returns></returns>
         public override string CalculateString(StringBuilder sb, int[] preFields) {
             return base.CalculateString(sb, HEADER_FIELD_ORDER);
         }

--- a/QuickFIXn/Message/Message.cs
+++ b/QuickFIXn/Message/Message.cs
@@ -793,16 +793,31 @@ namespace QuickFix
                 m.Header.GetString(Tags.TargetCompID));
         }
 
-        private Object lock_ToString = new Object();
-        public override string ToString()
+        private Object lock_ConstructString = new Object();
+        /// <summary>
+        /// Update BodyLength in Header, update CheckSum in Trailer, and return a FIX string.
+        /// (This function changes the object state!)
+        /// </summary>
+        /// <returns></returns>
+        public string ConstructString()
         {
-            lock (lock_ToString)
+            lock (lock_ConstructString)
             {
                 Header.SetField(new BodyLength(BodyLength()), true);
                 Trailer.SetField(new CheckSum(Fields.Converters.CheckSumConverter.Convert(CheckSum())), true);
 
                 return Header.CalculateString() + CalculateString() + Trailer.CalculateString();
             }
+        }
+
+        /// <summary>
+        /// Create a FIX-style string from the message.
+        /// This does NOT add/update BodyLength or CheckSum to the message header, or otherwise change the object state.
+        /// (Use <see cref="ConstructString"/> to compute and add/update BodyLength &amp; CheckSum.)
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString() {
+            return Header.CalculateString() + CalculateString() + Trailer.CalculateString();
         }
 
         protected int BodyLength()

--- a/QuickFIXn/Message/Trailer.cs
+++ b/QuickFIXn/Message/Trailer.cs
@@ -15,10 +15,20 @@ namespace QuickFix {
             : base(src) {
         }
 
+        /// <summary>
+        /// Creates a FIX (ish) string representation of this FieldMap (does not change the object state)
+        /// </summary>
+        /// <returns></returns>
         public override string CalculateString() {
             return base.CalculateString(new StringBuilder(), TRAILER_FIELD_ORDER);
         }
 
+        /// <summary>
+        /// Creates a FIX (ish) string representation of this FieldMap (does not change the object state)
+        /// </summary>
+        /// <param name="sb"></param>
+        /// <param name="preFields"></param>
+        /// <returns></returns>
         public override string CalculateString(StringBuilder sb, int[] preFields) {
             return base.CalculateString(sb, TRAILER_FIELD_ORDER);
         }

--- a/QuickFIXn/Session.cs
+++ b/QuickFIXn/Session.cs
@@ -789,7 +789,7 @@ namespace QuickFix
                             {
                                 GenerateSequenceReset(resendReq, begin, msgSeqNum);
                             }
-                            Send(msg.ToString());
+                            Send(msg.ConstructString());
                             begin = 0;
                         }
                         current = msgSeqNum + 1;
@@ -1517,7 +1517,7 @@ namespace QuickFix
                 }
                 else
                 {
-                    NextMessage(msg.ToString());
+                    NextMessage(msg.ConstructString());
                 }
                 return true;
             }
@@ -1567,7 +1567,7 @@ namespace QuickFix
                     }
                 }
 
-                string messageString = message.ToString();
+                string messageString = message.ConstructString();
                 if (0 == seqNum)
                     Persist(message, messageString);
                 return Send(messageString);

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -22,6 +22,8 @@ What's New
 * #878 - corrections to tag 45 "Side" in various DDs (gbirchmeier) - most people won't notice, easy fix if they do
      * fix typo in FIX50 and FIX50SP1: `CROSS_SHORT_EXXMPT` fixed to `CROSS_SHORT_EXEMPT`
      * correction in FIX41 and FIX42: `D` to `UNDISCLOSED`
+* #863 - Change Message.ToString() to not alter object state anymore. (gbirchmeier)
+         Use new function Message.ConstructString() if you need BodyLength/CheckSum to be updated.
 
 **Non-breaking changes**
 * #864 - when multiple threads race to init DefaultMessageFactory,

--- a/UnitTests/DataDictionaryTests.cs
+++ b/UnitTests/DataDictionaryTests.cs
@@ -318,7 +318,7 @@ namespace UnitTests
             //verify that FromString didn't correct the counter
             //HEY YOU, READ THIS NOW: if these fail, first check if MessageTests::FromString_DoNotCorrectCounter() passes
             Assert.AreEqual("386=3", n.NoTradingSessions.toStringField());  
-            StringAssert.Contains("386=3", n.ToString());
+            StringAssert.Contains("386=3", n.ConstructString());
 
             Assert.Throws<QuickFix.RepeatingGroupCountMismatch>(delegate { dd.CheckGroupCount(n.NoTradingSessions, n, "D"); });
         }

--- a/UnitTests/Fields/Converters/CheckSumConverterTests.cs
+++ b/UnitTests/Fields/Converters/CheckSumConverterTests.cs
@@ -1,0 +1,22 @@
+using NUnit.Framework;
+using QuickFix.Fields.Converters;
+
+namespace UnitTests.Fields.Converters;
+
+[TestFixture]
+public class CheckSumConverterTests {
+    [Test]
+    public void ConvertStringToInt() {
+        Assert.AreEqual(1, CheckSumConverter.Convert("1"));
+        Assert.AreEqual(123, CheckSumConverter.Convert("123"));
+        Assert.AreEqual(12, CheckSumConverter.Convert("012"));
+    }
+
+    [Test]
+    public void ConvertIntToString() {
+        Assert.AreEqual("001", CheckSumConverter.Convert(1));
+        Assert.AreEqual("012", CheckSumConverter.Convert(12));
+        Assert.AreEqual("123", CheckSumConverter.Convert(123));
+        Assert.AreEqual("1234", CheckSumConverter.Convert(1234));
+    }
+}

--- a/UnitTests/MessageTests.cs
+++ b/UnitTests/MessageTests.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 using QuickFix;
 using QuickFix.Fields;
 using UnitTests.TestHelpers;
+using Message = QuickFix.Message;
 
 namespace UnitTests
 {
@@ -185,7 +186,7 @@ namespace UnitTests
 
             n.FromString(s, true, dd, dd, _defaultMsgFactory);
             Assert.AreEqual("386=3", n.NoTradingSessions.toStringField());
-            StringAssert.Contains("386=3", n.ToString()); //should not be "corrected" to 2!
+            StringAssert.Contains("386=3", n.ConstructString()); //should not be "corrected" to 2!
         }
 
         [Test]
@@ -209,52 +210,7 @@ namespace UnitTests
         }
 
         [Test]
-        public void ToStringTest()
-        {
-            string str1 = "8=FIX.4.2\x01" + "9=55\x01" + "35=0\x01" + "34=3\x01" + "49=TW\x01" +
-                "52=20000426-12:05:06\x01" + "56=ISLD\x01" + "1=acct123\x01" + "10=123\x01";
-            Message msg = new Message();
-            try
-            {
-                msg.FromString(str1, true, null, null, _defaultMsgFactory);
-            }
-            catch (InvalidMessage e)
-            {
-                Assert.Fail("Unexpected exception (InvalidMessage): " + e.Message);
-            }
-            StringField f1 = new StringField(8);
-            StringField f2 = new StringField(9);
-            StringField f3 = new StringField(35);
-            StringField f4 = new StringField(34);
-            StringField f5 = new StringField(49);
-            StringField f6 = new StringField(52);
-            StringField f7 = new StringField(56);
-            StringField f8 = new StringField(10);
-            StringField f9 = new StringField(1);
-            msg.Header.GetField(f1);
-            msg.Header.GetField(f2);
-            msg.Header.GetField(f3);
-            msg.Header.GetField(f4);
-            msg.Header.GetField(f5);
-            msg.Header.GetField(f6);
-            msg.Header.GetField(f7);
-            msg.GetField(f9);
-            msg.Trailer.GetField(f8);
-            Assert.That(f1.Obj, Is.EqualTo("FIX.4.2"));
-            Assert.That(f2.Obj, Is.EqualTo("55"));
-            Assert.That(f3.Obj, Is.EqualTo("0"));
-            Assert.That(f4.Obj, Is.EqualTo("3"));
-            Assert.That(f5.Obj, Is.EqualTo("TW"));
-            Assert.That(f6.Obj, Is.EqualTo("20000426-12:05:06"));
-            Assert.That(f7.Obj, Is.EqualTo("ISLD"));
-            Assert.That(f8.Obj, Is.EqualTo("123"));
-            Assert.That(f9.Obj, Is.EqualTo("acct123"));
-            string raw = msg.ToString();
-            Assert.That(raw, Is.EqualTo(str1));
-        }
-
-        [Test]
-        public void ToStringFieldOrder()
+        public void ConstructStringFieldOrder()
         {
             Message msg = new Message();
             msg.Header.SetField(new QuickFix.Fields.MsgType("A"));
@@ -263,7 +219,7 @@ namespace UnitTests
             msg.Header.SetField(new QuickFix.Fields.TargetCompID("TARGET"));
             msg.Header.SetField(new QuickFix.Fields.MsgSeqNum(42));
             string expect = "8=FIX.4.2\x01" + "9=31\x01" + "35=A\x01" + "34=42\x01" + "49=SENDER\x01" + "56=TARGET\x01" + "10=200\x01";
-            Assert.That(msg.ToString(), Is.EqualTo(expect));
+            Assert.That(msg.ConstructString(), Is.EqualTo(expect));
         }
 
         [Test]
@@ -525,7 +481,7 @@ namespace UnitTests
             group2.EncodedText = new QuickFix.Fields.EncodedText("bbb");
             news.AddGroup(group2);
 
-            string raw = news.ToString();
+            string raw = news.ConstructString();
 
             string nul = "\x01";
             StringAssert.Contains(
@@ -547,7 +503,7 @@ namespace UnitTests
             group.Text = new QuickFix.Fields.Text("line2");
             news.AddGroup(group);
 
-            string raw = news.ToString();
+            string raw = news.ConstructString();
 
             string nul = "\x01";
             StringAssert.Contains(
@@ -676,7 +632,7 @@ namespace UnitTests
             symGroup.SecurityID = new SecurityID("secid2");
             msg.AddGroup(symGroup);
 
-            string msgString = msg.ToString();
+            string msgString = msg.ConstructString();
             string expected = String.Join(Message.SOH, new string[] { "146=2", "55=FOO1", "48=secid1", "55=FOO2", "48=secid2" });
 
             StringAssert.Contains(expected, msgString);
@@ -710,7 +666,7 @@ namespace UnitTests
             symGroup.SecurityIDSource = new SecurityIDSource("src2");
             msg.AddGroup(symGroup);
 
-            string msgString = msg.ToString();
+            string msgString = msg.ConstructString();
             string expected = String.Join(Message.SOH, new string[] { "146=2",
                 "55=FOO1", "65=sfx1", "48=secid1", "22=src1",
                 "55=FOO2", "65=sfx2", "48=secid2", "22=src2",
@@ -720,12 +676,12 @@ namespace UnitTests
         }
 
         [Test]
-        public void ToString_FIX50()
+        public void ConstructString_FIX50()
         {
             QuickFix.FIX50.News msg = new QuickFix.FIX50.News();
             msg.Headline = new Headline("FOO");
 
-            StringAssert.StartsWith("8=FIXT.1.1" + Message.SOH, msg.ToString());
+            StringAssert.StartsWith("8=FIXT.1.1" + Message.SOH, msg.ConstructString());
         }
 
         [Test]
@@ -753,7 +709,7 @@ namespace UnitTests
 
             ci.AddGroup(noParty);
 
-            string msgString = ci.ToString();
+            string msgString = ci.ConstructString();
             string expected = String.Join(Message.SOH, new string[] {
                 "909=CollateralInquiry", // top-level fields (non-header)
                 "453=1", //NoPartyIDs
@@ -896,7 +852,7 @@ namespace UnitTests
             grp.QuoteEntryID = new QuoteEntryID("15467902");
             msg.AddGroup(grp);
 
-            string msgString = msg.ToString();
+            string msgString = msg.ConstructString();
 
             string expected = String.Join(Message.SOH, new string[] { "35=W", "22=4", "48=BE0932900518", "55=[N/A]", "262=1b145288-9c9a-4911-a084-7341c69d3e6b", "762=EURO_EUR", "268=2",
                 "269=0", "270=97.625", "15=EUR", "271=1246000", "272=20121024", "273=07:30:47", "276=I", "282=BEARGB21XXX", "299=15478575",
@@ -971,13 +927,13 @@ namespace UnitTests
             msg.FromString(msgStr, false, dd, dd, _defaultMsgFactory);
 
             // make sure no fields were dropped in parsing
-            Assert.AreEqual(msgStr.Length, msg.ToString().Length);
+            Assert.AreEqual(msgStr.Length, msg.ConstructString().Length);
 
             // make sure repeating groups are not rearranged
             // 1 level deep
-            StringAssert.Contains(String.Join(Message.SOH, new string[] { "55=ABC", "65=CD", "48=securityid", "22=1" }), msg.ToString());
+            StringAssert.Contains(String.Join(Message.SOH, new string[] { "55=ABC", "65=CD", "48=securityid", "22=1" }), msg.ConstructString());
             // 2 levels deep
-            StringAssert.Contains(String.Join(Message.SOH, new string[] { "311=underlyingsymbol", "312=WI", "309=underlyingsecurityid", "305=1" }), msg.ToString());
+            StringAssert.Contains(String.Join(Message.SOH, new string[] { "311=underlyingsymbol", "312=WI", "309=underlyingsecurityid", "305=1" }), msg.ConstructString());
         }
 
         [Test]
@@ -1009,7 +965,7 @@ namespace UnitTests
             msg.Trailer.SetField(new Signature("woot"));
             msg.Trailer.SetField(new SignatureLength(4));
 
-            string foo = msg.ToString().Replace(Message.SOH, '|');
+            string foo = msg.ConstructString().Replace(Message.SOH, '|');
             StringAssert.EndsWith("|10=099|", foo);
         }
 
@@ -1100,6 +1056,38 @@ namespace UnitTests
             Assert.That(noPartySubGrp.GetString(Tags.PartySubID), Is.EqualTo("14"));
             Assert.That(noPartySubGrp.GetString(Tags.PartySubIDType), Is.EqualTo("4"));
             Assert.That(noPartySubGrp.GetString(31338), Is.EqualTo("custom group field"));
+        }
+
+        private QuickFix.FIX44.News CreateStringResultInput() {
+            QuickFix.FIX44.News msg = new();
+            msg.Header.SetField(new BeginString(QuickFix.FixValues.BeginString.FIX44));
+            msg.Header.SetField(new MsgType("B"));
+            msg.SetField(new Headline("myHeadline"));
+
+            QuickFix.FIX44.News.LinesOfTextGroup grp1 = new() { Text = new Text("line1") };
+            QuickFix.FIX44.News.LinesOfTextGroup grp2 = new() { Text = new Text("line2") };
+            msg.AddGroup(grp1);
+            msg.AddGroup(grp2);
+            return msg;
+        }
+
+        [Test]
+        public void ToStringTest() {
+            QuickFix.FIX44.News msg = CreateStringResultInput();
+            // ToString() does not add BodyLength or CheckSum -- it does not change object state
+            string expected = "8=FIX.4.4|35=B|148=myHeadline|33=2|58=line1|58=line2|";
+            Assert.AreEqual(expected, msg.ToString().Replace(Message.SOH, '|'));
+        }
+
+        [Test]
+        public void ConstructStringTest() {
+            QuickFix.FIX44.News msg = CreateStringResultInput();
+            // ConstructString() adds BodyLength and CheckSum
+            string expected = "8=FIX.4.4|9=43|35=B|148=myHeadline|33=2|58=line1|58=line2|10=161|";
+            Assert.AreEqual(expected, msg.ConstructString().Replace(Message.SOH, '|'));
+
+            // the object state is changed
+            Assert.AreEqual(expected, msg.ToString().Replace(Message.SOH, '|'));
         }
     }
 }

--- a/UnitTests/SessionDynamicTest.cs
+++ b/UnitTests/SessionDynamicTest.cs
@@ -348,7 +348,7 @@ namespace UnitTests
             msg.Header.SetField(new QuickFix.Fields.SendingTime(System.DateTime.UtcNow));
             msg.SetField(new QuickFix.Fields.HeartBtInt(300));
             // Simple logon message
-            s.Send(CharEncoding.DefaultEncoding.GetBytes(msg.ToString()));
+            s.Send(CharEncoding.DefaultEncoding.GetBytes(msg.ConstructString()));
         }
 
         void ClearLogs()

--- a/UnitTests/SessionTest.cs
+++ b/UnitTests/SessionTest.cs
@@ -64,7 +64,7 @@ namespace UnitTests
                 Console.WriteLine(String.Format("  {0}: count {1}", key, msgLookup[key].Count));
                 foreach (QuickFix.Message m in msgLookup[key])
                 {
-                    Console.WriteLine("  - " + m.ToString());
+                    Console.WriteLine("  - " + m.ConstructString());
                 }
             }
         }
@@ -230,7 +230,7 @@ namespace UnitTests
             msg.Header.SetField(new QuickFix.Fields.MsgSeqNum(seqNum++));
             msg.Header.SetField(new QuickFix.Fields.SendingTime(System.DateTime.UtcNow));
             msg.SetField(new QuickFix.Fields.HeartBtInt(1));
-            session.Next(msg.ToString());
+            session.Next(msg.ConstructString());
         }
 
         public bool SENT_SEQUENCE_RESET()
@@ -347,7 +347,7 @@ namespace UnitTests
             order.Header.SetField(new QuickFix.Fields.SenderCompID(sessionID.TargetCompID));
             order.Header.SetField(new QuickFix.Fields.MsgSeqNum(seqNum++));
 
-            session.Next(order.ToString());
+            session.Next(order.ConstructString());
         }
 
         public void SendResendRequest(SeqNumType begin, SeqNumType end)
@@ -370,7 +370,7 @@ namespace UnitTests
             msg.Header.SetField(new QuickFix.Fields.SenderCompID(sessionID.TargetCompID));
             msg.Header.SetField(new QuickFix.Fields.MsgSeqNum(seqNum++));
 
-            session.Next(msg.ToString());
+            session.Next(msg.ConstructString());
         }
 
         [Test]
@@ -721,10 +721,10 @@ namespace UnitTests
 
             reset.Header.SetField(new QuickFix.Fields.MsgSeqNum(2));
             reset.SetField(new QuickFix.Fields.NewSeqNo(2501));
-            session.Next(reset.ToString());
+            session.Next(reset.ConstructString());
 
             order.Header.SetField(new QuickFix.Fields.MsgSeqNum(2501));
-            session.Next(order.ToString());
+            session.Next(order.ConstructString());
 
             // Should have triggered next resend (2502->5001), check this
             //Console.WriteLine(responder.msgLookup[QuickFix.Fields.MsgType.RESENDREQUEST].Count);
@@ -736,10 +736,10 @@ namespace UnitTests
             // Jump forward to the end of the resend chunk with a fillgap reset message
             reset.Header.SetField(new QuickFix.Fields.MsgSeqNum(2502));
             reset.SetField(new QuickFix.Fields.NewSeqNo(5001));
-            session.Next(reset.ToString());
+            session.Next(reset.ConstructString());
 
             order.Header.SetField(new QuickFix.Fields.MsgSeqNum(5001));
-            session.Next(order.ToString());   // Triggers next resend (5002->5005)
+            session.Next(order.ConstructString());   // Triggers next resend (5002->5005)
 
             //Console.WriteLine(responder.msgLookup[QuickFix.Fields.MsgType.RESENDREQUEST].Count);
             Assert.That(responder.msgLookup[QuickFix.Fields.MsgType.RESENDREQUEST].Count == 1);
@@ -939,7 +939,7 @@ namespace UnitTests
             order.Header.SetField(new QuickFix.Fields.SenderCompID(sessionID.TargetCompID));
             order.Header.SetField(new QuickFix.Fields.MsgSeqNum(2));
 
-            session.Next(order.ToString());
+            session.Next(order.ConstructString());
 
             Assert.That(mockApp.InterceptedMessageTypes.Count, Is.EqualTo(2));
             Assert.True(mockApp.InterceptedMessageTypes.Contains(QuickFix.Fields.MsgType.LOGON));


### PR DESCRIPTION
resolves #863

Change `Message.ToString()` to not alter object state anymore (which breaks the [inheritance guidelines of ToString()](https://learn.microsoft.com/en-us/dotnet/api/system.object.tostring?view=net-8.0#notes-to-inheritors).

Moved the old functionality of computing/adding/updating BodyLength & CheckSum to the new function `Message.ConstructString()`.

(I really thought this was going to be more trouble than it actually was!)