### PR TITLE
cleanup/nullable-ize IField-derived classes

### DIFF
--- a/Examples/Executor/Executor.cs
+++ b/Examples/Executor/Executor.cs
@@ -52,7 +52,7 @@ namespace Executor
             {
                 case OrdType.LIMIT:
                     price = n.Price;
-                    if (price.Obj == 0)
+                    if (price.Value == 0)
                         throw new IncorrectTagValue(price.Tag);
                     break;
                 case OrdType.MARKET: break;
@@ -105,7 +105,7 @@ namespace Executor
             {
                 case OrdType.LIMIT:
                     price = n.Price;
-                    if (price.Obj == 0)
+                    if (price.Value == 0)
                         throw new IncorrectTagValue(price.Tag);
                     break;
                 case OrdType.MARKET: break;
@@ -160,7 +160,7 @@ namespace Executor
             {
                 case OrdType.LIMIT:
                     price = n.Price;
-                    if (price.Obj == 0)
+                    if (price.Value == 0)
                         throw new IncorrectTagValue(price.Tag);
                     break;
                 case OrdType.MARKET: break;
@@ -215,7 +215,7 @@ namespace Executor
             {
                 case OrdType.LIMIT:
                     price = n.Price;
-                    if (price.Obj == 0)
+                    if (price.Value == 0)
                         throw new IncorrectTagValue(price.Tag);
                     break;
                 case OrdType.MARKET: break;
@@ -270,7 +270,7 @@ namespace Executor
             {
                 case OrdType.LIMIT:
                     price = n.Price;
-                    if (price.Obj == 0)
+                    if (price.Value == 0)
                         throw new IncorrectTagValue(price.Tag);
                     break;
                 case OrdType.MARKET: break;
@@ -325,7 +325,7 @@ namespace Executor
             {
                 case OrdType.LIMIT:
                     price = n.Price;
-                    if (price.Obj == 0)
+                    if (price.Value == 0)
                         throw new IncorrectTagValue(price.Tag);
                     break;
                 case OrdType.MARKET: break;
@@ -375,7 +375,7 @@ namespace Executor
 
         public void OnMessage(QuickFix.FIX40.OrderCancelRequest msg, SessionID s)
         {
-            string orderid = (msg.IsSetOrderID()) ? msg.OrderID.Obj : "unknown orderID";
+            string orderid = (msg.IsSetOrderID()) ? msg.OrderID.Value : "unknown orderID";
             QuickFix.FIX40.OrderCancelReject ocj = new QuickFix.FIX40.OrderCancelReject(new OrderID(orderid), msg.ClOrdID);
             ocj.CxlRejReason = new CxlRejReason(CxlRejReason.UNKNOWN_ORDER);
             ocj.Text = new Text("Executor does not support order cancels");
@@ -392,7 +392,7 @@ namespace Executor
 
         public void OnMessage(QuickFix.FIX41.OrderCancelRequest msg, SessionID s)
         {
-            string orderid = (msg.IsSetOrderID()) ? msg.OrderID.Obj : "unknown orderID";
+            string orderid = (msg.IsSetOrderID()) ? msg.OrderID.Value : "unknown orderID";
             QuickFix.FIX41.OrderCancelReject ocj = new QuickFix.FIX41.OrderCancelReject(
                 new OrderID(orderid), msg.ClOrdID, msg.OrigClOrdID, new OrdStatus(OrdStatus.REJECTED));
             ocj.CxlRejReason = new CxlRejReason(CxlRejReason.UNKNOWN_ORDER);
@@ -410,7 +410,7 @@ namespace Executor
 
         public void OnMessage(QuickFix.FIX42.OrderCancelRequest msg, SessionID s)
         {
-            string orderid = (msg.IsSetOrderID()) ? msg.OrderID.Obj : "unknown orderID";
+            string orderid = (msg.IsSetOrderID()) ? msg.OrderID.Value : "unknown orderID";
             QuickFix.FIX42.OrderCancelReject ocj = new QuickFix.FIX42.OrderCancelReject(
                 new OrderID(orderid), msg.ClOrdID, msg.OrigClOrdID, new OrdStatus(OrdStatus.REJECTED), new CxlRejResponseTo(CxlRejResponseTo.ORDER_CANCEL_REQUEST));
             ocj.CxlRejReason = new CxlRejReason(CxlRejReason.UNKNOWN_ORDER);
@@ -428,7 +428,7 @@ namespace Executor
 
         public void OnMessage(QuickFix.FIX43.OrderCancelRequest msg, SessionID s)
         {
-            string orderid = (msg.IsSetOrderID()) ? msg.OrderID.Obj : "unknown orderID";
+            string orderid = (msg.IsSetOrderID()) ? msg.OrderID.Value : "unknown orderID";
             QuickFix.FIX43.OrderCancelReject ocj = new QuickFix.FIX43.OrderCancelReject(
                 new OrderID(orderid), msg.ClOrdID, msg.OrigClOrdID, new OrdStatus(OrdStatus.REJECTED), new CxlRejResponseTo(CxlRejResponseTo.ORDER_CANCEL_REQUEST));
             ocj.CxlRejReason = new CxlRejReason(CxlRejReason.UNKNOWN_ORDER);
@@ -446,7 +446,7 @@ namespace Executor
 
         public void OnMessage(QuickFix.FIX44.OrderCancelRequest msg, SessionID s)
         {
-            string orderid = (msg.IsSetOrderID()) ? msg.OrderID.Obj : "unknown orderID";
+            string orderid = (msg.IsSetOrderID()) ? msg.OrderID.Value : "unknown orderID";
             QuickFix.FIX44.OrderCancelReject ocj = new QuickFix.FIX44.OrderCancelReject(
                 new OrderID(orderid), msg.ClOrdID, msg.OrigClOrdID, new OrdStatus(OrdStatus.REJECTED), new CxlRejResponseTo(CxlRejResponseTo.ORDER_CANCEL_REQUEST));
             ocj.CxlRejReason = new CxlRejReason(CxlRejReason.OTHER);
@@ -464,7 +464,7 @@ namespace Executor
 
         public void OnMessage(QuickFix.FIX50.OrderCancelRequest msg, SessionID s)
         {
-            string orderid = (msg.IsSetOrderID()) ? msg.OrderID.Obj : "unknown orderID";
+            string orderid = (msg.IsSetOrderID()) ? msg.OrderID.Value : "unknown orderID";
             QuickFix.FIX50.OrderCancelReject ocj = new QuickFix.FIX50.OrderCancelReject(
                 new OrderID(orderid), msg.ClOrdID, msg.OrigClOrdID, new OrdStatus(OrdStatus.REJECTED), new CxlRejResponseTo(CxlRejResponseTo.ORDER_CANCEL_REQUEST));
             ocj.CxlRejReason = new CxlRejReason(CxlRejReason.OTHER);
@@ -484,7 +484,7 @@ namespace Executor
 
         public void OnMessage(QuickFix.FIX40.OrderCancelReplaceRequest msg, SessionID s)
         {
-            string orderid = (msg.IsSetOrderID()) ? msg.OrderID.Obj : "unknown orderID";
+            string orderid = (msg.IsSetOrderID()) ? msg.OrderID.Value : "unknown orderID";
             QuickFix.FIX40.OrderCancelReject ocj = new QuickFix.FIX40.OrderCancelReject(new OrderID(orderid), msg.ClOrdID);
             ocj.CxlRejReason = new CxlRejReason(CxlRejReason.UNKNOWN_ORDER);
             ocj.Text = new Text("Executor does not support order cancel/replaces");
@@ -501,7 +501,7 @@ namespace Executor
 
         public void OnMessage(QuickFix.FIX41.OrderCancelReplaceRequest msg, SessionID s)
         {
-            string orderid = (msg.IsSetOrderID()) ? msg.OrderID.Obj : "unknown orderID";
+            string orderid = (msg.IsSetOrderID()) ? msg.OrderID.Value : "unknown orderID";
             QuickFix.FIX41.OrderCancelReject ocj = new QuickFix.FIX41.OrderCancelReject(
                 new OrderID(orderid), msg.ClOrdID, msg.OrigClOrdID, new OrdStatus(OrdStatus.REJECTED));
             ocj.CxlRejReason = new CxlRejReason(CxlRejReason.UNKNOWN_ORDER);
@@ -519,7 +519,7 @@ namespace Executor
 
         public void OnMessage(QuickFix.FIX42.OrderCancelReplaceRequest msg, SessionID s)
         {
-            string orderid = (msg.IsSetOrderID()) ? msg.OrderID.Obj : "unknown orderID";
+            string orderid = (msg.IsSetOrderID()) ? msg.OrderID.Value : "unknown orderID";
             QuickFix.FIX42.OrderCancelReject ocj = new QuickFix.FIX42.OrderCancelReject(
                 new OrderID(orderid), msg.ClOrdID, msg.OrigClOrdID, new OrdStatus(OrdStatus.REJECTED), new CxlRejResponseTo(CxlRejResponseTo.ORDER_CANCEL_REPLACE_REQUEST));
             ocj.CxlRejReason = new CxlRejReason(CxlRejReason.UNKNOWN_ORDER);
@@ -537,7 +537,7 @@ namespace Executor
 
         public void OnMessage(QuickFix.FIX43.OrderCancelReplaceRequest msg, SessionID s)
         {
-            string orderid = (msg.IsSetOrderID()) ? msg.OrderID.Obj : "unknown orderID";
+            string orderid = (msg.IsSetOrderID()) ? msg.OrderID.Value : "unknown orderID";
             QuickFix.FIX43.OrderCancelReject ocj = new QuickFix.FIX43.OrderCancelReject(
                 new OrderID(orderid), msg.ClOrdID, msg.OrigClOrdID, new OrdStatus(OrdStatus.REJECTED), new CxlRejResponseTo(CxlRejResponseTo.ORDER_CANCEL_REPLACE_REQUEST));
             ocj.CxlRejReason = new CxlRejReason(CxlRejReason.UNKNOWN_ORDER);
@@ -555,7 +555,7 @@ namespace Executor
 
         public void OnMessage(QuickFix.FIX44.OrderCancelReplaceRequest msg, SessionID s)
         {
-            string orderid = (msg.IsSetOrderID()) ? msg.OrderID.Obj : "unknown orderID";
+            string orderid = (msg.IsSetOrderID()) ? msg.OrderID.Value : "unknown orderID";
             QuickFix.FIX44.OrderCancelReject ocj = new QuickFix.FIX44.OrderCancelReject(
                 new OrderID(orderid), msg.ClOrdID, msg.OrigClOrdID, new OrdStatus(OrdStatus.REJECTED), new CxlRejResponseTo(CxlRejResponseTo.ORDER_CANCEL_REPLACE_REQUEST));
             ocj.CxlRejReason = new CxlRejReason(CxlRejReason.OTHER);
@@ -573,7 +573,7 @@ namespace Executor
 
         public void OnMessage(QuickFix.FIX50.OrderCancelReplaceRequest msg, SessionID s)
         {
-            string orderid = (msg.IsSetOrderID()) ? msg.OrderID.Obj : "unknown orderID";
+            string orderid = (msg.IsSetOrderID()) ? msg.OrderID.Value : "unknown orderID";
             QuickFix.FIX50.OrderCancelReject ocj = new QuickFix.FIX50.OrderCancelReject(
                 new OrderID(orderid), msg.ClOrdID, msg.OrigClOrdID, new OrdStatus(OrdStatus.REJECTED), new CxlRejResponseTo(CxlRejResponseTo.ORDER_CANCEL_REPLACE_REQUEST));
             ocj.CxlRejReason = new CxlRejReason(CxlRejReason.OTHER);

--- a/QuickFIXn/AbstractInitiator.cs
+++ b/QuickFIXn/AbstractInitiator.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System.Threading;
+﻿using System.Threading;
 using System.Collections.Generic;
 using System;
 using QuickFix.Logger;

--- a/QuickFIXn/AcceptorSocketDescriptor.cs
+++ b/QuickFIXn/AcceptorSocketDescriptor.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Collections.Generic;
 using System.Net;
 using QuickFix.Logger;

--- a/QuickFIXn/ClientHandlerThread.cs
+++ b/QuickFIXn/ClientHandlerThread.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System.Net.Sockets;
+﻿using System.Net.Sockets;
 using System.Threading;
 using System;
 using QuickFix.Logger;

--- a/QuickFIXn/DefaultMessageFactory.cs
+++ b/QuickFIXn/DefaultMessageFactory.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/QuickFIXn/DefaultMessageFactory.cs
+++ b/QuickFIXn/DefaultMessageFactory.cs
@@ -68,7 +68,7 @@ namespace QuickFix
             if (beginString == QuickFix.Values.BeginString_FIXT11 && !Message.IsAdminMsgType(msgType))
             {
                 _factories.TryGetValue(
-                    QuickFix.FixValues.ApplVerID.ToBeginString(applVerId.Obj),
+                    QuickFix.FixValues.ApplVerID.ToBeginString(applVerId.Value),
                     out messageFactory);
             }
 
@@ -85,7 +85,7 @@ namespace QuickFix
         {
             string key = beginString;
             if(beginString.Equals(FixValues.BeginString.FIXT11))
-                key = QuickFix.FixValues.ApplVerID.ToBeginString(_defaultApplVerId.getValue());
+                key = QuickFix.FixValues.ApplVerID.ToBeginString(_defaultApplVerId.Value);
 
             if (_factories.TryGetValue(key, out IMessageFactory? factory))
                 return factory.Create(beginString, msgType, groupCounterTag);

--- a/QuickFIXn/Fields/BooleanField.cs
+++ b/QuickFIXn/Fields/BooleanField.cs
@@ -1,37 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿namespace QuickFix.Fields;
 
-namespace QuickFix.Fields
-{
-    /// <summary>
-    /// FIX BooleanField class
-    /// </summary>
-    public class BooleanField : FieldBase<Boolean>
-    {
-        public BooleanField(int tag)
-            : base(tag, false) { }
-           
-        public BooleanField(int tag, Boolean b)
-            : base(tag, b) { }
+/// <summary>
+/// FIX Boolean field
+/// </summary>
+public class BooleanField : FieldBase<bool> {
+    public BooleanField(int tag)
+        : base(tag, false) {
+    }
 
-        /// <summary>
-        /// quickfix-cpp compat - returns base type
-        /// </summary>
-        /// <returns>Boolean object</returns>
-        public Boolean getValue()
-        { return Obj; }
+    public BooleanField(int tag, bool b)
+        : base(tag, b) {
+    }
 
-        /// <summary>
-        /// quickfix-cpp compat - set object
-        /// </summary>
-        public void setValue(Boolean b)
-        { Obj = b; }
-
-        protected override string makeString()
-        {
-            return Converters.BoolConverter.Convert(Obj);
-        }
+    protected override string MakeString() {
+        return Converters.BoolConverter.Convert(Value);
     }
 }
+

--- a/QuickFIXn/Fields/CharField.cs
+++ b/QuickFIXn/Fields/CharField.cs
@@ -1,30 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿namespace QuickFix.Fields;
 
-namespace QuickFix.Fields
-{
-    /// <summary>
-    /// A character message field
-    /// </summary>
-    public class CharField : FieldBase<Char>
-    {
-        public CharField(int tag)
-            :base(tag, '\0') {}
+/// <summary>
+/// FIX character field
+/// </summary>
+public class CharField : FieldBase<char> {
+    public CharField(int tag)
+        : base(tag, '\0') {
+    }
 
-        public CharField(int tag, char c)
-            : base(tag, c) { }
+    public CharField(int tag, char c)
+        : base(tag, c) {
+    }
 
-        // quickfix compat
-        public char getValue()
-        { return Obj; }
-
-        public void setValue(char c)
-        { Obj = c; }
-
-        protected override string makeString()
-        {
-            return Converters.CharConverter.Convert(Obj);
-        }
+    protected override string MakeString() {
+        return Converters.CharConverter.Convert(Value);
     }
 }

--- a/QuickFIXn/Fields/Converters/DateTimeConverter.cs
+++ b/QuickFIXn/Fields/Converters/DateTimeConverter.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 

--- a/QuickFIXn/Fields/DateTimeField.cs
+++ b/QuickFIXn/Fields/DateTimeField.cs
@@ -21,17 +21,9 @@ namespace QuickFix.Fields
             timePrecision = timeFormatPrecision;
         }
 
-
-        // quickfix compat
-        public DateTime getValue()
-        { return Obj; }
-
-        public void setValue(DateTime dt)
-        { Obj = dt; }
-
-        protected override string makeString()
+        protected override string MakeString()
         {
-            return Converters.DateTimeConverter.ToFIX(Obj, timePrecision);
+            return Converters.DateTimeConverter.ToFIX(Value, timePrecision);
         }
     }
 
@@ -49,9 +41,9 @@ namespace QuickFix.Fields
         public DateOnlyField(int tag, DateTime dt, TimeStampPrecision timeFormatPrecision)
             : base(tag, dt, timeFormatPrecision) { }
 
-        protected override string makeString()
+        protected override string MakeString()
         {
-            return Converters.DateTimeConverter.ToFIXDateOnly(Obj);
+            return Converters.DateTimeConverter.ToFIXDateOnly(Value);
         }
     }
 
@@ -69,9 +61,9 @@ namespace QuickFix.Fields
         public TimeOnlyField(int tag, DateTime dt, TimeStampPrecision timeFormatPrecision)
             : base(tag, dt, timeFormatPrecision) { }
 
-        protected override string makeString()
+        protected override string MakeString()
         {
-            return Converters.DateTimeConverter.ToFIXTimeOnly(Obj, base.timePrecision);
+            return Converters.DateTimeConverter.ToFIXTimeOnly(Value, base.timePrecision);
         }
     }
 }

--- a/QuickFIXn/Fields/DecimalField.cs
+++ b/QuickFIXn/Fields/DecimalField.cs
@@ -15,16 +15,9 @@ namespace QuickFix.Fields
         public DecimalField(int tag, Decimal val)
             : base(tag, val) { }
 
-        // quickfix compat
-        public Decimal getValue()
-        { return Obj; }
-
-        public void setValue(Decimal d)
-        { Obj = d; }
-
-        protected override string makeString()
+        protected override string MakeString()
         {
-            return Converters.DecimalConverter.Convert(Obj);
+            return Converters.DecimalConverter.Convert(Value);
         }
     }
 }

--- a/QuickFIXn/Fields/IField.cs
+++ b/QuickFIXn/Fields/IField.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System;
+﻿using System;
 
 namespace QuickFix.Fields
 {

--- a/QuickFIXn/Fields/IField.cs
+++ b/QuickFIXn/Fields/IField.cs
@@ -1,33 +1,40 @@
 ﻿#nullable enable
+using System;
+
 namespace QuickFix.Fields
 {
     /// <summary>
     /// Interface for all field classes
     /// </summary>
-    public abstract class IField
+    public interface IField
     {
-        #region Properties
-        public abstract int Tag { get; set; }
-        #endregion
+        public int Tag { get; set; }
 
         /// <summary>
         /// returns full fix string: tag=val
         /// </summary>
-        public abstract string toStringField();
+        public string ToStringField();
 
         /// <summary>
-        /// returns formatted string for fix
+        /// returns field value (not tag) formatted for FIX
         /// </summary>
-        public abstract override string ToString();
+        public string ToString();
 
         /// <summary>
-        /// length of formatted field (including tag=val\001)
+        /// length of formatted field (including the trailing SOH) e.g. tag=val\001
         /// </summary>
-        public abstract int getLength();
+        public int GetLength();
 
         /// <summary>
-        /// checksum
+        /// Sum of bytes; used in calculating checksum
         /// </summary>
-        public abstract int getTotal();
+        public int GetTotal();
+
+        [Obsolete("Use capitalized ToStringField() instead")]
+        public string toStringField();
+        [Obsolete("Use capitalized GetLength() instead")]
+        public int getLength();
+        [Obsolete("Use capitalized GetTotal() instead")]
+        public int getTotal();
     }
 }

--- a/QuickFIXn/Fields/IntField.cs
+++ b/QuickFIXn/Fields/IntField.cs
@@ -1,30 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿namespace QuickFix.Fields;
 
-namespace QuickFix.Fields
-{
-    /// <summary>
-    /// An integer message field
-    /// </summary>
-    public class IntField : FieldBase<int>
-    {
-        public IntField(int tag)
-            : base(tag, 0) { }
+/// <summary>
+/// FIX Integer field
+/// </summary>
+public class IntField : FieldBase<int> {
+    public IntField(int tag)
+        : base(tag, 0) {
+    }
 
-        public IntField(int tag, int val)
-            : base(tag, val) {}
+    public IntField(int tag, int val)
+        : base(tag, val) {
+    }
 
-        // quickfix compat
-        public int getValue()
-        { return Obj; }
-
-        public void setValue(int v)
-        { Obj = v; }
-
-        protected override string makeString()
-        {
-            return Converters.IntConverter.Convert(Obj);
-        }
+    protected override string MakeString() {
+        return Converters.IntConverter.Convert(Value);
     }
 }

--- a/QuickFIXn/Fields/StringField.cs
+++ b/QuickFIXn/Fields/StringField.cs
@@ -15,16 +15,9 @@ namespace QuickFix.Fields
         public StringField(int tag, string str)
             : base(tag, str) { }
 
-        // quickfix compat
-        public string getValue()
-        { return Obj; }
-
-        public void setValue(string val)
-        { Obj = val; }
-
-        protected override string makeString()
+        protected override string MakeString()
         {
-            return Obj;
+            return Value;
         }
     }
 }

--- a/QuickFIXn/Fields/ULongField.cs
+++ b/QuickFIXn/Fields/ULongField.cs
@@ -15,16 +15,9 @@ namespace QuickFix.Fields
         public ULongField(int tag, ulong val)
             : base(tag, val) {}
 
-        // quickfix compat
-        public ulong getValue()
-        { return Obj; }
-
-        public void setValue(ulong v)
-        { Obj = v; }
-
-        protected override string makeString()
+        protected override string MakeString()
         {
-            return Converters.ULongConverter.Convert(Obj);
+            return Converters.ULongConverter.Convert(Value);
         }
     }
 }

--- a/QuickFIXn/HttpServer.cs
+++ b/QuickFIXn/HttpServer.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/QuickFIXn/Logger/CompositeLog.cs
+++ b/QuickFIXn/Logger/CompositeLog.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System;
+﻿using System;
 
 namespace QuickFix.Logger;
 

--- a/QuickFIXn/Logger/CompositeLogFactory.cs
+++ b/QuickFIXn/Logger/CompositeLogFactory.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System.Linq;
+﻿using System.Linq;
 
 namespace QuickFix.Logger;
 

--- a/QuickFIXn/Logger/FileLog.cs
+++ b/QuickFIXn/Logger/FileLog.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System;
+﻿using System;
 using QuickFix.Fields.Converters;
 using QuickFix.Util;
 

--- a/QuickFIXn/Logger/FileLogFactory.cs
+++ b/QuickFIXn/Logger/FileLogFactory.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-namespace QuickFix.Logger;
+﻿namespace QuickFix.Logger;
 
 /// <summary>
 /// Creates a message store that stores messages in a file

--- a/QuickFIXn/Logger/ILogFactory.cs
+++ b/QuickFIXn/Logger/ILogFactory.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-namespace QuickFix.Logger;
+﻿namespace QuickFix.Logger;
 
 /// <summary>
 /// Creates a log instance

--- a/QuickFIXn/Logger/NonSessionLog.cs
+++ b/QuickFIXn/Logger/NonSessionLog.cs
@@ -1,6 +1,3 @@
-#nullable enable
-using System;
-
 namespace QuickFix.Logger;
 
 /// <summary>

--- a/QuickFIXn/Logger/NullLogFactory.cs
+++ b/QuickFIXn/Logger/NullLogFactory.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-namespace QuickFix.Logger;
+﻿namespace QuickFix.Logger;
 
 public class NullLogFactory : ILogFactory
 {

--- a/QuickFIXn/Logger/ScreenLog.cs
+++ b/QuickFIXn/Logger/ScreenLog.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-namespace QuickFix.Logger;
+﻿namespace QuickFix.Logger;
 
 /// <summary>
 /// FIXME - needs to log sessionIDs, timestamps, etc.

--- a/QuickFIXn/Logger/ScreenLogFactory.cs
+++ b/QuickFIXn/Logger/ScreenLogFactory.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-namespace QuickFix.Logger;
+﻿namespace QuickFix.Logger;
 
 public class ScreenLogFactory : ILogFactory
 {

--- a/QuickFIXn/Message/FieldMap.cs
+++ b/QuickFIXn/Message/FieldMap.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/QuickFIXn/Message/FieldMap.cs
+++ b/QuickFIXn/Message/FieldMap.cs
@@ -120,7 +120,7 @@ namespace QuickFix
         /// <returns><paramref name="field"/></returns>
         public BooleanField GetField(BooleanField field)
         {
-            field.Obj = GetBoolean(field.Tag);
+            field.Value = GetBoolean(field.Tag);
             return field;
         }
 
@@ -132,7 +132,7 @@ namespace QuickFix
         /// <returns><paramref name="field"/></returns>
         public StringField GetField(StringField field)
         {
-            field.Obj = GetString(field.Tag);
+            field.Value = GetString(field.Tag);
             return field;
         }
 
@@ -144,7 +144,7 @@ namespace QuickFix
         /// <returns><paramref name="field"/></returns>
         public CharField GetField(CharField field)
         {
-            field.Obj = GetChar(field.Tag);
+            field.Value = GetChar(field.Tag);
             return field;
         }
 
@@ -156,7 +156,7 @@ namespace QuickFix
         /// <returns><paramref name="field"/></returns>
         public IntField GetField(IntField field)
         {
-            field.Obj = GetInt(field.Tag);
+            field.Value = GetInt(field.Tag);
             return field;
         }
 
@@ -168,7 +168,7 @@ namespace QuickFix
         /// <returns><paramref name="field"/></returns>
         public ULongField GetField(ULongField field)
         {
-            field.Obj = GetULong(field.Tag);
+            field.Value = GetULong(field.Tag);
             return field;
         }
 
@@ -180,7 +180,7 @@ namespace QuickFix
         /// <returns><paramref name="field"/></returns>
         public DecimalField GetField(DecimalField field)
         {
-            field.Obj = GetDecimal(field.Tag);
+            field.Value = GetDecimal(field.Tag);
             return field;
         }
 
@@ -192,7 +192,7 @@ namespace QuickFix
         /// <returns><paramref name="field"/></returns>
         public DateTimeField GetField(DateTimeField field)
         {
-            field.Obj = GetDateTime(field.Tag);
+            field.Value = GetDateTime(field.Tag);
             return field;
         }
 
@@ -204,7 +204,7 @@ namespace QuickFix
         /// <returns><paramref name="field"/></returns>
         public DateOnlyField GetField(DateOnlyField field)
         {
-            field.Obj = GetDateOnly(field.Tag);
+            field.Value = GetDateOnly(field.Tag);
             return field;
         }
 
@@ -216,7 +216,7 @@ namespace QuickFix
         /// <returns><paramref name="field"/></returns>
         public TimeOnlyField GetField(TimeOnlyField field)
         {
-            field.Obj = GetTimeOnly(field.Tag);
+            field.Value = GetTimeOnly(field.Tag);
             return field;
         }
 
@@ -318,7 +318,7 @@ namespace QuickFix
                 throw new FieldNotFoundException(tag);
 
             if (fld is FieldBase<int> intField)
-                return intField.Obj;
+                return intField.Value;
 
             return IntConverter.Convert(fld.ToString());
         }
@@ -335,7 +335,7 @@ namespace QuickFix
             {
                 IField fld = _fields[tag];
                 if (fld.GetType() == typeof(ULongField))
-                    return ((ULongField)fld).Obj;
+                    return ((ULongField)fld).Value;
                 return ULongConverter.Convert(fld.ToString());
             }
             catch (System.Collections.Generic.KeyNotFoundException)
@@ -357,9 +357,9 @@ namespace QuickFix
 
             return fld switch
             {
-                DateOnlyField dateOnlyField => dateOnlyField.Obj.Date,
-                TimeOnlyField timeOnlyField => new DateTime(1980, 01, 01).Add(timeOnlyField.Obj.TimeOfDay),
-                FieldBase<DateTime> dateTimeField => dateTimeField.Obj,
+                DateOnlyField dateOnlyField => dateOnlyField.Value.Date,
+                TimeOnlyField timeOnlyField => new DateTime(1980, 01, 01).Add(timeOnlyField.Value.TimeOfDay),
+                FieldBase<DateTime> dateTimeField => dateTimeField.Value,
                 _ => DateTimeConverter.ParseToDateTime(fld.ToString())
             };
         }
@@ -376,7 +376,7 @@ namespace QuickFix
                 throw new FieldNotFoundException(tag);
 
             if (fld is FieldBase<DateTime> dateTimeField)
-                return dateTimeField.Obj.Date;
+                return dateTimeField.Value.Date;
 
             return DateTimeConverter.ParseToDateOnly(fld.ToString());
         }
@@ -393,7 +393,7 @@ namespace QuickFix
                 throw new FieldNotFoundException(tag);
 
             if (fld is FieldBase<DateTime> dateTimeField)
-                return new DateTime(1980, 01, 01).Add(dateTimeField.Obj.TimeOfDay);
+                return new DateTime(1980, 01, 01).Add(dateTimeField.Value.TimeOfDay);
 
             return DateTimeConverter.ParseToTimeOnly(fld.ToString());
         }
@@ -410,7 +410,7 @@ namespace QuickFix
                 throw new FieldNotFoundException(tag);
 
             if (fld is FieldBase<bool> boolField)
-                return boolField.Obj;
+                return boolField.Value;
 
             return BoolConverter.Convert(fld.ToString());
         }
@@ -441,7 +441,7 @@ namespace QuickFix
                 throw new FieldNotFoundException(tag);
 
             if (fld is FieldBase<char> charField)
-                return charField.Obj;
+                return charField.Value;
 
             return CharConverter.Convert(fld.ToString());
         }
@@ -458,7 +458,7 @@ namespace QuickFix
                 throw new FieldNotFoundException(tag);
 
             if (fld is FieldBase<decimal> decimalField)
-                return decimalField.Obj;
+                return decimalField.Value;
 
             return DecimalConverter.Convert(fld.ToString());
         }
@@ -528,13 +528,13 @@ namespace QuickFix
             foreach (IField field in _fields.Values)
             {
                 if (field.Tag != Fields.Tags.CheckSum)
-                    total += field.getTotal();
+                    total += field.GetTotal();
             }
 
             foreach (IField field in this.RepeatedTags)
             {
                 if (field.Tag != Fields.Tags.CheckSum)
-                    total += field.getTotal();
+                    total += field.GetTotal();
             }
 
             foreach (List<Group> groupList in _groups.Values)
@@ -550,23 +550,21 @@ namespace QuickFix
             int total = 0;
             foreach (IField field in _fields.Values)
             {
-                if (field != null
-                    && field.Tag != Tags.BeginString
+                if (field.Tag != Tags.BeginString
                     && field.Tag != Tags.BodyLength
                     && field.Tag != Tags.CheckSum)
                 {
-                    total += field.getLength();
+                    total += field.GetLength();
                 }
             }
 
             foreach (IField field in this.RepeatedTags)
             {
-                if (field != null
-                    && field.Tag != Tags.BeginString
+                if (field.Tag != Tags.BeginString
                     && field.Tag != Tags.BodyLength
                     && field.Tag != Tags.CheckSum)
                 {
-                    total += field.getLength();
+                    total += field.GetLength();
                 }
             }
 
@@ -596,7 +594,7 @@ namespace QuickFix
         /// <returns></returns>
         public virtual string CalculateString(StringBuilder sb, int[] preFields)
         {
-            HashSet<int> groupCounterTags = new HashSet<int>(_groups.Keys);
+            HashSet<int> groupCounterTags = new(_groups.Keys);
             
             foreach (int preField in preFields)
             {
@@ -618,7 +616,7 @@ namespace QuickFix
                     continue;
                 if (preFields.Contains(field.Tag))
                     continue; //already did this one
-                sb.Append(field.Tag.ToString() + "=" + field.ToString());
+                sb.Append($"{field.Tag}={field.ToString()}");
                 sb.Append(Message.SOH);
             }
 
@@ -631,7 +629,7 @@ namespace QuickFix
                 if (groupList.Count == 0)
                     continue; //probably unnecessary, but it doesn't hurt to check
 
-                sb.Append(_fields[counterTag].toStringField());
+                sb.Append(_fields[counterTag].ToStringField());
                 sb.Append(Message.SOH);
 
                 foreach (Group group in groupList)
@@ -647,7 +645,7 @@ namespace QuickFix
         /// <param name="fieldNo">the counter tag of the group</param>
         /// <returns></returns>
         public int GroupCount(int fieldNo) {
-            return _groups.ContainsKey(fieldNo) ? _groups[fieldNo].Count : 0;
+            return _groups.TryGetValue(fieldNo, out var group) ? group.Count : 0;
         }
 
         /// <summary>

--- a/QuickFIXn/Message/FieldNotFoundException.cs
+++ b/QuickFIXn/Message/FieldNotFoundException.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System;
+﻿using System;
 
 namespace QuickFix
 {

--- a/QuickFIXn/Message/Group.cs
+++ b/QuickFIXn/Message/Group.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System;
+﻿using System;
 using System.Text;
 
 namespace QuickFix

--- a/QuickFIXn/Message/Header.cs
+++ b/QuickFIXn/Message/Header.cs
@@ -1,5 +1,3 @@
-#nullable enable
-using System;
 using System.Text;
 using QuickFix.Fields;
 

--- a/QuickFIXn/Message/Message.cs
+++ b/QuickFIXn/Message/Message.cs
@@ -146,7 +146,7 @@ namespace QuickFix
         public static string ExtractBeginString(string msgstr)
         {
             int i = 0;
-            return ExtractField(msgstr, ref i).Obj;
+            return ExtractField(msgstr, ref i).Value;
         }
 
         public static bool IsHeaderField(int tag)
@@ -375,7 +375,7 @@ namespace QuickFix
 
                     if (Tags.MsgType.Equals(f.Tag))
                     {
-                        string msgType = f.Obj;
+                        string msgType = f.Value;
                         if (appDict is not null)
                         {
                             msgMap = appDict.GetMapForMessage(msgType);
@@ -655,48 +655,48 @@ namespace QuickFix
             {
                 SenderCompID senderCompId = new SenderCompID();
                 header.GetField(senderCompId);
-                if (senderCompId.Obj.Length > 0)
-                    Header.SetField(new TargetCompID(senderCompId.Obj));
+                if (senderCompId.Value.Length > 0)
+                    Header.SetField(new TargetCompID(senderCompId.Value));
             }
 
             if (header.IsSetField(Tags.SenderSubID))
             {
                 SenderSubID senderSubId = new SenderSubID();
                 header.GetField(senderSubId);
-                if (senderSubId.Obj.Length > 0)
-                    Header.SetField(new TargetSubID(senderSubId.Obj));
+                if (senderSubId.Value.Length > 0)
+                    Header.SetField(new TargetSubID(senderSubId.Value));
             }
 
             if (header.IsSetField(Tags.SenderLocationID))
             {
                 SenderLocationID senderLocationId = new SenderLocationID();
                 header.GetField(senderLocationId);
-                if (senderLocationId.Obj.Length > 0)
-                    Header.SetField(new TargetLocationID(senderLocationId.Obj));
+                if (senderLocationId.Value.Length > 0)
+                    Header.SetField(new TargetLocationID(senderLocationId.Value));
             }
 
             if (header.IsSetField(Tags.TargetCompID))
             {
                 TargetCompID targetCompId = new TargetCompID();
                 header.GetField(targetCompId);
-                if (targetCompId.Obj.Length > 0)
-                    Header.SetField(new SenderCompID(targetCompId.Obj));
+                if (targetCompId.Value.Length > 0)
+                    Header.SetField(new SenderCompID(targetCompId.Value));
             }
 
             if (header.IsSetField(Tags.TargetSubID))
             {
                 TargetSubID targetSubId = new TargetSubID();
                 header.GetField(targetSubId);
-                if (targetSubId.Obj.Length > 0)
-                    Header.SetField(new SenderSubID(targetSubId.Obj));
+                if (targetSubId.Value.Length > 0)
+                    Header.SetField(new SenderSubID(targetSubId.Value));
             }
 
             if (header.IsSetField(Tags.TargetLocationID))
             {
                 TargetLocationID targetLocationId = new TargetLocationID();
                 header.GetField(targetLocationId);
-                if (targetLocationId.Obj.Length > 0)
-                    Header.SetField(new SenderLocationID(targetLocationId.Obj));
+                if (targetLocationId.Value.Length > 0)
+                    Header.SetField(new SenderLocationID(targetLocationId.Value));
             }
 
             // optional routing tags

--- a/QuickFIXn/Message/Message.cs
+++ b/QuickFIXn/Message/Message.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System;
+﻿using System;
 using System.Text;
 using QuickFix.Fields;
 using System.Text.RegularExpressions;

--- a/QuickFIXn/Message/Trailer.cs
+++ b/QuickFIXn/Message/Trailer.cs
@@ -1,5 +1,3 @@
-#nullable enable
-using System;
 using System.Text;
 using QuickFix.Fields;
 

--- a/QuickFIXn/MessageBuilder.cs
+++ b/QuickFIXn/MessageBuilder.cs
@@ -41,7 +41,7 @@ namespace QuickFix
 
         internal Message Build()
         {
-            Message message = _msgFactory.Create(BeginString, _defaultApplVerId, MsgType.Obj);
+            Message message = _msgFactory.Create(BeginString, _defaultApplVerId, MsgType.Value);
             message.FromString(
                 _msgStr,
                 _validateLengthAndChecksum,
@@ -58,7 +58,7 @@ namespace QuickFix
             if (_message is not null)
                 return _message;
 
-            Message message = _msgFactory.Create(BeginString, MsgType.Obj);
+            Message message = _msgFactory.Create(BeginString, MsgType.Value);
             message.FromString(
                 _msgStr,
                 false,

--- a/QuickFIXn/MessageBuilder.cs
+++ b/QuickFIXn/MessageBuilder.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-namespace QuickFix
+﻿namespace QuickFix
 {
     internal class MessageBuilder
     {

--- a/QuickFIXn/Session.cs
+++ b/QuickFIXn/Session.cs
@@ -550,7 +550,7 @@ namespace QuickFix
                 if (_appDoesEarlyIntercept)
                     ((IApplicationExt)Application).FromEarlyIntercept(message, SessionID);
 
-                string msgType = msgBuilder.MsgType.Obj;
+                string msgType = msgBuilder.MsgType.Value;
                 string beginString = msgBuilder.BeginString;
 
                 if (!beginString.Equals(SessionID.BeginString))
@@ -600,7 +600,7 @@ namespace QuickFix
 
                 try
                 {
-                    if (MsgType.LOGON.Equals(msgBuilder.MsgType.Obj))
+                    if (MsgType.LOGON.Equals(msgBuilder.MsgType.Value))
                         Disconnect("Logon message is not valid");
                 }
                 catch (MessageParseError)
@@ -616,7 +616,7 @@ namespace QuickFix
             }
             catch (UnsupportedVersion uvx)
             {
-                if (MsgType.LOGOUT.Equals(msgBuilder.MsgType.Obj))
+                if (MsgType.LOGOUT.Equals(msgBuilder.MsgType.Value))
                 {
                     NextLogout(message!);
                 }
@@ -641,7 +641,7 @@ namespace QuickFix
                 }
                 else
                 {
-                    if (MsgType.LOGON.Equals(msgBuilder.MsgType.Obj))
+                    if (MsgType.LOGON.Equals(msgBuilder.MsgType.Value))
                     {
                         Log.OnEvent("Required field missing from logon");
                         Disconnect("Required field missing from logon");
@@ -1547,12 +1547,12 @@ namespace QuickFix
                         Fields.ResetSeqNumFlag resetSeqNumFlag = new Fields.ResetSeqNumFlag(false);
                         if (message.IsSetField(resetSeqNumFlag))
                             message.GetField(resetSeqNumFlag);
-                        if (resetSeqNumFlag.getValue())
+                        if (resetSeqNumFlag.Value)
                         {
                             _state.Reset("ResetSeqNumFlag");
                             message.Header.SetField(new Fields.MsgSeqNum(_state.NextSenderMsgSeqNum));
                         }
-                        _state.SentReset = resetSeqNumFlag.Obj;
+                        _state.SentReset = resetSeqNumFlag.Value;
                     }
                 }
                 else

--- a/QuickFIXn/Session.cs
+++ b/QuickFIXn/Session.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/QuickFIXn/SessionFactory.cs
+++ b/QuickFIXn/SessionFactory.cs
@@ -98,7 +98,7 @@ namespace QuickFix
             }
             string senderDefaultApplVerId = "";
             if(defaultApplVerId is not null)
-                senderDefaultApplVerId = defaultApplVerId.Obj;
+                senderDefaultApplVerId = defaultApplVerId.Value;
 
             Session session = new Session(
                 isInitiator,
@@ -204,7 +204,7 @@ namespace QuickFix
                     {
                         Fields.ApplVerID applVerId = Message.GetApplVerID(settings.GetString(SessionSettings.DEFAULT_APPLVERID));
                         DataDictionary.DataDictionary dd = CreateDataDictionary(sessionId, settings, SessionSettings.APP_DATA_DICTIONARY, sessionId.BeginString);
-                        provider.AddApplicationDataDictionary(applVerId.Obj, dd);
+                        provider.AddApplicationDataDictionary(applVerId.Value, dd);
                     }
                     else
                     {
@@ -215,7 +215,7 @@ namespace QuickFix
 
                         string beginStringQualifier = setting.Key.Substring(offset);
                         DataDictionary.DataDictionary dd = CreateDataDictionary(sessionId, settings, setting.Key, beginStringQualifier);
-                        provider.AddApplicationDataDictionary(Message.GetApplVerID(beginStringQualifier).Obj, dd);
+                        provider.AddApplicationDataDictionary(Message.GetApplVerID(beginStringQualifier).Value, dd);
                     }
                 }
             }

--- a/QuickFIXn/SessionFactory.cs
+++ b/QuickFIXn/SessionFactory.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System;
+﻿using System;
 using System.Collections.Generic;
 using QuickFix.Logger;
 using QuickFix.Store;

--- a/QuickFIXn/SessionID.cs
+++ b/QuickFIXn/SessionID.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System;
+﻿using System;
 
 namespace QuickFix
 {

--- a/QuickFIXn/SessionSchedule.cs
+++ b/QuickFIXn/SessionSchedule.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace QuickFix

--- a/QuickFIXn/SessionState.cs
+++ b/QuickFIXn/SessionState.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Collections.Generic;
 using QuickFix.Logger;

--- a/QuickFIXn/Settings.cs
+++ b/QuickFIXn/Settings.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace QuickFix
 {

--- a/QuickFIXn/SettingsDictionary.cs
+++ b/QuickFIXn/SettingsDictionary.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using QuickFix.Fields.Converters;

--- a/QuickFIXn/SocketInitiatorThread.cs
+++ b/QuickFIXn/SocketInitiatorThread.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.IO;
 using System.Net;

--- a/QuickFIXn/SocketReader.cs
+++ b/QuickFIXn/SocketReader.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System.Net.Sockets;
+﻿using System.Net.Sockets;
 using System.IO;
 using System;
 using System.Linq;

--- a/QuickFIXn/Store/FileStore.cs
+++ b/QuickFIXn/Store/FileStore.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
 using QuickFix.Util;

--- a/QuickFIXn/Store/FileStoreFactory.cs
+++ b/QuickFIXn/Store/FileStoreFactory.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-namespace QuickFix.Store;
+﻿namespace QuickFix.Store;
 
 /// <summary>
 /// Creates a message store that stores messages in a file

--- a/QuickFIXn/Store/MemoryStore.cs
+++ b/QuickFIXn/Store/MemoryStore.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace QuickFix.Store;

--- a/QuickFIXn/ThreadedSocketAcceptor.cs
+++ b/QuickFIXn/ThreadedSocketAcceptor.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System;

--- a/QuickFIXn/ThreadedSocketReactor.cs
+++ b/QuickFIXn/ThreadedSocketReactor.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading;

--- a/QuickFIXn/Transport/SocketInitiator.cs
+++ b/QuickFIXn/Transport/SocketInitiator.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/QuickFIXn/Transport/SslCertCache.cs
+++ b/QuickFIXn/Transport/SslCertCache.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/QuickFIXn/Transport/SslStreamFactory.cs
+++ b/QuickFIXn/Transport/SslStreamFactory.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Diagnostics;
 using System.IO;

--- a/QuickFIXn/Transport/StreamFactory.cs
+++ b/QuickFIXn/Transport/StreamFactory.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System;
+﻿using System;
 using System.IO;
 using System.Linq;
 using System.Net;

--- a/QuickFIXn/Util/StringUtil.cs
+++ b/QuickFIXn/Util/StringUtil.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Runtime.InteropServices;
 
 namespace QuickFix.Util

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -35,6 +35,10 @@ What's New
          finishes loading all the dlls (gbirchmeier, with thanks to diagnosis by Brian Leach aka baffled)
          (Note: this may be the cause of spurious "incorrect BeginString" issues that have been observed)
 * #877 - throw an exception if Message.ToJSON(dd=null,convertEnumsToDescriptions=true) is called (gbirchmeier)
+* #TBD - cleanup/nullable-ize IField-derived classes (gbirchmeier)
+     * deprecate lower-case-starting function names (renamed to upper-case-starting)
+     * deprecate <Foo>Field.Obj (renamed to Value)
+     * deprecate <Foo>Field.getValue/setValue (just use Value getter/setter)
 
 ### v1.12.0
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -35,7 +35,7 @@ What's New
          finishes loading all the dlls (gbirchmeier, with thanks to diagnosis by Brian Leach aka baffled)
          (Note: this may be the cause of spurious "incorrect BeginString" issues that have been observed)
 * #877 - throw an exception if Message.ToJSON(dd=null,convertEnumsToDescriptions=true) is called (gbirchmeier)
-* #TBD - cleanup/nullable-ize IField-derived classes (gbirchmeier)
+* #888 - cleanup/nullable-ize IField-derived classes (gbirchmeier)
      * deprecate lower-case-starting function names (renamed to upper-case-starting)
      * deprecate <Foo>Field.Obj (renamed to Value)
      * deprecate <Foo>Field.getValue/setValue (just use Value getter/setter)

--- a/UnitTests/DataDictionaryTests.cs
+++ b/UnitTests/DataDictionaryTests.cs
@@ -315,7 +315,7 @@ namespace UnitTests
 
             //verify that FromString didn't correct the counter
             //HEY YOU, READ THIS NOW: if these fail, first check if MessageTests::FromString_DoNotCorrectCounter() passes
-            Assert.AreEqual("386=3", n.NoTradingSessions.toStringField());  
+            Assert.AreEqual("386=3", n.NoTradingSessions.ToStringField());
             StringAssert.Contains("386=3", n.ConstructString());
 
             Assert.Throws<RepeatingGroupCountMismatch>(delegate { dd.CheckGroupCount(n.NoTradingSessions, n, "D"); });

--- a/UnitTests/DataDictionary_ValidateTests.cs
+++ b/UnitTests/DataDictionary_ValidateTests.cs
@@ -81,10 +81,10 @@ public class DataDictionary_ValidateTests
         MsgType msgType = Message.IdentifyType(msgStr);
         string beginString = Message.ExtractBeginString(msgStr);
 
-        Message message = f.Create(beginString, msgType.Obj);
+        Message message = f.Create(beginString, msgType.Value);
         message.FromString(msgStr, true, dd, dd, f);
 
-        DataDictionary.Validate(message, dd, dd, beginString, msgType.Obj);
+        DataDictionary.Validate(message, dd, dd, beginString, msgType.Value);
     }
 
     [Test]

--- a/UnitTests/FieldMapTests.cs
+++ b/UnitTests/FieldMapTests.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using NUnit.Framework;
 using QuickFix;
 using QuickFix.Fields;
@@ -12,10 +9,10 @@ namespace UnitTests
     [TestFixture]
     public class FieldMapTests
     {
-        private FieldMap fieldmap;
+        private FieldMap _fieldmap;
         public FieldMapTests()
         {
-            this.fieldmap = new FieldMap();
+            this._fieldmap = new FieldMap();
         }
 
         [Test]
@@ -23,14 +20,14 @@ namespace UnitTests
         {
 
             CharField field = new CharField(100, 'd');
-            fieldmap.SetField(field);
+            _fieldmap.SetField(field);
             CharField refield = new CharField(100);
-            fieldmap.GetField(refield);
-            Assert.That('d', Is.EqualTo(refield.Obj));
-            field.Obj = 'e';
-            fieldmap.SetField(field);
-            CharField r = fieldmap.GetField(refield);
-            Assert.That('e', Is.EqualTo(refield.Obj));
+            _fieldmap.GetField(refield);
+            Assert.That('d', Is.EqualTo(refield.Value));
+            field.Value = 'e';
+            _fieldmap.SetField(field);
+            CharField r = _fieldmap.GetField(refield);
+            Assert.That('e', Is.EqualTo(refield.Value));
 
             Assert.AreSame(refield, r);
         }
@@ -39,38 +36,38 @@ namespace UnitTests
         [Test]
         public void GetCharTest()
         {
-            fieldmap.SetField(new CharField(20, 'a'));
-            Assert.That(fieldmap.GetChar(20), Is.EqualTo('a'));
-            fieldmap.SetField(new StringField(21, "b"));
-            Assert.That(fieldmap.GetChar(21), Is.EqualTo('b'));
+            _fieldmap.SetField(new CharField(20, 'a'));
+            Assert.That(_fieldmap.GetChar(20), Is.EqualTo('a'));
+            _fieldmap.SetField(new StringField(21, "b"));
+            Assert.That(_fieldmap.GetChar(21), Is.EqualTo('b'));
             Assert.Throws(typeof(FieldNotFoundException),
-                delegate { fieldmap.GetString(99900); });
+                delegate { _fieldmap.GetString(99900); });
         }
 
         [Test]
         public void GetDecimalTest()
         {
             var val = new Decimal(20.4);
-            fieldmap.SetField(new DecimalField(200, val));
-            Assert.That(fieldmap.GetDecimal(200), Is.EqualTo(val));
-            fieldmap.SetField(new StringField(201, "33.22"));
-            Assert.That(fieldmap.GetDecimal(201), Is.EqualTo(new Decimal(33.22)));
+            _fieldmap.SetField(new DecimalField(200, val));
+            Assert.That(_fieldmap.GetDecimal(200), Is.EqualTo(val));
+            _fieldmap.SetField(new StringField(201, "33.22"));
+            Assert.That(_fieldmap.GetDecimal(201), Is.EqualTo(new Decimal(33.22)));
             Assert.Throws(typeof(FieldNotFoundException),
-                delegate { fieldmap.GetString(99900); });
+                delegate { _fieldmap.GetString(99900); });
         }
-        
+
 
         [Test]
         public void StringFieldTest()
         {
 
-            fieldmap.SetField(new Account("hello"));
+            _fieldmap.SetField(new Account("hello"));
             Account acct = new Account();
-            fieldmap.GetField(acct);
-            Assert.That("hello", Is.EqualTo(acct.Obj));
-            fieldmap.SetField(new Account("helloworld"));
-            StringField r = fieldmap.GetField(acct);
-            Assert.That("helloworld", Is.EqualTo(acct.getValue()));
+            _fieldmap.GetField(acct);
+            Assert.That("hello", Is.EqualTo(acct.Value));
+            _fieldmap.SetField(new Account("helloworld"));
+            StringField r = _fieldmap.GetField(acct);
+            Assert.That("helloworld", Is.EqualTo(acct.Value));
 
             Assert.AreSame(r, acct);
         }
@@ -78,23 +75,23 @@ namespace UnitTests
         [Test]
         public void GetStringTest()
         {
-            fieldmap.SetField(new Account("hello"));
-            Assert.That(fieldmap.GetString(QuickFix.Fields.Tags.Account), Is.EqualTo("hello"));
+            _fieldmap.SetField(new Account("hello"));
+            Assert.That(_fieldmap.GetString(QuickFix.Fields.Tags.Account), Is.EqualTo("hello"));
             Assert.Throws(typeof(FieldNotFoundException),
-                delegate { fieldmap.GetString(99900); });
+                delegate { _fieldmap.GetString(99900); });
         }
 
         [Test]
         public void DateTimeFieldTest()
         {
 
-            fieldmap.SetField(new DateTimeField(Tags.TransactTime, new DateTime(2009, 12, 10)));
+            _fieldmap.SetField(new DateTimeField(Tags.TransactTime, new DateTime(2009, 12, 10)));
             TransactTime tt = new TransactTime();
-            fieldmap.GetField(tt);
-            Assert.That(new DateTime(2009, 12, 10), Is.EqualTo(tt.Obj));
-            fieldmap.SetField(new TransactTime(new DateTime(2010, 12, 10)));
-            DateTimeField r = fieldmap.GetField(tt);
-            Assert.That(new DateTime(2010, 12, 10), Is.EqualTo(tt.getValue()));
+            _fieldmap.GetField(tt);
+            Assert.That(new DateTime(2009, 12, 10), Is.EqualTo(tt.Value));
+            _fieldmap.SetField(new TransactTime(new DateTime(2010, 12, 10)));
+            DateTimeField r = _fieldmap.GetField(tt);
+            Assert.That(new DateTime(2010, 12, 10), Is.EqualTo(tt.Value));
 
             Assert.AreSame(r, tt);
         }
@@ -102,39 +99,39 @@ namespace UnitTests
         [Test]
         public void DateTimeFieldNanoTest()
         {
-            fieldmap.SetField(new StringField(Tags.TransactTime, "20200309-20:53:10.643649215"));
+            _fieldmap.SetField(new StringField(Tags.TransactTime, "20200309-20:53:10.643649215"));
             TransactTime tt = new TransactTime();
-            fieldmap.GetField(tt);
+            _fieldmap.GetField(tt);
             // Ticks resolution is 100 nanoseconds, so we lose the last 2 decimal points
-            Assert.That(tt.Obj.Ticks, Is.EqualTo(637193839906436492));
+            Assert.That(tt.Value.Ticks, Is.EqualTo(637193839906436492));
         }
 
         [Test]
         public void DateOnlyFieldTest()
         {
-            fieldmap.SetField(new DateOnlyField(Tags.MDEntryDate, new DateTime(2009, 12, 10, 1, 2, 3)));
+            _fieldmap.SetField(new DateOnlyField(Tags.MDEntryDate, new DateTime(2009, 12, 10, 1, 2, 3)));
             MDEntryDate ed = new MDEntryDate();
-            fieldmap.GetField(ed);
-            Assert.AreEqual(new DateTime(2009, 12, 10), ed.Obj);
-            fieldmap.SetField(new MDEntryDate(new DateTime(2010, 12, 10)));
-            DateOnlyField r = fieldmap.GetField(ed);
-            Assert.AreEqual(new DateTime(2010, 12, 10), ed.getValue());            
-            
+            _fieldmap.GetField(ed);
+            Assert.AreEqual(new DateTime(2009, 12, 10), ed.Value);
+            _fieldmap.SetField(new MDEntryDate(new DateTime(2010, 12, 10)));
+            DateOnlyField r = _fieldmap.GetField(ed);
+            Assert.AreEqual(new DateTime(2010, 12, 10), ed.Value);
+
             Assert.AreSame(r, ed);
             Assert.AreEqual("20101210", ed.ToString());
         }
 
         [Test]
         public void TimeOnlyFieldTest()
-        {            
-            fieldmap.SetField(new TimeOnlyField(Tags.MDEntryTime, new DateTime(1, 1, 1, 1, 2, 3), false));
+        {
+            _fieldmap.SetField(new TimeOnlyField(Tags.MDEntryTime, new DateTime(1, 1, 1, 1, 2, 3), false));
             MDEntryTime et = new MDEntryTime();
-            fieldmap.GetField(et);
-            Assert.AreEqual(new DateTime(1980, 01, 01, 1, 2, 3), et.Obj);
-            fieldmap.SetField(new MDEntryTime(new DateTime(1, 1, 1, 1, 2, 5)));
-            TimeOnlyField r = fieldmap.GetField(et);
-            Assert.AreEqual(new DateTime(1980, 01, 01, 1, 2, 5), et.getValue());
-            
+            _fieldmap.GetField(et);
+            Assert.AreEqual(new DateTime(1980, 01, 01, 1, 2, 3), et.Value);
+            _fieldmap.SetField(new MDEntryTime(new DateTime(1, 1, 1, 1, 2, 5)));
+            TimeOnlyField r = _fieldmap.GetField(et);
+            Assert.AreEqual(new DateTime(1980, 01, 01, 1, 2, 5), et.Value);
+
             Assert.AreSame(r, et);
             Assert.AreEqual("01:02:05.000", et.ToString());
         }
@@ -142,30 +139,30 @@ namespace UnitTests
         [Test]
         public void GetDateTimeTest()
         {
-            fieldmap.SetField(new DateTimeField(Tags.TransactTime, new DateTime(2009, 12, 10)));
-            Assert.That(fieldmap.GetDateTime(Tags.TransactTime), Is.EqualTo(new DateTime(2009, 12, 10)));
-            fieldmap.SetField(new StringField(233, "20091211-12:12:44"));
-            Assert.That(fieldmap.GetDateTime(233), Is.EqualTo(new DateTime(2009, 12, 11, 12, 12, 44)));
+            _fieldmap.SetField(new DateTimeField(Tags.TransactTime, new DateTime(2009, 12, 10)));
+            Assert.That(_fieldmap.GetDateTime(Tags.TransactTime), Is.EqualTo(new DateTime(2009, 12, 10)));
+            _fieldmap.SetField(new StringField(233, "20091211-12:12:44"));
+            Assert.That(_fieldmap.GetDateTime(233), Is.EqualTo(new DateTime(2009, 12, 11, 12, 12, 44)));
             Assert.Throws(typeof(FieldNotFoundException),
-                    delegate { fieldmap.GetDateTime(99900); });
+                    delegate { _fieldmap.GetDateTime(99900); });
         }
 
         [Test]
         public void GetDateOnlyTest()
         {
-            fieldmap.SetField(new DateOnlyField(Tags.MDEntryDate, new DateTime(2009, 12, 10, 1, 2, 3)));
-            Assert.AreEqual(new DateTime(2009, 12, 10), fieldmap.GetDateTime(Tags.MDEntryDate));
-            fieldmap.SetField(new StringField(233, "20091211"));
-            Assert.AreEqual(new DateTime(2009, 12, 11), fieldmap.GetDateOnly(233));
+            _fieldmap.SetField(new DateOnlyField(Tags.MDEntryDate, new DateTime(2009, 12, 10, 1, 2, 3)));
+            Assert.AreEqual(new DateTime(2009, 12, 10), _fieldmap.GetDateTime(Tags.MDEntryDate));
+            _fieldmap.SetField(new StringField(233, "20091211"));
+            Assert.AreEqual(new DateTime(2009, 12, 11), _fieldmap.GetDateOnly(233));
         }
 
         [Test]
         public void GetTimeOnlyTest()
         {
-            fieldmap.SetField(new TimeOnlyField(Tags.MDEntryTime, new DateTime(2009, 12, 10, 1, 2, 3)));
-            Assert.AreEqual(new DateTime(1980, 01, 01, 1, 2, 3), fieldmap.GetDateTime(Tags.MDEntryTime));
-            fieldmap.SetField(new StringField(233, "07:30:47"));
-            Assert.AreEqual(new DateTime(1980, 01, 01, 7, 30, 47), fieldmap.GetTimeOnly(233));
+            _fieldmap.SetField(new TimeOnlyField(Tags.MDEntryTime, new DateTime(2009, 12, 10, 1, 2, 3)));
+            Assert.AreEqual(new DateTime(1980, 01, 01, 1, 2, 3), _fieldmap.GetDateTime(Tags.MDEntryTime));
+            _fieldmap.SetField(new StringField(233, "07:30:47"));
+            Assert.AreEqual(new DateTime(1980, 01, 01, 7, 30, 47), _fieldmap.GetTimeOnly(233));
         }
 
         [Test]
@@ -173,13 +170,13 @@ namespace UnitTests
         {
             BooleanField field = new BooleanField(200, true);
             BooleanField refield = new BooleanField(200);
-            fieldmap.SetField(field);
-            fieldmap.GetField(refield);
-            Assert.That(true, Is.EqualTo(refield.Obj));
-            field.setValue(false);
-            fieldmap.SetField(field);
-            BooleanField r = fieldmap.GetField(refield);
-            Assert.That(false, Is.EqualTo(refield.Obj));
+            _fieldmap.SetField(field);
+            _fieldmap.GetField(refield);
+            Assert.That(true, Is.EqualTo(refield.Value));
+            field.Value = false;
+            _fieldmap.SetField(field);
+            BooleanField r = _fieldmap.GetField(refield);
+            Assert.That(false, Is.EqualTo(refield.Value));
 
             Assert.AreSame(r, refield);
         }
@@ -187,12 +184,12 @@ namespace UnitTests
         [Test]
         public void GetBooleanTest()
         {
-            fieldmap.SetField(new BooleanField(200, true));
-            Assert.That(fieldmap.GetBoolean(200), Is.EqualTo(true));
-            fieldmap.SetField(new StringField(201, "N"));
-            Assert.That(fieldmap.GetBoolean(201), Is.EqualTo(false));
+            _fieldmap.SetField(new BooleanField(200, true));
+            Assert.That(_fieldmap.GetBoolean(200), Is.EqualTo(true));
+            _fieldmap.SetField(new StringField(201, "N"));
+            Assert.That(_fieldmap.GetBoolean(201), Is.EqualTo(false));
             Assert.Throws(typeof(FieldNotFoundException),
-                delegate { fieldmap.GetString(99900); });
+                delegate { _fieldmap.GetString(99900); });
         }
 
         [Test]
@@ -201,13 +198,13 @@ namespace UnitTests
 
             IntField field = new IntField(200, 101);
             IntField refield = new IntField(200);
-            fieldmap.SetField(field);
-            fieldmap.GetField(refield);
-            Assert.That(101, Is.EqualTo(refield.Obj));
-            field.setValue(102);
-            fieldmap.SetField(field);
-            IntField r = fieldmap.GetField(refield);
-            Assert.That(102, Is.EqualTo(refield.Obj));
+            _fieldmap.SetField(field);
+            _fieldmap.GetField(refield);
+            Assert.That(101, Is.EqualTo(refield.Value));
+            field.Value = 102;
+            _fieldmap.SetField(field);
+            IntField r = _fieldmap.GetField(refield);
+            Assert.That(102, Is.EqualTo(refield.Value));
 
             Assert.AreSame(r, refield);
         }
@@ -217,12 +214,12 @@ namespace UnitTests
         {
 
             IntField field = new IntField(200, 101);
-            fieldmap.SetField(field);
-            Assert.That(fieldmap.GetInt(200), Is.EqualTo(101));
-            fieldmap.SetField(new StringField(202, "2222"));
-            Assert.That(fieldmap.GetInt(202), Is.EqualTo(2222));
+            _fieldmap.SetField(field);
+            Assert.That(_fieldmap.GetInt(200), Is.EqualTo(101));
+            _fieldmap.SetField(new StringField(202, "2222"));
+            Assert.That(_fieldmap.GetInt(202), Is.EqualTo(2222));
             Assert.Throws(typeof(FieldNotFoundException),
-                delegate { fieldmap.GetInt(99900); });
+                delegate { _fieldmap.GetInt(99900); });
         }
 
         [Test]
@@ -230,13 +227,13 @@ namespace UnitTests
         {
             DecimalField field = new DecimalField(200, new Decimal(101.0001));
             DecimalField refield = new DecimalField(200);
-            fieldmap.SetField(field);
-            fieldmap.GetField(refield);
-            Assert.That(101.0001, Is.EqualTo(refield.Obj));
-            field.setValue(new Decimal(101.0002));
-            fieldmap.SetField(field);
-            DecimalField r = fieldmap.GetField(refield);
-            Assert.That(101.0002, Is.EqualTo(refield.Obj));
+            _fieldmap.SetField(field);
+            _fieldmap.GetField(refield);
+            Assert.That(101.0001, Is.EqualTo(refield.Value));
+            field.Value = 101.0002m;
+            _fieldmap.SetField(field);
+            DecimalField r = _fieldmap.GetField(refield);
+            Assert.That(101.0002, Is.EqualTo(refield.Value));
 
             Assert.AreSame(r, refield);
         }
@@ -245,8 +242,8 @@ namespace UnitTests
         public void DefaultFieldTest()
         {
             DecimalField field = new DecimalField(200, new Decimal(101.0001));
-            fieldmap.SetField(field);
-            string refield = fieldmap.GetString(200);
+            _fieldmap.SetField(field);
+            string refield = _fieldmap.GetString(200);
             Assert.That("101.0001", Is.EqualTo(refield));
         }
 
@@ -255,37 +252,37 @@ namespace UnitTests
         {
             IntField field = new IntField(21901, 1011);
             IntField refield = new IntField(21901);
-            fieldmap.SetField(field, false);
-            fieldmap.GetField(refield);
-            Assert.That(1011, Is.EqualTo(refield.Obj));
-            field.setValue(1021);
+            _fieldmap.SetField(field, false);
+            _fieldmap.GetField(refield);
+            Assert.That(1011, Is.EqualTo(refield.Value));
+            field.Value = 1021;
             IntField refield2 = new IntField(21901);
-            fieldmap.SetField(field, false);
-            fieldmap.GetField(refield2);
-            Assert.That(refield.Obj, Is.EqualTo(1011));
-            fieldmap.SetField(field, true);
+            _fieldmap.SetField(field, false);
+            _fieldmap.GetField(refield2);
+            Assert.That(refield.Value, Is.EqualTo(1011));
+            _fieldmap.SetField(field, true);
             IntField refield3 = new IntField(21901);
-            fieldmap.GetField(refield3);
-            Assert.That(1021, Is.EqualTo(refield3.Obj));
+            _fieldmap.GetField(refield3);
+            Assert.That(1021, Is.EqualTo(refield3.Value));
         }
 
         [Test]
         public void FieldNotFoundTest()
         {
             Assert.Throws(typeof(FieldNotFoundException),
-                delegate { fieldmap.GetString(99900); });
+                delegate { _fieldmap.GetString(99900); });
             Assert.Throws(typeof(FieldNotFoundException),
-                delegate { fieldmap.GetField(new DateTimeField(1002030)); });
+                delegate { _fieldmap.GetField(new DateTimeField(1002030)); });
             Assert.Throws(typeof(FieldNotFoundException),
-                 delegate { fieldmap.GetField(new CharField(23099)); });
+                 delegate { _fieldmap.GetField(new CharField(23099)); });
             Assert.Throws(typeof(FieldNotFoundException),
-                 delegate { fieldmap.GetField(new BooleanField(99900)); });
+                 delegate { _fieldmap.GetField(new BooleanField(99900)); });
             Assert.Throws(typeof(FieldNotFoundException),
-                 delegate { fieldmap.GetField(new StringField(99900)); });
+                 delegate { _fieldmap.GetField(new StringField(99900)); });
             Assert.Throws(typeof(FieldNotFoundException),
-                delegate { fieldmap.GetField(new IntField(99900)); });
+                delegate { _fieldmap.GetField(new IntField(99900)); });
             Assert.Throws(typeof(FieldNotFoundException),
-                delegate { fieldmap.GetField(new DecimalField(99900)); });
+                delegate { _fieldmap.GetField(new DecimalField(99900)); });
         }
 
         [Test]
@@ -327,11 +324,11 @@ namespace UnitTests
             Assert.That(fm.GetGroup(2, 100), Is.EqualTo(g2));
 
             Assert.Throws(typeof(FieldNotFoundException),
-                delegate { fieldmap.GetGroup(0, 101); });
+                delegate { _fieldmap.GetGroup(0, 101); });
             Assert.Throws(typeof(FieldNotFoundException),
-                delegate { fieldmap.GetGroup(3, 100); });
+                delegate { _fieldmap.GetGroup(3, 100); });
             Assert.Throws(typeof(FieldNotFoundException),
-                delegate { fieldmap.GetGroup(1, 101); });
+                delegate { _fieldmap.GetGroup(1, 101); });
         }
 
         [Test]
@@ -346,18 +343,18 @@ namespace UnitTests
             Assert.That(fm.GetGroup(2, 100), Is.EqualTo(g2));
 
             Assert.Throws(typeof(FieldNotFoundException),
-                delegate { fieldmap.RemoveGroup(0, 101); });
+                delegate { _fieldmap.RemoveGroup(0, 101); });
             Assert.Throws(typeof(FieldNotFoundException),
-                delegate { fieldmap.RemoveGroup(3, 100); });
+                delegate { _fieldmap.RemoveGroup(3, 100); });
             Assert.Throws(typeof(FieldNotFoundException),
-                delegate { fieldmap.RemoveGroup(1, 101); });
+                delegate { _fieldmap.RemoveGroup(1, 101); });
 
             fm.RemoveGroup(1, 100);
             Assert.Throws(typeof(FieldNotFoundException),
-                delegate { fieldmap.GetGroup(2, 100); });
+                delegate { _fieldmap.GetGroup(2, 100); });
             fm.RemoveGroup(1, 100);
             Assert.Throws(typeof(FieldNotFoundException),
-                delegate { fieldmap.GetGroup(1, 100); });
+                delegate { _fieldmap.GetGroup(1, 100); });
         }
 
         [Test]
