### PR TITLE
Fixed issue: throw IOException: The process cannot access the file 'xxxx\log\Non-Session-Log.messages.current.log' because it is being used by another process.

### DIFF
--- a/QuickFIXn/Logger/NonSessionLog.cs
+++ b/QuickFIXn/Logger/NonSessionLog.cs
@@ -16,12 +16,23 @@ public class NonSessionLog : System.IDisposable {
     }
 
     internal void OnEvent(string s) {
+        if (_disposed) return;
+
         lock (_sync) {
             _log ??= _logFactory.CreateNonSessionLog();
         }
-        _log.OnEvent(s);
+        _log?.OnEvent(s);
     }
 
-    public void Dispose() => _log?.Dispose();
+    private bool _disposed;
+    public void Dispose() {
+        if (_disposed) return;
+
+        if (_log != null) {
+            _log.Dispose();
+            _log = null;
+            _disposed = true;
+        }
+    }
 }
 

--- a/QuickFIXn/Logger/NonSessionLog.cs
+++ b/QuickFIXn/Logger/NonSessionLog.cs
@@ -4,7 +4,7 @@ namespace QuickFix.Logger;
 /// A logger that can be used when the calling logic cannot identify a session (which is rare).
 /// Does not create a file until first write.
 /// </summary>
-public class NonSessionLog {
+public class NonSessionLog : System.IDisposable {
 
     private readonly ILogFactory _logFactory;
     private ILog? _log;
@@ -21,5 +21,7 @@ public class NonSessionLog {
         }
         _log.OnEvent(s);
     }
+
+    public void Dispose() => _log?.Dispose();
 }
 

--- a/QuickFIXn/ThreadedSocketAcceptor.cs
+++ b/QuickFIXn/ThreadedSocketAcceptor.cs
@@ -274,6 +274,8 @@ namespace QuickFix
             LogoutAllSessions(force);
             DisposeSessions();
             _sessions.Clear();
+            _nonSessionLog.Dispose();
+            _isStarted = false;
 
             // FIXME StopSessionTimer();
             // FIXME Session.UnregisterSessions(GetSessions());

--- a/UnitTests/ThreadedSocketReactorTests.cs
+++ b/UnitTests/ThreadedSocketReactorTests.cs
@@ -57,7 +57,7 @@ namespace UnitTests
             var ex = Assert.Throws<SocketException>(delegate { testingObject.Run(); })!;
 
             StringAssert.StartsWith("<event> Error starting listener:", stdOut.ToString());
-            StringAssert.StartsWith("Address already in use", ex.Message);
+            Assert.That(ex.SocketErrorCode, Is.EqualTo(SocketError.AddressAlreadyInUse));
         }
 
         [TearDown]


### PR DESCRIPTION
- throw System.IOException: The process cannot access the file 'xxxx\log\Non-Session-Log.messages.current.log' because it is being used by another process. (**Validation using [ThreadedSocketAcceptorTests.TestRecreation](https://github.com/connamara/quickfixn/blob/2d544b5ffd89e7ac57e454aa985b17eae72460a5/UnitTests/ThreadedSocketAcceptorTests.cs#L49C21-L49C35) unit test method**)
- When the `Acceptor` stops, the `_isStarted` field value should be set to `false`.
- Since .NET runtime’s exceptions use culture information to set the Message value, the message value of the Exception should not be asserted, but rather the ErrorCode of the Exception. (**Verify by switching the regional settings of the operating system to a non-English speaking country.**)