@@ -373,11 +370,11 @@ namespace UnitTests
 
             Group g3 = new Group(100, 202);
             Assert.Throws(typeof(FieldNotFoundException),
-                delegate { fieldmap.ReplaceGroup(0, 101, g3); });
+                delegate { _fieldmap.ReplaceGroup(0, 101, g3); });
             Assert.Throws(typeof(FieldNotFoundException),
-                delegate { fieldmap.ReplaceGroup(3, 100, g3); });
+                delegate { _fieldmap.ReplaceGroup(3, 100, g3); });
             Assert.Throws(typeof(FieldNotFoundException),
-                delegate { fieldmap.ReplaceGroup(1, 101, g3); });
+                delegate { _fieldmap.ReplaceGroup(1, 101, g3); });
 
             fm.ReplaceGroup(1, 100, g3);
             fm.ReplaceGroup(2, 100, g3);

--- a/UnitTests/FieldTests.cs
+++ b/UnitTests/FieldTests.cs
@@ -2,6 +2,7 @@
 using NUnit.Framework;
 using QuickFix.Fields;
 using UnitTests.TestHelpers;
+using StringField = QuickFix.Fields.StringField;
 
 namespace UnitTests
 {
@@ -21,10 +22,10 @@ namespace UnitTests
         public void IntFieldTest()
         {
             IntField field = new IntField(Tags.AdvTransType, 500);
-            Assert.That(field.getValue(), Is.EqualTo(500));
+            Assert.That(field.Value, Is.EqualTo(500));
             Assert.That(field.Tag, Is.EqualTo(5));
             Assert.That(field.ToString(), Is.EqualTo("500"));
-            Assert.That(field.Obj, Is.EqualTo(500));
+            Assert.That(field.Value, Is.EqualTo(500));
             Assert.That(field.Tag, Is.EqualTo(5));
             field.Tag = 10;
             Assert.That(field.Tag, Is.EqualTo(10));
@@ -34,19 +35,19 @@ namespace UnitTests
         public void StringFieldTest()
         {
             StringField field = new StringField(200, "wayner");
-            Assert.That(field.Obj, Is.EqualTo("wayner"));
-            Assert.That(field.getValue(), Is.EqualTo("wayner"));
+            Assert.That(field.Value, Is.EqualTo("wayner"));
+            Assert.That(field.Value, Is.EqualTo("wayner"));
             Assert.That(field.Tag, Is.EqualTo(200));
-            field.setValue("galway");
-            Assert.That(field.Obj, Is.EqualTo("galway"));
+            field.Value = "galway";
+            Assert.That(field.Value, Is.EqualTo("galway"));
         }
 
         [Test]
         public void CharFieldTest()
         {
             CharField field = new CharField(200, '3');
-            Assert.That(field.Obj, Is.EqualTo('3'));
-            Assert.That(field.getValue(), Is.EqualTo('3'));
+            Assert.That(field.Value, Is.EqualTo('3'));
+            Assert.That(field.Value, Is.EqualTo('3'));
             Assert.That(field.Tag, Is.EqualTo(200));
         }
 
@@ -56,22 +57,22 @@ namespace UnitTests
             Decimal val = new Decimal(3.232535);
             Decimal newval = new Decimal(3.14159);
             DecimalField field = new DecimalField(200, val);
-            Assert.That(field.Obj, Is.EqualTo(val));
-            Assert.That(field.getValue(), Is.EqualTo(val));
+            Assert.That(field.Value, Is.EqualTo(val));
+            Assert.That(field.Value, Is.EqualTo(val));
             Assert.That(field.Tag, Is.EqualTo(200));
-            field.Obj = newval;
-            Assert.That(field.Obj, Is.EqualTo(newval));
+            field.Value = newval;
+            Assert.That(field.Value, Is.EqualTo(newval));
         }
 
         [Test]
         public void BooleanFieldTest()
         {
             BooleanField field = new BooleanField(10, true);
-            Assert.That(field.Obj, Is.EqualTo(true));
-            Assert.That(field.getValue(), Is.EqualTo(true));
+            Assert.That(field.Value, Is.EqualTo(true));
+            Assert.That(field.Value, Is.EqualTo(true));
             Assert.That(field.Tag, Is.EqualTo(10));
-            field.Obj = false;
-            Assert.That(field.Obj, Is.EqualTo(false));
+            field.Value = false;
+            Assert.That(field.Value, Is.EqualTo(false));
         }
 
         [Test]
@@ -80,11 +81,11 @@ namespace UnitTests
             DateTime val = new DateTime( 2009, 9, 4, 3, 44, 1 );
             DateTime newval = new DateTime(2009, 9, 4, 3, 44, 1);
             DateTimeField field = new DateTimeField(200, val);
-            Assert.That(field.Obj, Is.EqualTo(val));
-            Assert.That(field.getValue(), Is.EqualTo(val));
+            Assert.That(field.Value, Is.EqualTo(val));
+            Assert.That(field.Value, Is.EqualTo(val));
             Assert.That(field.Tag, Is.EqualTo(200));
-            field.Obj = newval;
-            Assert.That(field.Obj, Is.EqualTo(newval));
+            field.Value = newval;
+            Assert.That(field.Value, Is.EqualTo(newval));
             Assert.That(field.ToString(), Is.EqualTo("20090904-03:44:01.000"));
         }
         
@@ -94,66 +95,63 @@ namespace UnitTests
             DateTime val = TimeHelper.MakeDateTime(2009, 9, 4, 3, 44, 1, 100, 310, 300);
             DateTime newval = TimeHelper.MakeDateTime(2009, 9, 4, 3, 44, 1, 100, 310, 300);
             DateTimeField field = new DateTimeField(200, val, QuickFix.Fields.Converters.TimeStampPrecision.Nanosecond);
-            Assert.That(field.Obj, Is.EqualTo(val));
-            Assert.That(field.getValue(), Is.EqualTo(val));
+            Assert.That(field.Value, Is.EqualTo(val));
+            Assert.That(field.Value, Is.EqualTo(val));
             Assert.That(field.Tag, Is.EqualTo(200));
-            field.Obj = newval;
-            Assert.That(field.Obj, Is.EqualTo(newval));
+            field.Value = newval;
+            Assert.That(field.Value, Is.EqualTo(newval));
             Assert.That(field.ToString(), Is.EqualTo("20090904-03:44:01.100310300"));
         }
         
         [Test]
         public void StringFieldTest_TotalAndLength()
         {
-            /// <remarks>
-            /// from quickfix/j FieldTest.java
-            /// </remarks>  
             StringField obj = new StringField(12, "VALUE");
-            Assert.That(obj.toStringField(), Is.EqualTo("12=VALUE"));
-            Assert.That(obj.getTotal(), Is.EqualTo(542));
-            Assert.That(obj.getLength(), Is.EqualTo(9));
-            obj.Obj = "VALUF"; // F = E+1
-            Assert.That(obj.toStringField(), Is.EqualTo("12=VALUF"));
-            Assert.That(obj.getTotal(), Is.EqualTo(543));
-            Assert.That(obj.getLength(), Is.EqualTo(9));
+            Assert.That(obj.ToStringField(), Is.EqualTo("12=VALUE"));
+            Assert.That(obj.GetTotal(), Is.EqualTo(542));
+            Assert.That(obj.GetLength(), Is.EqualTo(9));
+            obj.Value = "VALUF"; // F = E+1
+            Assert.That(obj.ToStringField(), Is.EqualTo("12=VALUF"));
+            Assert.That(obj.GetTotal(), Is.EqualTo(543));
+            Assert.That(obj.GetLength(), Is.EqualTo(9));
             obj.Tag = 13; // 13 = 12+1
-            Assert.That(obj.toStringField(), Is.EqualTo("13=VALUF"));
-            Assert.That(obj.getTotal(), Is.EqualTo(544));
-            Assert.That(obj.getLength(), Is.EqualTo(9));
+            Assert.That(obj.ToStringField(), Is.EqualTo("13=VALUF"));
+            Assert.That(obj.GetTotal(), Is.EqualTo(544));
+            Assert.That(obj.GetLength(), Is.EqualTo(9));
 
             // latin-1-specific character
             obj = new StringField(359, "olé!"); // the é is single-byte in iso-8859-1, but is 2 bytes in ascii or utf-8
-            Assert.AreEqual(708, obj.getTotal()); // sum of all bytes in "359=olé!"+nul
-            Assert.AreEqual(9, obj.getLength());  // 8 single-byte chars + 1 nul char
+            Assert.AreEqual(708, obj.GetTotal()); // sum of all bytes in "359=olé!"+nul
+            Assert.AreEqual(9, obj.GetLength());  // 8 single-byte chars + 1 nul char
         }
 
         [Test]
         public void DefaultValTest()
         {
             BooleanField bf = new BooleanField(110);
-            Assert.That(false, Is.EqualTo(bf.Obj));
+            Assert.That(false, Is.EqualTo(bf.Value));
             Assert.That(110, Is.EqualTo(bf.Tag));
             CharField cf = new CharField(300);
-            Assert.That('\0', Is.EqualTo(cf.getValue()));
+            Assert.That('\0', Is.EqualTo(cf.Value));
             Assert.That(300, Is.EqualTo(cf.Tag));
             DateTimeField dtf = new DateTimeField(3);
             Assert.That(3, Is.EqualTo(dtf.Tag));
             StringField sf = new StringField(32);
             Assert.That(32, Is.EqualTo(sf.Tag));
-            Assert.That("", Is.EqualTo(sf.Obj));
+            Assert.That("", Is.EqualTo(sf.Value));
             IntField ifld = new IntField(239);
             Assert.That(239, Is.EqualTo(ifld.Tag));
-            Assert.That(0, Is.EqualTo(ifld.Obj));
+            Assert.That(0, Is.EqualTo(ifld.Value));
             DecimalField df = new DecimalField(1);
             Assert.That(1, Is.EqualTo(df.Tag));
-            Assert.That(new Decimal(0.0), Is.EqualTo(df.Obj));
+            Assert.That(new Decimal(0.0), Is.EqualTo(df.Value));
         }
 
         [Test]
         public void AccountFieldTest()
         {
             Account acct = new Account("iiiD4");
-            Assert.That("iiiD4", Is.EqualTo(acct.Obj));
+            Assert.That("iiiD4", Is.EqualTo(acct.Value));
             Assert.That(Tags.Account, Is.EqualTo(acct.Tag));
         }
 
@@ -161,11 +159,11 @@ namespace UnitTests
         public void EnumFieldTest()
         {
             CommType ct = new CommType(CommType.PER_UNIT);
-            Assert.That('1', Is.EqualTo(ct.getValue()));
+            Assert.That('1', Is.EqualTo(ct.Value));
             ExecInst ei = new ExecInst(ExecInst.STRICT_LIMIT);
-            Assert.That("b", Is.EqualTo(ei.getValue()));
+            Assert.That("b", Is.EqualTo(ei.Value));
             AllocStatus ass = new AllocStatus(AllocStatus.REVERSED);
-            Assert.That(7, Is.EqualTo(ass.getValue()));
+            Assert.That(7, Is.EqualTo(ass.Value));
         }
 
         [Test]

--- a/UnitTests/GenMessageTest.cs
+++ b/UnitTests/GenMessageTest.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using NUnit.Framework;
-using QuickFix;
 using QuickFix.Fields;
 
 namespace UnitTests
@@ -11,88 +8,88 @@ namespace UnitTests
     public class GenMessageTests
     {
         [Test]
-        public void TCRFieldPropertiesTest()
+        public void TcrFieldPropertiesTest()
         {
-            Decimal val = new Decimal(3.232535);
-            QuickFix.FIX44.TradeCaptureReport tcr = new QuickFix.FIX44.TradeCaptureReport();
+            decimal val = 3.232535m;
+            QuickFix.FIX44.TradeCaptureReport tcr = new();
             tcr.AvgPx = new AvgPx(val);
-            Assert.That(tcr.AvgPx.getValue(), Is.EqualTo(val));
+            Assert.That(tcr.AvgPx.Value, Is.EqualTo(val));
         }
 
         [Test]
-        public void TCRFieldGetterTest()
+        public void TcrFieldGetterTest()
         {
-            AvgPx avgPx = new AvgPx(new Decimal(10.5));
+            AvgPx avgPx = new AvgPx(10.5m);
             QuickFix.FIX44.TradeCaptureReport tcr = new QuickFix.FIX44.TradeCaptureReport();
             tcr.SetField(avgPx);
-            Assert.That(tcr.AvgPx.getValue(), Is.EqualTo(avgPx.getValue()));
+            Assert.That(tcr.AvgPx.Value, Is.EqualTo(avgPx.Value));
             AvgPx avgPx2 = new AvgPx();
             tcr.GetField(avgPx2);
-            Assert.That(avgPx2.getValue(), Is.EqualTo(avgPx.getValue()));
+            Assert.That(avgPx2.Value, Is.EqualTo(avgPx.Value));
         }
 
         [Test]
-        public void TCRFieldSetterTypeSafeOldWayTest()
+        public void TcrFieldSetterTypeSafeOldWayTest()
         {
-            AvgPx avgPx = new AvgPx(new Decimal(10.5));
+            AvgPx avgPx = new AvgPx(10.5m);
             QuickFix.FIX44.TradeCaptureReport tcr = new QuickFix.FIX44.TradeCaptureReport();
             tcr.Set(avgPx);
-            Assert.That(tcr.AvgPx.getValue(), Is.EqualTo(avgPx.getValue()));
+            Assert.That(tcr.AvgPx.Value, Is.EqualTo(avgPx.Value));
         }
 
 
         [Test]
-        public void TCRFieldGetterTypeSafeOldWayTest()
+        public void TcrFieldGetterTypeSafeOldWayTest()
         {
-            AvgPx avgPx = new AvgPx(new Decimal(10.5));
+            AvgPx avgPx = new AvgPx(10.5m);
             QuickFix.FIX44.TradeCaptureReport tcr = new QuickFix.FIX44.TradeCaptureReport();
-            tcr.Set(new AvgPx(new Decimal(10.5)));
+            tcr.Set(new AvgPx(10.5m));
             tcr.Get(avgPx);
-            Assert.That(tcr.AvgPx.getValue(), Is.EqualTo(avgPx.getValue()));
+            Assert.That(tcr.AvgPx.Value, Is.EqualTo(avgPx.Value));
         }
 
         [Test]
-        public void TCRMsgTypeGetsSetTest()
+        public void TcrMsgTypeGetsSetTest()
         {
             QuickFix.FIX44.TradeCaptureReport tcr = new QuickFix.FIX44.TradeCaptureReport();
-            Assert.That(tcr.Header.IsSetField(QuickFix.Fields.Tags.MsgType), Is.True);
+            Assert.That(tcr.Header.IsSetField(Tags.MsgType), Is.True);
             MsgType msgType = new MsgType();
             tcr.Header.GetField(msgType);
-            Assert.That(msgType.getValue(), Is.EqualTo("AE"));
+            Assert.That(msgType.Value, Is.EqualTo("AE"));
         }
 
         [Test]
-        public void TCRReqFieldsCTORTest()
+        public void TcrReqFieldsCtorTest()
         {
             QuickFix.FIX44.TradeCaptureReport tcr = new QuickFix.FIX44.TradeCaptureReport(
                 new TradeReportID("dude1"),
                 new PreviouslyReported(true),
                 new Symbol("AAPL"),
-                new LastQty(new Decimal(100.1)),
-                new LastPx(new Decimal(100.2)),
+                new LastQty(100.1m),
+                new LastPx(100.2m),
                 new TradeDate("2010-12-12"),
                 new TransactTime(new DateTime(2010, 12, 15, 10, 55, 32, 455)));
-            Assert.That(tcr.Symbol.getValue(), Is.EqualTo("AAPL"));
-            Assert.That(tcr.TradeReportID.getValue(), Is.EqualTo("dude1"));
+            Assert.That(tcr.Symbol.Value, Is.EqualTo("AAPL"));
+            Assert.That(tcr.TradeReportID.Value, Is.EqualTo("dude1"));
             MsgType msgType = new MsgType();
             tcr.Header.GetField(msgType);
-            Assert.That(msgType.getValue(), Is.EqualTo("AE"));
+            Assert.That(msgType.Value, Is.EqualTo("AE"));
         }
 
         [Test]
-        public void TCRisSetTest()
+        public void TcrIsSetTest()
         {
             QuickFix.FIX44.TradeCaptureReport tcr = new QuickFix.FIX44.TradeCaptureReport(
                 new TradeReportID("dude1"),
                 new PreviouslyReported(true),
                 new Symbol("AAPL"),
-                new LastQty(new Decimal(100.1)),
-                new LastPx(new Decimal(100.2)),
+                new LastQty(100.1m),
+                new LastPx(100.2m),
                 new TradeDate("2010-12-12"),
                 new TransactTime(new DateTime(2010, 12, 15, 10, 55, 32, 455)));
             LastPx lastPx = new LastPx();
             Assert.That(tcr.IsSet(lastPx), Is.True);
-            AvgPx avgPx = new AvgPx(new Decimal(10.5));
+            AvgPx avgPx = new AvgPx(10.5m);
             Assert.That(tcr.IsSet(avgPx), Is.False);
             Assert.That(tcr.IsSetAvgPx(), Is.False);
             tcr.Set(avgPx);
@@ -102,31 +99,32 @@ namespace UnitTests
         }
 
         [Test]
-        public void TCRGroupCTORTest()
+        public void TcrGroupCtorTest()
         {
-            int[] expFieldOrder = new int[] {
-                    54, 37, 198, 11, 526, 66, 453, 1, 660, 581, 81, 575, 576,
+            int[] expFieldOrder =
+            [
+                54, 37, 198, 11, 526, 66, 453, 1, 660, 581, 81, 575, 576,
                     635, 578, 579, 821, 15, 376, 377, 528, 529, 582, 40, 18, 483,
                     336, 625, 943, 12, 13, 479, 497, 381, 157, 230, 158, 159,
                     738, 920, 921, 922, 238, 237, 118, 119, 120, 155, 156, 77,
                     58, 354, 355, 752, 518, 232, 136, 825, 826, 591, 70, 78, 0
-                };
+            ];
             QuickFix.FIX44.TradeCaptureReport.NoSidesGroup noSides = new QuickFix.FIX44.TradeCaptureReport.NoSidesGroup();
             Assert.That(noSides.FieldOrder, Is.EqualTo(expFieldOrder));
             Assert.That(QuickFix.FIX44.TradeCaptureReport.NoSidesGroup.fieldOrder, Is.EqualTo(expFieldOrder));
         }
 
         [Test]
-        public void TCRGroupInGroupCTORTest()
+        public void TcrGroupInGroupCtorTest()
         {
-            int[] expFieldOrder = { 757, 758, 759, 806, 0 };
+            int[] expFieldOrder = [757, 758, 759, 806, 0];
             QuickFix.FIX44.TradeCaptureReport.NoSidesGroup.NoAllocsGroup.NoNested2PartyIDsGroup grp = new QuickFix.FIX44.TradeCaptureReport.NoSidesGroup.NoAllocsGroup.NoNested2PartyIDsGroup();
             Assert.That(grp.FieldOrder, Is.EqualTo(expFieldOrder));
             Assert.That(QuickFix.FIX44.TradeCaptureReport.NoSidesGroup.NoAllocsGroup.NoNested2PartyIDsGroup.fieldOrder, Is.EqualTo(expFieldOrder));
         }
 
         [Test]
-        public void TCRGroupFieldGetterSetterTest()
+        public void TcrGroupFieldGetterSetterTest()
         {
             QuickFix.FIX44.TradeCaptureReport.NoSidesGroup noSides = new QuickFix.FIX44.TradeCaptureReport.NoSidesGroup();
             OrderID ordId = new OrderID("fooey");
@@ -135,7 +133,7 @@ namespace UnitTests
             noSides.Set(ordId);
             Assert.That(noSides.IsSet(ordId), Is.True);
             Assert.That(noSides.IsSetOrderID(), Is.True);
-            Assert.That(noSides.OrderID.getValue(), Is.EqualTo("fooey"));
+            Assert.That(noSides.OrderID.Value, Is.EqualTo("fooey"));
         }
     }
 }

--- a/UnitTests/GroupTests.cs
+++ b/UnitTests/GroupTests.cs
@@ -50,8 +50,8 @@ namespace UnitTests
 
             QuickFix.FIX42.News.LinesOfTextGroup clone = linesGroup.Clone() as QuickFix.FIX42.News.LinesOfTextGroup;
 
-            Assert.AreEqual(linesGroup.Text.Obj, clone.Text.Obj);
-            Assert.AreEqual(linesGroup.EncodedText.Obj, clone.EncodedText.Obj);
+            Assert.AreEqual(linesGroup.Text.Value, clone.Text.Value);
+            Assert.AreEqual(linesGroup.EncodedText.Value, clone.EncodedText.Value);
             Assert.AreEqual(linesGroup.Delim, clone.Delim);
             Assert.AreEqual(linesGroup.CounterField, clone.CounterField);
             Assert.AreEqual(linesGroup.FieldOrder, clone.FieldOrder);


### PR DESCRIPTION
Finished cleaning up all the nullable-enable warnings in the "QuickFIX" csproj!

* deprecate lower-case-starting function names (renamed to upper-case-starting)
* deprecate <Foo>Field.Obj (renamed to Value)
* deprecate <Foo>Field.getValue/setValue (just use Value getter/setter)
* major cleanup of MessageTests.cs
* started cleaning up SessionTests.cs, but that needs more work