### PR TITLE
Upgrade the unit testing framework to the latest version and remove obsolete Assert's methods

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/AcceptanceTest/AcceptanceTest.csproj
+++ b/AcceptanceTest/AcceptanceTest.csproj
@@ -8,11 +8,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.6.1" />
-    <PackageReference Include="coverlet.collector" Version="3.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="NUnit" Version="4.2.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/AcceptanceTest/ReflectorClient.cs
+++ b/AcceptanceTest/ReflectorClient.cs
@@ -39,7 +39,7 @@ internal class ReflectorClient : IReflector
 
     public void Expect(string expectedMessage)
     {
-        Assert.IsNotNull(_socket);
+        Assert.That(_socket, Is.Not.Null);
 
         string actualMessage;
         while (!_parser.ReadFixMessage(out actualMessage))
@@ -107,7 +107,7 @@ internal class ReflectorClient : IReflector
     public void Initiate(string initiateMessage)
     {
         string decoratedMessage = Decorate(initiateMessage);
-        Assert.IsNotNull(_socket);
+        Assert.That(_socket, Is.Not.Null);
         _socket.Send(Encoding.Latin1.GetBytes(decoratedMessage));
     }
 
@@ -180,7 +180,7 @@ internal class ReflectorClient : IReflector
 
     public void InitiateConnect()
     {
-        Assert.IsNull(_socket);
+        Assert.That(_socket, Is.Null);
 
         _socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
         _socket.Connect(_endPoint);
@@ -188,17 +188,17 @@ internal class ReflectorClient : IReflector
 
     public void InitiateDisconnect()
     {
-        Assert.IsNotNull(_socket);
+        Assert.That(_socket, Is.Not.Null);
 
         ShutdownSocket();
     }
 
     public void ExpectDisconnect()
     {
-        Assert.IsNotNull(_socket);
+        Assert.That(_socket, Is.Not.Null);
 
         int bytesRead = _socket.Receive(_readBuffer);
-        Assert.AreEqual(0, bytesRead);
+        Assert.That(bytesRead, Is.EqualTo(0));
 
         ShutdownSocket();
     }

--- a/QuickFIXn/Logger/NonSessionLog.cs
+++ b/QuickFIXn/Logger/NonSessionLog.cs
@@ -4,7 +4,7 @@ namespace QuickFix.Logger;
 /// A logger that can be used when the calling logic cannot identify a session (which is rare).
 /// Does not create a file until first write.
 /// </summary>
-public class NonSessionLog {
+public class NonSessionLog : System.IDisposable {
 
     private readonly ILogFactory _logFactory;
     private ILog? _log;
@@ -21,5 +21,7 @@ public class NonSessionLog {
         }
         _log.OnEvent(s);
     }
+
+    public void Dispose() => _log?.Dispose();
 }
 

--- a/QuickFIXn/ThreadedSocketAcceptor.cs
+++ b/QuickFIXn/ThreadedSocketAcceptor.cs
@@ -274,6 +274,8 @@ namespace QuickFix
             LogoutAllSessions(force);
             DisposeSessions();
             _sessions.Clear();
+            _nonSessionLog.Dispose();
+            _isStarted = false;
 
             // FIXME StopSessionTimer();
             // FIXME Session.UnregisterSessions(GetSessions());

--- a/UnitTests/DDFieldTests.cs
+++ b/UnitTests/DDFieldTests.cs
@@ -18,14 +18,14 @@ namespace UnitTests
 
             DDField ddf = new DDField(5, "Foo", enums, "STRING");
 
-            Assert.AreEqual(ddf.Tag, 5);
-            Assert.AreEqual(ddf.Name, "Foo");
-            Assert.AreEqual(ddf.EnumDict, enums);
-            Assert.AreEqual(ddf.FixFldType, "STRING");
-            Assert.AreEqual(ddf.FieldType, typeof(QuickFix.Fields.StringField));
+            Assert.That(5, Is.EqualTo(ddf.Tag));
+            Assert.That("Foo", Is.EqualTo(ddf.Name));
+            Assert.That(enums, Is.EqualTo(ddf.EnumDict));
+            Assert.That("STRING", Is.EqualTo(ddf.FixFldType));
+            Assert.That(typeof(QuickFix.Fields.StringField), Is.EqualTo(ddf.FieldType));
 
-            Assert.IsFalse(ddf.IsMultipleValueFieldWithEnums);
-            Assert.IsTrue(ddf.HasEnums());
+            Assert.That(ddf.IsMultipleValueFieldWithEnums, Is.False);
+            Assert.That(ddf.HasEnums(), Is.True);
         }
 
         [Test]
@@ -33,14 +33,14 @@ namespace UnitTests
         {
             DDField ddf = new DDField(111, "MultiX", new Dictionary<string, string>(), "MULTIPLEVALUESTRING");
 
-            Assert.AreEqual(ddf.Tag, 111);
-            Assert.AreEqual(ddf.Name, "MultiX");
-            Assert.AreEqual(ddf.EnumDict.Count, 0);
-            Assert.AreEqual(ddf.FixFldType, "MULTIPLEVALUESTRING");
-            Assert.AreEqual(ddf.FieldType, typeof(QuickFix.Fields.StringField));
+            Assert.That(111, Is.EqualTo(ddf.Tag));
+            Assert.That("MultiX", Is.EqualTo(ddf.Name));
+            Assert.That(0, Is.EqualTo(ddf.EnumDict.Count));
+            Assert.That("MULTIPLEVALUESTRING", Is.EqualTo(ddf.FixFldType));
+            Assert.That(typeof(QuickFix.Fields.StringField), Is.EqualTo(ddf.FieldType));
 
-            Assert.IsTrue(ddf.IsMultipleValueFieldWithEnums);
-            Assert.IsFalse(ddf.HasEnums());
+            Assert.That(ddf.IsMultipleValueFieldWithEnums, Is.True);
+            Assert.That(ddf.HasEnums(), Is.False);
         }
     }
 }

--- a/UnitTests/DataDictionaryTests.cs
+++ b/UnitTests/DataDictionaryTests.cs
@@ -54,8 +54,8 @@ namespace UnitTests
             dd.LoadFIXSpec("FIX44");
             Assert.That(dd.FieldHasValue(QuickFix.Fields.Tags.StatusValue, "1"), Is.EqualTo(true));
             Assert.That(dd.FieldHasValue(QuickFix.Fields.Tags.StatusValue, "CONNECTED"), Is.EqualTo(false));
-            Assert.False(dd.FieldsByTag[1].HasEnums());
-            Assert.True(dd.FieldsByTag[945].HasEnums());
+            Assert.That(dd.FieldsByTag[1].HasEnums(), Is.False);
+            Assert.That(dd.FieldsByTag[945].HasEnums(), Is.True);
         }
 
         [Test]
@@ -63,9 +63,9 @@ namespace UnitTests
         {
             DataDictionary dd = new DataDictionary();
             dd.LoadFIXSpec("FIX44");
-            Assert.AreEqual(typeof (Dictionary<string, string>), dd.FieldsByTag[945].EnumDict.GetType());
+            Assert.That(dd.FieldsByTag[945].EnumDict.GetType(), Is.EqualTo(typeof(Dictionary<string, string>)));
             Assert.That("COMPLETED", Is.EqualTo(dd.FieldsByTag[945].EnumDict["2"]));
-            Assert.AreNotEqual("HEARTBEAT", dd.FieldsByTag[35].EnumDict["A"]);
+            Assert.That(dd.FieldsByTag[35].EnumDict["A"], Is.Not.EqualTo("HEARTBEAT"));
         }
 
         [Test]
@@ -82,8 +82,8 @@ namespace UnitTests
             DataDictionary dd = new DataDictionary();
             dd.LoadFIXSpec("FIX44");
             DDMap tcr = dd.Messages["AE"];
-            Assert.True(tcr.Fields.ContainsKey(55));
-            Assert.False(tcr.Fields.ContainsKey(5995));
+            Assert.That(tcr.Fields.ContainsKey(55), Is.True);
+            Assert.That(tcr.Fields.ContainsKey(5995), Is.False);
         }
 
         [Test]
@@ -92,9 +92,9 @@ namespace UnitTests
             DataDictionary dd = new DataDictionary();
             dd.LoadFIXSpec("FIX44");
             DDMap tcrr = dd.Messages["AD"];
-            Assert.True(tcrr.IsGroup(711));
-            Assert.True(tcrr.IsField(711));  // No Field also a field
-            Assert.True(tcrr.GetGroup(711).IsField(311));
+            Assert.That(tcrr.IsGroup(711), Is.True);
+            Assert.That(tcrr.IsField(711), Is.True);  // No Field also a field
+            Assert.That(tcrr.GetGroup(711).IsField(311), Is.True);
             Assert.That(tcrr.Groups[711].Fields[311].Name, Is.EqualTo("UnderlyingSymbol"));
             Assert.That(tcrr.Groups[711].Delim, Is.EqualTo(311));
             DDMap tcr = dd.Messages["AE"];
@@ -108,9 +108,9 @@ namespace UnitTests
             dd.LoadFIXSpec("FIX44");
             DDMap msgJ = dd.Messages["J"];
 
-            Assert.True(msgJ.IsGroup(73));
-            Assert.False(msgJ.IsGroup(756));
-            Assert.True(msgJ.GetGroup(73).IsGroup(756));
+            Assert.That(msgJ.IsGroup(73), Is.True);
+            Assert.That(msgJ.IsGroup(756), Is.False);
+            Assert.That(msgJ.GetGroup(73).IsGroup(756), Is.True);
         }
 
         [Test]
@@ -119,12 +119,12 @@ namespace UnitTests
             DataDictionary dd = new DataDictionary();
             dd.LoadTestFIXSpec("group_begins_group");
             DDMap msg = dd.Messages["magic"];
-            Assert.True(msg.IsGroup(6660)); // NoMagics group
-            Assert.True(msg.GetGroup(6660).IsGroup(7770)); // NoMagics/NoRabbits
-            Assert.True(msg.GetGroup(6660).IsField(6661)); // NoMagics/MagicWord
-            Assert.True(msg.GetGroup(6660).GetGroup(7770).IsField(7711)); // NoMagics/NoRabbits/RabbitName
-            Assert.AreEqual(7770, msg.GetGroup(6660).Delim); // NoMagics delim is NoRabbits counter
-            Assert.AreEqual(7711, msg.GetGroup(6660).GetGroup(7770).Delim); // NoRabbits delim is RabbitName
+            Assert.That(msg.IsGroup(6660), Is.True); // NoMagics group
+            Assert.That(msg.GetGroup(6660).IsGroup(7770), Is.True); // NoMagics/NoRabbits
+            Assert.That(msg.GetGroup(6660).IsField(6661), Is.True); // NoMagics/MagicWord
+            Assert.That(msg.GetGroup(6660).GetGroup(7770).IsField(7711), Is.True); // NoMagics/NoRabbits/RabbitName
+            Assert.That(msg.GetGroup(6660).Delim, Is.EqualTo(7770)); // NoMagics delim is NoRabbits counter
+            Assert.That(msg.GetGroup(6660).GetGroup(7770).Delim, Is.EqualTo(7711)); // NoRabbits delim is RabbitName
         }
 
         [Test]
@@ -133,10 +133,10 @@ namespace UnitTests
             DataDictionary dd = new DataDictionary();
             dd.LoadFIXSpec("FIX44");
             DDMap headerMap = dd.Header;
-            Assert.True(headerMap.IsGroup(627));
+            Assert.That(headerMap.IsGroup(627), Is.True);
             DDGrp grpMap = headerMap.GetGroup(627);
-            Assert.True(dd.Header.GetGroup(627).IsField(628));
-            Assert.True(grpMap.IsField(628));
+            Assert.That(dd.Header.GetGroup(627).IsField(628), Is.True);
+            Assert.That(grpMap.IsField(628), Is.True);
         }
 
         [Test]
@@ -144,8 +144,8 @@ namespace UnitTests
         {
             DataDictionary dd = new DataDictionary();
             dd.LoadFIXSpec("FIX44");
-            Assert.True(dd.Messages["AE"].ReqFields.Contains(571));
-            Assert.False(dd.Messages["AE"].ReqFields.Contains(828));
+            Assert.That(dd.Messages["AE"].ReqFields.Contains(571), Is.True);
+            Assert.That(dd.Messages["AE"].ReqFields.Contains(828), Is.False);
         }
 
         [Test]
@@ -153,7 +153,7 @@ namespace UnitTests
         {
             DataDictionary dd = new DataDictionary();
             dd.LoadFIXSpec("FIX44");
-            Assert.True(dd.Header.ReqFields.Contains(9));
+            Assert.That(dd.Header.ReqFields.Contains(9), Is.True);
             Assert.That(dd.Header.Fields.Count, Is.EqualTo(27));
         }
 
@@ -162,7 +162,7 @@ namespace UnitTests
         {
             DataDictionary dd = new DataDictionary();
             dd.LoadFIXSpec("FIX44");
-            Assert.True(dd.Trailer.ReqFields.Contains(10));
+            Assert.That(dd.Trailer.ReqFields.Contains(10), Is.True);
             Assert.That(dd.Trailer.Fields.Count, Is.EqualTo(3));
         }
 
@@ -315,8 +315,8 @@ namespace UnitTests
 
             //verify that FromString didn't correct the counter
             //HEY YOU, READ THIS NOW: if these fail, first check if MessageTests::FromString_DoNotCorrectCounter() passes
-            Assert.AreEqual("386=3", n.NoTradingSessions.ToStringField());
-            StringAssert.Contains("386=3", n.ConstructString());
+            Assert.That(n.NoTradingSessions.ToStringField(), Is.EqualTo("386=3"));
+            Assert.That(n.ConstructString(), Does.Contain("386=3"));
 
             Assert.Throws<RepeatingGroupCountMismatch>(delegate { dd.CheckGroupCount(n.NoTradingSessions, n, "D"); });
         }
@@ -337,9 +337,9 @@ namespace UnitTests
             dd.LoadFIXSpec("FIX44");
 
             // AD => Instrument component (optional) => 55 (Symbol)
-            Assert.False(dd.Messages["AD"].ReqFields.Contains(55));
+            Assert.That(dd.Messages["AD"].ReqFields.Contains(55), Is.False);
             // 7 => Instrument component (required) => 55 (Symbol)
-            Assert.True(dd.Messages["7"].ReqFields.Contains(55));
+            Assert.That(dd.Messages["7"].ReqFields.Contains(55), Is.True);
         }
 
         [Test]
@@ -347,12 +347,12 @@ namespace UnitTests
         {
             DataDictionary dd = new DataDictionary();
             dd.LoadTestFIXSpec("required_is_optional");
-            Assert.True(dd.Messages["magic"].ReqFields.Contains(1111));  //base required field
-            Assert.False(dd.Messages["magic"].ReqFields.Contains(5555)); //base optional field
-            Assert.False(dd.Messages["magic"].ReqFields.Contains(5556)); //component optional field
+            Assert.That(dd.Messages["magic"].ReqFields.Contains(1111), Is.True);  //base required field
+            Assert.That(dd.Messages["magic"].ReqFields.Contains(5555), Is.False); //base optional field
+            Assert.That(dd.Messages["magic"].ReqFields.Contains(5556), Is.False); //component optional field
 
-            Assert.False(dd.Messages["magic"].Groups[6660].Required); // group isn't required
-            Assert.False(dd.Messages["magic"].Groups[6660].ReqFields.Contains(6662)); // group optional field
+            Assert.That(dd.Messages["magic"].Groups[6660].Required, Is.False); // group isn't required
+            Assert.That(dd.Messages["magic"].Groups[6660].ReqFields.Contains(6662), Is.False); // group optional field
         }
 
         [Test] // Issue #493
@@ -364,13 +364,13 @@ namespace UnitTests
             // The fact that it doesn't throw is sufficient, but we'll do some other checks anyway.
 
             DDMap logon = dd.GetMapForMessage("A")!;
-            Assert.True(logon.IsField(108)); // HeartBtInt
-            Assert.True(logon.IsField(9000)); // CustomField
+            Assert.That(logon.IsField(108), Is.True); // HeartBtInt
+            Assert.That(logon.IsField(9000), Is.True); // CustomField
 
             DDMap news = dd.GetMapForMessage("B")!;
-            Assert.True(news.IsField(148)); // Headline
-            Assert.True(news.IsGroup(33)); // LinesOfText
-            Assert.True(news.GetGroup(33).IsField(355)); // EncodedText
+            Assert.That(news.IsField(148), Is.True); // Headline
+            Assert.That(news.IsGroup(33), Is.True); // LinesOfText
+            Assert.That(news.GetGroup(33).IsField(355), Is.True); // EncodedText
         }
 
         private static XmlNode MakeNode(string xmlString)
@@ -388,22 +388,22 @@ namespace UnitTests
         public void VerifyChildNodeAndReturnNameAtt() {
             XmlNode parentNode = MakeNode("<parentnode name='Daddy'/>");
 
-            Assert.AreEqual("qty", DataDictionary.VerifyChildNodeAndReturnNameAtt(
-                MakeNode("<sometag name='qty'/>"), parentNode));
+            Assert.That(DataDictionary.VerifyChildNodeAndReturnNameAtt(MakeNode("<sometag name='qty'/>"), parentNode),
+                Is.EqualTo("qty"));
 
             DictionaryParseException dpx = Assert.Throws<DictionaryParseException>(
                 delegate { DataDictionary.VerifyChildNodeAndReturnNameAtt(MakeNode("foo"), parentNode); })!;
-            Assert.AreEqual("Malformed data dictionary: Found text-only node containing 'foo'", dpx.Message);
+            Assert.That(dpx.Message, Is.EqualTo("Malformed data dictionary: Found text-only node containing 'foo'"));
 
             dpx = Assert.Throws<DictionaryParseException>(
                 delegate { DataDictionary.VerifyChildNodeAndReturnNameAtt(MakeNode("<field>qty</field>"), parentNode); })!;
-            Assert.AreEqual("Malformed data dictionary: Found 'field' node without 'name' within parent 'parentnode/Daddy'", dpx.Message);
+            Assert.That(dpx.Message, Is.EqualTo("Malformed data dictionary: Found 'field' node without 'name' within parent 'parentnode/Daddy'"));
 
             // alt error message, where parent has no name
             parentNode = MakeNode("<parentnode/>");
             dpx = Assert.Throws<DictionaryParseException>(
                 delegate { DataDictionary.VerifyChildNodeAndReturnNameAtt(MakeNode("<field>qty</field>"), parentNode); })!;
-            Assert.AreEqual("Malformed data dictionary: Found 'field' node without 'name' within parent 'parentnode/parentnode'", dpx.Message);
+            Assert.That(dpx.Message, Is.EqualTo("Malformed data dictionary: Found 'field' node without 'name' within parent 'parentnode/parentnode'"));
         }
     }
 }

--- a/UnitTests/DataDictionary_ValidateTests.cs
+++ b/UnitTests/DataDictionary_ValidateTests.cs
@@ -15,7 +15,7 @@ public class DataDictionary_ValidateTests
 
         var ex = Assert.Throws<UnsupportedVersion>(delegate {
             DataDictionary.Validate(new Message(), dd, dd, "foobar", "X"); });
-        StringAssert.Contains("Incorrect BeginString (foobar)", ex!.Message);
+        Assert.That(ex!.Message, Does.Contain("Incorrect BeginString (foobar)"));
     }
 
     [Test]
@@ -41,7 +41,7 @@ public class DataDictionary_ValidateTests
 
         var ex = Assert.Throws<TagOutOfOrder>(delegate {
             DataDictionary.Validate(msg, dd, dd, "FIX.4.4", "B"); });
-        StringAssert.Contains("Tag specified out of required order", ex!.Message);
+        Assert.That(ex!.Message, Does.Contain("Tag specified out of required order"));
     }
 
     [Test]
@@ -105,9 +105,9 @@ public class DataDictionary_ValidateTests
         Group rabbitGroup = new Group(7770, 7711, new[] { 7711, 7722 });
         magicGroup.GetGroup(2, rabbitGroup);
 
-        Assert.AreEqual("abracadabra", magicGroup.GetString(6661));
-        Assert.AreEqual("Floppy", rabbitGroup.GetString(7711));
-        Assert.AreEqual("white", rabbitGroup.GetString(7712));
+        Assert.That(magicGroup.GetString(6661), Is.EqualTo("abracadabra"));
+        Assert.That(rabbitGroup.GetString(7711), Is.EqualTo("Floppy"));
+        Assert.That(rabbitGroup.GetString(7712), Is.EqualTo("white"));
     }
 
     [Test]
@@ -273,7 +273,7 @@ public class DataDictionary_ValidateTests
 
         var ex = Assert.Throws<RequiredTagMissing>(() =>
             DataDictionary.Validate(message, dd, dd, beginString, msgType));
-        Assert.AreEqual(55, ex!.Field);
+        Assert.That(ex!.Field, Is.EqualTo(55));
     }
 
     [Test] // Issue #66

--- a/UnitTests/DefaultMessageFactoryTests.cs
+++ b/UnitTests/DefaultMessageFactoryTests.cs
@@ -16,13 +16,13 @@ namespace UnitTests
             DefaultMessageFactory dmf = new DefaultMessageFactory(QuickFix.FixValues.ApplVerID.FIX50);
 
             Group g44 = dmf.Create("FIX.4.4", "B", 33);
-            Assert.IsInstanceOf<QuickFix.FIX44.News.LinesOfTextGroup>(g44);
+            Assert.That(g44, Is.InstanceOf<QuickFix.FIX44.News.LinesOfTextGroup>());
 
             Group g50 = dmf.Create("FIXT.1.1", "B", 33);
-            Assert.IsInstanceOf<QuickFix.FIX50.News.NoLinesOfTextGroup>(g50);
+            Assert.That(g50, Is.InstanceOf<QuickFix.FIX50.News.NoLinesOfTextGroup>());
 
             Group g50sp2 = dmf.Create("FIXT.1.1", "CD", QuickFix.Fields.Tags.NoAsgnReqs);
-            Assert.IsNull(g50sp2);
+            Assert.That(g50sp2, Is.Null);
         }
 
         [Test]
@@ -31,10 +31,10 @@ namespace UnitTests
             DefaultMessageFactory dmf = new DefaultMessageFactory();
 
             Group g44 = dmf.Create("FIX.4.4", "B", 33);
-            Assert.IsInstanceOf<QuickFix.FIX44.News.LinesOfTextGroup>(g44);
+            Assert.That(g44, Is.InstanceOf<QuickFix.FIX44.News.LinesOfTextGroup>());
 
             Group g50sp2 = dmf.Create("FIXT.1.1", "CD", QuickFix.Fields.Tags.NoAsgnReqs);
-            Assert.IsInstanceOf<QuickFix.FIX50SP2.StreamAssignmentReport.NoAsgnReqsGroup>(g50sp2);
+            Assert.That(g50sp2, Is.InstanceOf<QuickFix.FIX50SP2.StreamAssignmentReport.NoAsgnReqsGroup>());
         }
     }
 }

--- a/UnitTests/FieldMapTests.cs
+++ b/UnitTests/FieldMapTests.cs
@@ -29,7 +29,7 @@ namespace UnitTests
             CharField r = _fieldmap.GetField(refield);
             Assert.That('e', Is.EqualTo(refield.Value));
 
-            Assert.AreSame(refield, r);
+            Assert.That(r, Is.SameAs(refield));
         }
 
 
@@ -69,7 +69,7 @@ namespace UnitTests
             StringField r = _fieldmap.GetField(acct);
             Assert.That("helloworld", Is.EqualTo(acct.Value));
 
-            Assert.AreSame(r, acct);
+            Assert.That(acct, Is.SameAs(r));
         }
 
         [Test]
@@ -93,7 +93,7 @@ namespace UnitTests
             DateTimeField r = _fieldmap.GetField(tt);
             Assert.That(new DateTime(2010, 12, 10), Is.EqualTo(tt.Value));
 
-            Assert.AreSame(r, tt);
+            Assert.That(tt, Is.SameAs(r));
         }
 
         [Test]
@@ -112,13 +112,13 @@ namespace UnitTests
             _fieldmap.SetField(new DateOnlyField(Tags.MDEntryDate, new DateTime(2009, 12, 10, 1, 2, 3)));
             MDEntryDate ed = new MDEntryDate();
             _fieldmap.GetField(ed);
-            Assert.AreEqual(new DateTime(2009, 12, 10), ed.Value);
+            Assert.That(ed.Value, Is.EqualTo(new DateTime(2009, 12, 10)));
             _fieldmap.SetField(new MDEntryDate(new DateTime(2010, 12, 10)));
             DateOnlyField r = _fieldmap.GetField(ed);
-            Assert.AreEqual(new DateTime(2010, 12, 10), ed.Value);
+            Assert.That(ed.Value, Is.EqualTo(new DateTime(2010, 12, 10)));
 
-            Assert.AreSame(r, ed);
-            Assert.AreEqual("20101210", ed.ToString());
+            Assert.That(ed, Is.SameAs(r));
+            Assert.That(ed.ToString(), Is.EqualTo("20101210"));
         }
 
         [Test]
@@ -127,13 +127,13 @@ namespace UnitTests
             _fieldmap.SetField(new TimeOnlyField(Tags.MDEntryTime, new DateTime(1, 1, 1, 1, 2, 3), false));
             MDEntryTime et = new MDEntryTime();
             _fieldmap.GetField(et);
-            Assert.AreEqual(new DateTime(1980, 01, 01, 1, 2, 3), et.Value);
+            Assert.That(et.Value, Is.EqualTo(new DateTime(1980, 01, 01, 1, 2, 3)));
             _fieldmap.SetField(new MDEntryTime(new DateTime(1, 1, 1, 1, 2, 5)));
             TimeOnlyField r = _fieldmap.GetField(et);
-            Assert.AreEqual(new DateTime(1980, 01, 01, 1, 2, 5), et.Value);
+            Assert.That(et.Value, Is.EqualTo(new DateTime(1980, 01, 01, 1, 2, 5)));
 
-            Assert.AreSame(r, et);
-            Assert.AreEqual("01:02:05.000", et.ToString());
+            Assert.That(et, Is.SameAs(r));
+            Assert.That(et.ToString(), Is.EqualTo("01:02:05.000"));
         }
 
         [Test]
@@ -151,18 +151,18 @@ namespace UnitTests
         public void GetDateOnlyTest()
         {
             _fieldmap.SetField(new DateOnlyField(Tags.MDEntryDate, new DateTime(2009, 12, 10, 1, 2, 3)));
-            Assert.AreEqual(new DateTime(2009, 12, 10), _fieldmap.GetDateTime(Tags.MDEntryDate));
+            Assert.That(_fieldmap.GetDateTime(Tags.MDEntryDate), Is.EqualTo(new DateTime(2009, 12, 10)));
             _fieldmap.SetField(new StringField(233, "20091211"));
-            Assert.AreEqual(new DateTime(2009, 12, 11), _fieldmap.GetDateOnly(233));
+            Assert.That(_fieldmap.GetDateOnly(233), Is.EqualTo(new DateTime(2009, 12, 11)));
         }
 
         [Test]
         public void GetTimeOnlyTest()
         {
             _fieldmap.SetField(new TimeOnlyField(Tags.MDEntryTime, new DateTime(2009, 12, 10, 1, 2, 3)));
-            Assert.AreEqual(new DateTime(1980, 01, 01, 1, 2, 3), _fieldmap.GetDateTime(Tags.MDEntryTime));
+            Assert.That(_fieldmap.GetDateTime(Tags.MDEntryTime), Is.EqualTo(new DateTime(1980, 01, 01, 1, 2, 3)));
             _fieldmap.SetField(new StringField(233, "07:30:47"));
-            Assert.AreEqual(new DateTime(1980, 01, 01, 7, 30, 47), _fieldmap.GetTimeOnly(233));
+            Assert.That(_fieldmap.GetTimeOnly(233), Is.EqualTo(new DateTime(1980, 01, 01, 7, 30, 47)));
         }
 
         [Test]
@@ -178,7 +178,7 @@ namespace UnitTests
             BooleanField r = _fieldmap.GetField(refield);
             Assert.That(false, Is.EqualTo(refield.Value));
 
-            Assert.AreSame(r, refield);
+            Assert.That(refield, Is.SameAs(r));
         }
 
         [Test]
@@ -206,7 +206,7 @@ namespace UnitTests
             IntField r = _fieldmap.GetField(refield);
             Assert.That(102, Is.EqualTo(refield.Value));
 
-            Assert.AreSame(r, refield);
+            Assert.That(refield, Is.SameAs(r));
         }
 
         [Test]
@@ -235,7 +235,7 @@ namespace UnitTests
             DecimalField r = _fieldmap.GetField(refield);
             Assert.That(101.0002, Is.EqualTo(refield.Value));
 
-            Assert.AreSame(r, refield);
+            Assert.That(refield, Is.SameAs(r));
         }
 
         [Test]
@@ -297,19 +297,19 @@ namespace UnitTests
         public void GroupDelimTest()
         {
             Group g1 = new Group(100, 200);
-            Assert.AreEqual(100, g1.CounterField); //counter
-            Assert.AreEqual(200, g1.Delim);
+            Assert.That(g1.CounterField, Is.EqualTo(100)); //counter
+            Assert.That(g1.Delim, Is.EqualTo(200));
 
             g1.SetField(new StringField(200, "delim!"));
 
             FieldMap fm = new FieldMap();
             fm.AddGroup(g1);
-            Assert.AreEqual(1, fm.GetInt(100));
+            Assert.That(fm.GetInt(100), Is.EqualTo(1));
 
             Group g2 = new Group(100, 200);
             g2.SetField(new StringField(200, "again!"));
             fm.AddGroup(g2);
-            Assert.AreEqual(2, fm.GetInt(100));
+            Assert.That(fm.GetInt(100), Is.EqualTo(2));
         }
 
         [Test]
@@ -421,7 +421,7 @@ namespace UnitTests
             fm.AddGroup(linesGroup);
 
             var rvGroup = fm.GetGroup(1, Tags.LinesOfText);
-            Assert.IsInstanceOf<QuickFix.FIX42.News.LinesOfTextGroup>(rvGroup);
+            Assert.That(rvGroup, Is.InstanceOf<QuickFix.FIX42.News.LinesOfTextGroup>());
         }
     }
 }

--- a/UnitTests/FieldTests.cs
+++ b/UnitTests/FieldTests.cs
@@ -13,9 +13,9 @@ namespace UnitTests
         public void Tag()
         {
             // three paths to this value
-            Assert.AreEqual(1, QuickFix.Fields.Account.TAG);
-            Assert.AreEqual(1, new QuickFix.Fields.Account().Tag);
-            Assert.AreEqual(1, QuickFix.Fields.Tags.Account);
+            Assert.That(QuickFix.Fields.Account.TAG, Is.EqualTo(1));
+            Assert.That(new QuickFix.Fields.Account().Tag, Is.EqualTo(1));
+            Assert.That(QuickFix.Fields.Tags.Account, Is.EqualTo(1));
         }
 
         [Test]
@@ -121,8 +121,8 @@ namespace UnitTests
 
             // latin-1-specific character
             obj = new StringField(359, "olé!"); // the é is single-byte in iso-8859-1, but is 2 bytes in ascii or utf-8
-            Assert.AreEqual(708, obj.GetTotal()); // sum of all bytes in "359=olé!"+nul
-            Assert.AreEqual(9, obj.GetLength());  // 8 single-byte chars + 1 nul char
+            Assert.That(obj.GetTotal(), Is.EqualTo(708)); // sum of all bytes in "359=olé!"+nul
+            Assert.That(obj.GetLength(), Is.EqualTo(9));  // 8 single-byte chars + 1 nul char
         }
 
         [Test]
@@ -170,17 +170,17 @@ namespace UnitTests
         public void DateOnlyFieldTest()
         {
             MDEntryDate d = new MDEntryDate(new DateTime(2011, 11, 30, 8, 9, 10, 555));
-            Assert.AreEqual("20111130", d.ToString());
+            Assert.That(d.ToString(), Is.EqualTo("20111130"));
         }
 
         [Test]
         public void TimeOnlyFieldTest()
         {
             MDEntryTime t = new MDEntryTime(new DateTime(2011, 11, 30, 8, 9, 10, 555), true);
-            Assert.AreEqual("08:09:10.555", t.ToString());
+            Assert.That(t.ToString(), Is.EqualTo("08:09:10.555"));
 
             t = new MDEntryTime(new DateTime(2011, 11, 30, 8, 9, 10, 555), false);
-            Assert.AreEqual("08:09:10", t.ToString());
+            Assert.That(t.ToString(), Is.EqualTo("08:09:10"));
         }
 
         [Test]
@@ -193,11 +193,11 @@ namespace UnitTests
             StringField diffTag = new StringField(999, "a");
             IField diffType = new CharField(123, 'a');
 
-            Assert.True(a1.Equals(aSame));
-            Assert.True(a1.Equals(a2));
-            Assert.False(a1.Equals(diffValue));
-            Assert.False(a1.Equals(diffTag));
-            Assert.False(a1.Equals(diffType));
+            Assert.That(a1.Equals(aSame), Is.True);
+            Assert.That(a1.Equals(a2), Is.True);
+            Assert.That(a1.Equals(diffValue), Is.False);
+            Assert.That(a1.Equals(diffTag), Is.False);
+            Assert.That(a1.Equals(diffType), Is.False);
         }
     }
 }

--- a/UnitTests/Fields/Converters/CheckSumConverterTests.cs
+++ b/UnitTests/Fields/Converters/CheckSumConverterTests.cs
@@ -7,16 +7,16 @@ namespace UnitTests.Fields.Converters;
 public class CheckSumConverterTests {
     [Test]
     public void ConvertStringToInt() {
-        Assert.AreEqual(1, CheckSumConverter.Convert("1"));
-        Assert.AreEqual(123, CheckSumConverter.Convert("123"));
-        Assert.AreEqual(12, CheckSumConverter.Convert("012"));
+        Assert.That(CheckSumConverter.Convert("1"), Is.EqualTo(1));
+        Assert.That(CheckSumConverter.Convert("123"), Is.EqualTo(123));
+        Assert.That(CheckSumConverter.Convert("012"), Is.EqualTo(12));
     }
 
     [Test]
     public void ConvertIntToString() {
-        Assert.AreEqual("001", CheckSumConverter.Convert(1));
-        Assert.AreEqual("012", CheckSumConverter.Convert(12));
-        Assert.AreEqual("123", CheckSumConverter.Convert(123));
-        Assert.AreEqual("1234", CheckSumConverter.Convert(1234));
+        Assert.That(CheckSumConverter.Convert(1), Is.EqualTo("001"));
+        Assert.That(CheckSumConverter.Convert(12), Is.EqualTo("012"));
+        Assert.That(CheckSumConverter.Convert(123), Is.EqualTo("123"));
+        Assert.That(CheckSumConverter.Convert(1234), Is.EqualTo("1234"));
     }
 }

--- a/UnitTests/Fields/Converters/DateTimeConverterTests.cs
+++ b/UnitTests/Fields/Converters/DateTimeConverterTests.cs
@@ -176,11 +176,11 @@ public class DateTimeConverterTests {
 #pragma warning restore CS0618
 
         //THEN - the date time object is setup correctly
-        Assert.AreEqual(13, convertedTime.Hours);
-        Assert.AreEqual(22, convertedTime.Minutes);
-        Assert.AreEqual(12, convertedTime.Seconds);
-        Assert.AreEqual(123, convertedTime.Milliseconds);
-        Assert.AreEqual(timeStringWithMicroseconds, string.Format(DateTimeConverter.TIME_ONLY_FORMAT_WITH_MICROSECONDS, new DateTime(convertedTime.Ticks)));
+        Assert.That(convertedTime.Hours, Is.EqualTo(13));
+        Assert.That(convertedTime.Minutes, Is.EqualTo(22));
+        Assert.That(convertedTime.Seconds, Is.EqualTo(12));
+        Assert.That(convertedTime.Milliseconds, Is.EqualTo(123));
+        Assert.That(timeStringWithMicroseconds, Is.EqualTo(string.Format(DateTimeConverter.TIME_ONLY_FORMAT_WITH_MICROSECONDS, new DateTime(convertedTime.Ticks))));
     }
 
     [Test]
@@ -195,10 +195,10 @@ public class DateTimeConverterTests {
 #pragma warning restore CS0618
 
         //THEN - the date time object is setup correctly
-        Assert.AreEqual(13, convertedTime.Hours);
-        Assert.AreEqual(22, convertedTime.Minutes);
-        Assert.AreEqual(12, convertedTime.Seconds);
-        Assert.AreEqual(123, convertedTime.Milliseconds);
-        Assert.AreEqual(timeStringWithMilliseconds + "000", string.Format(DateTimeConverter.TIME_ONLY_FORMAT_WITH_MICROSECONDS, new DateTime(convertedTime.Ticks)));
+        Assert.That(convertedTime.Hours, Is.EqualTo(13));
+        Assert.That(convertedTime.Minutes, Is.EqualTo(22));
+        Assert.That(convertedTime.Seconds, Is.EqualTo(12));
+        Assert.That(convertedTime.Milliseconds, Is.EqualTo(123));
+        Assert.That(timeStringWithMilliseconds + "000", Is.EqualTo(string.Format(DateTimeConverter.TIME_ONLY_FORMAT_WITH_MICROSECONDS, new DateTime(convertedTime.Ticks))));
     }
 }

--- a/UnitTests/FileStoreTests.cs
+++ b/UnitTests/FileStoreTests.cs
@@ -76,39 +76,39 @@ namespace UnitTests
         [Test]
         public void NextSenderMsgSeqNumTest()
         {
-            Assert.AreEqual(1, _store!.NextSenderMsgSeqNum);
+            Assert.That(_store!.NextSenderMsgSeqNum, Is.EqualTo(1));
             _store.NextSenderMsgSeqNum = 5;
-            Assert.AreEqual(5, _store.NextSenderMsgSeqNum);
+            Assert.That(_store.NextSenderMsgSeqNum, Is.EqualTo(5));
             RebuildStore();
-            Assert.AreEqual(5, _store.NextSenderMsgSeqNum);
+            Assert.That(_store.NextSenderMsgSeqNum, Is.EqualTo(5));
         }
 
         [Test]
         public void IncNextSenderMsgSeqNumTest()
         {
             _store!.IncrNextSenderMsgSeqNum();
-            Assert.AreEqual(2, _store.NextSenderMsgSeqNum);
+            Assert.That(_store.NextSenderMsgSeqNum, Is.EqualTo(2));
             RebuildStore();
-            Assert.AreEqual(2, _store.NextSenderMsgSeqNum);
+            Assert.That(_store.NextSenderMsgSeqNum, Is.EqualTo(2));
         }
 
         [Test]
         public void NextTargetMsgSeqNumTest()
         {
-            Assert.AreEqual(1, _store!.NextTargetMsgSeqNum);
+            Assert.That(_store!.NextTargetMsgSeqNum, Is.EqualTo(1));
             _store.NextTargetMsgSeqNum = 6;
-            Assert.AreEqual(6, _store.NextTargetMsgSeqNum);
+            Assert.That(_store.NextTargetMsgSeqNum, Is.EqualTo(6));
             RebuildStore();
-            Assert.AreEqual(6, _store.NextTargetMsgSeqNum);
+            Assert.That(_store.NextTargetMsgSeqNum, Is.EqualTo(6));
         }
 
         [Test]
         public void IncNextTargetMsgSeqNumTest()
         {
             _store!.IncrNextTargetMsgSeqNum();
-            Assert.AreEqual(2, _store.NextTargetMsgSeqNum);
+            Assert.That(_store.NextTargetMsgSeqNum, Is.EqualTo(2));
             RebuildStore();
-            Assert.AreEqual(2, _store.NextTargetMsgSeqNum);
+            Assert.That(_store.NextTargetMsgSeqNum, Is.EqualTo(2));
         }
 
         /// Using UInt64 seqnums per FIX Trading Community Continuous Markets Working Group recommendations.
@@ -124,30 +124,30 @@ namespace UnitTests
             _store.IncrNextTargetMsgSeqNum();
 
             // Then the next seqnums should be UInt64.MaxValue
-            Assert.AreEqual(System.UInt64.MaxValue, _store.NextSenderMsgSeqNum);
-            Assert.AreEqual(System.UInt64.MaxValue, _store.NextTargetMsgSeqNum);
+            Assert.That(_store.NextSenderMsgSeqNum, Is.EqualTo(System.UInt64.MaxValue));
+            Assert.That(_store.NextTargetMsgSeqNum, Is.EqualTo(System.UInt64.MaxValue));
 
             // When the store is reloaded from files
             RebuildStore();
 
             // Then the next seqnums should still be UInt64.MaxValue
-            Assert.AreEqual(System.UInt64.MaxValue, _store.NextSenderMsgSeqNum);
-            Assert.AreEqual(System.UInt64.MaxValue, _store.NextTargetMsgSeqNum);
+            Assert.That(_store.NextSenderMsgSeqNum, Is.EqualTo(System.UInt64.MaxValue));
+            Assert.That(_store.NextTargetMsgSeqNum, Is.EqualTo(System.UInt64.MaxValue));
 
             // When the next seqnums are incremented again
             _store.IncrNextSenderMsgSeqNum();
             _store.IncrNextTargetMsgSeqNum();
 
             // Then the next seqnums should overflow to zero
-            Assert.AreEqual(0, _store.NextSenderMsgSeqNum);
-            Assert.AreEqual(0, _store.NextTargetMsgSeqNum);
+            Assert.That(_store.NextSenderMsgSeqNum, Is.EqualTo(0));
+            Assert.That(_store.NextTargetMsgSeqNum, Is.EqualTo(0));
             
             // When the store is reloaded from files
             RebuildStore();
 
             // Then the next seqnums should still be zero
-            Assert.AreEqual(0, _store.NextSenderMsgSeqNum);
-            Assert.AreEqual(0, _store.NextTargetMsgSeqNum);
+            Assert.That(_store.NextSenderMsgSeqNum, Is.EqualTo(0));
+            Assert.That(_store.NextTargetMsgSeqNum, Is.EqualTo(0));
         }
 
         [Test]
@@ -157,8 +157,8 @@ namespace UnitTests
             _store!.NextTargetMsgSeqNum = 5;
             _store.NextSenderMsgSeqNum = 4;
             _store.Reset();
-            Assert.AreEqual(1, _store.NextTargetMsgSeqNum);
-            Assert.AreEqual(1, _store.NextSenderMsgSeqNum);
+            Assert.That(_store.NextTargetMsgSeqNum, Is.EqualTo(1));
+            Assert.That(_store.NextSenderMsgSeqNum, Is.EqualTo(1));
 
             // Check that messages do not persist after reset
             _store.Set(1, "dude");
@@ -184,7 +184,7 @@ namespace UnitTests
             Thread.Sleep(1000);
             _store.Reset();
             DateTime d3 = _store.CreationTime.Value;
-            Assert.AreEqual(-1, DateTimeOffset.Compare(d1, d3)); // e.g. d1 is earlier than d3
+            Assert.That(DateTimeOffset.Compare(d1, d3), Is.EqualTo(-1)); // e.g. d1 is earlier than d3
         }
 
 
@@ -200,14 +200,14 @@ namespace UnitTests
             _store.Get(2, 3, msgs);
             var expected = new List<string>() { "pude", "ok" };
 
-            Assert.AreEqual(expected, msgs);
+            Assert.That(msgs, Is.EqualTo(expected));
 
             RebuildStore();
 
             msgs = new List<string>();
             _store.Get(2, 3, msgs);
 
-            Assert.AreEqual(expected, msgs);
+            Assert.That(msgs, Is.EqualTo(expected));
         }
     }
 }

--- a/UnitTests/GroupTests.cs
+++ b/UnitTests/GroupTests.cs
@@ -33,7 +33,7 @@ namespace UnitTests
                               + "523=subDEF|803=31|";
 
             //Console.WriteLine(msgString);
-            StringAssert.Contains(expected, msgString.Replace(Message.SOH, '|'));
+            Assert.That(msgString.Replace(Message.SOH, '|'), Does.Contain(expected));
         }
 
         [Test]
@@ -45,11 +45,11 @@ namespace UnitTests
 
             QuickFix.FIX42.News.LinesOfTextGroup clone = (linesGroup.Clone() as QuickFix.FIX42.News.LinesOfTextGroup)!;
 
-            Assert.AreEqual(linesGroup.Text.Value, clone.Text.Value);
-            Assert.AreEqual(linesGroup.EncodedText.Value, clone.EncodedText.Value);
-            Assert.AreEqual(linesGroup.Delim, clone.Delim);
-            Assert.AreEqual(linesGroup.CounterField, clone.CounterField);
-            Assert.AreEqual(linesGroup.FieldOrder, clone.FieldOrder);
+            Assert.That(clone.Text.Value, Is.EqualTo(linesGroup.Text.Value));
+            Assert.That(clone.EncodedText.Value, Is.EqualTo(linesGroup.EncodedText.Value));
+            Assert.That(clone.Delim, Is.EqualTo(linesGroup.Delim));
+            Assert.That(clone.CounterField, Is.EqualTo(linesGroup.CounterField));
+            Assert.That(clone.FieldOrder, Is.EqualTo(linesGroup.FieldOrder));
         }
     }
 }

--- a/UnitTests/Logger/FileLogTests.cs
+++ b/UnitTests/Logger/FileLogTests.cs
@@ -26,8 +26,8 @@ public class FileLogTests
         QuickFix.SessionID someSessionId = new QuickFix.SessionID("FIX.4.4", "sender", "target");
         QuickFix.SessionID someSessionIdWithQualifier = new QuickFix.SessionID("FIX.4.3", "sender", "target", "foo");
 
-        Assert.AreEqual("FIX.4.4-sender-target", FileLog.Prefix(someSessionId));
-        Assert.AreEqual("FIX.4.3-sender-target-foo", FileLog.Prefix(someSessionIdWithQualifier));
+        Assert.That(FileLog.Prefix(someSessionId), Is.EqualTo("FIX.4.4-sender-target"));
+        Assert.That(FileLog.Prefix(someSessionIdWithQualifier), Is.EqualTo("FIX.4.3-sender-target-foo"));
     }
 
     [Test]

--- a/UnitTests/MessageCrackerTests.cs
+++ b/UnitTests/MessageCrackerTests.cs
@@ -61,9 +61,9 @@ namespace UnitTests
                 }
             }
 
-            Assert.AreEqual(2, handlers.Count);
-            Assert.AreEqual(handlers[0].GetParameters()[0].ParameterType, typeof(QuickFix.FIX42.News));
-            Assert.AreEqual(handlers[1].GetParameters()[0].ParameterType, typeof(QuickFix.FIXT11.Logon));
+            Assert.That(handlers.Count, Is.EqualTo(2));
+            Assert.That(typeof(QuickFix.FIX42.News), Is.EqualTo(handlers[0].GetParameters()[0].ParameterType));
+            Assert.That(typeof(QuickFix.FIXT11.Logon), Is.EqualTo(handlers[1].GetParameters()[0].ParameterType));
         }
 
 
@@ -86,19 +86,19 @@ namespace UnitTests
             TestCracker tc = (mc as TestCracker)!;
 
             mc.Crack(new QuickFix.FIX42.News(), _dummySessionId);
-            Assert.IsTrue(tc.CrackedNews42);
-            Assert.IsFalse(tc.CrackedNews44);
+            Assert.That(tc.CrackedNews42, Is.True);
+            Assert.That(tc.CrackedNews44, Is.False);
 
             // reset and do the opposite
             tc.CrackedNews42 = false;
 
             mc.Crack(new QuickFix.FIX44.News(), _dummySessionId);
-            Assert.IsFalse(tc.CrackedNews42);
-            Assert.IsTrue(tc.CrackedNews44);
+            Assert.That(tc.CrackedNews42, Is.False);
+            Assert.That(tc.CrackedNews44, Is.True);
 
-            Assert.IsFalse(tc.CrackedLogonFIXT11);
+            Assert.That(tc.CrackedLogonFIXT11, Is.False);
             mc.Crack(new QuickFix.FIXT11.Logon(), _dummySessionId);
-            Assert.IsTrue(tc.CrackedLogonFIXT11);
+            Assert.That(tc.CrackedLogonFIXT11, Is.True);
         }
 
         [Test]

--- a/UnitTests/MessageTests.cs
+++ b/UnitTests/MessageTests.cs
@@ -160,7 +160,7 @@ namespace UnitTests
             QuickFix.FIX44.ExecutionReport.NoPartyIDsGroup partyGroup = new QuickFix.FIX44.ExecutionReport.NoPartyIDsGroup();
             msg.GetGroup(2, partyGroup);
 
-            Assert.False(partyGroup.IsSetNoPartySubIDs());
+            Assert.That(partyGroup.IsSetNoPartySubIDs(), Is.False);
         }
 
         [Test]
@@ -178,8 +178,8 @@ namespace UnitTests
                         + "10=35|").Replace('|', Message.SOH);
 
             n.FromString(s, true, dd, dd, _defaultMsgFactory);
-            Assert.AreEqual("386=3", n.NoTradingSessions.ToStringField());
-            StringAssert.Contains("386=3", n.ConstructString()); //should not be "corrected" to 2!
+            Assert.That(n.NoTradingSessions.ToStringField(), Is.EqualTo("386=3"));
+            Assert.That(n.ConstructString(), Does.Contain("386=3")); //should not be "corrected" to 2!
         }
 
         [Test]
@@ -239,17 +239,17 @@ namespace UnitTests
             int numHeaderFields = 0;
             foreach (KeyValuePair<int, IField> unused in msg.Header)
                 ++numHeaderFields;
-            Assert.AreEqual(7, numHeaderFields);
+            Assert.That(numHeaderFields, Is.EqualTo(7));
 
             int numTrailerFields = 0;
             foreach (KeyValuePair<int, IField> unused in msg.Trailer)
                 ++numTrailerFields;
-            Assert.AreEqual(1, numTrailerFields);
+            Assert.That(numTrailerFields, Is.EqualTo(1));
 
             int numBodyFields = 0;
             foreach (KeyValuePair<int, IField> unused in msg)
                 ++numBodyFields;
-            Assert.AreEqual(1, numBodyFields);
+            Assert.That(numBodyFields, Is.EqualTo(1));
         }
 
         [Test]
@@ -258,14 +258,14 @@ namespace UnitTests
             string msgStr = ("8=FIX.4.2|9=72|35=0|34=3|49=TW|49=BOGUS|52=20000426-12:05:06|56=ISLD|"
                              + "1=acct123|1=bogus|10=052|10=000|").Replace('|', Message.SOH);
             Message msg = new Message(msgStr);
-            Assert.AreEqual(1, msg.Header.RepeatedTags.Count);
-            Assert.AreEqual(49, msg.Header.RepeatedTags[0].Tag);
+            Assert.That(msg.Header.RepeatedTags.Count, Is.EqualTo(1));
+            Assert.That(msg.Header.RepeatedTags[0].Tag, Is.EqualTo(49));
 
-            Assert.AreEqual(1, msg.Trailer.RepeatedTags.Count);
-            Assert.AreEqual(10, msg.Trailer.RepeatedTags[0].Tag);
+            Assert.That(msg.Trailer.RepeatedTags.Count, Is.EqualTo(1));
+            Assert.That(msg.Trailer.RepeatedTags[0].Tag, Is.EqualTo(10));
 
-            Assert.AreEqual(1, msg.RepeatedTags.Count);
-            Assert.AreEqual(1, msg.RepeatedTags[0].Tag);
+            Assert.That(msg.RepeatedTags.Count, Is.EqualTo(1));
+            Assert.That(msg.RepeatedTags[0].Tag, Is.EqualTo(1));
         }
 
         [Test]
@@ -350,7 +350,7 @@ namespace UnitTests
             n.FromString(s, true, dd, dd, _defaultMsgFactory);
 
             //verify that the data field was read correctly
-            Assert.AreEqual(n.Header.GetInt(212), n.Header.GetString(213).Length);
+            Assert.That(n.Header.GetString(213).Length, Is.EqualTo(n.Header.GetInt(212)));
         }
 
         [Test]
@@ -368,7 +368,7 @@ namespace UnitTests
 
             FieldNotFoundException ex =
                 Assert.Throws<FieldNotFoundException>(delegate { n.FromString(s, true, dd, dd, _defaultMsgFactory); })!;
-            Assert.AreEqual("field not found for tag: 212", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("field not found for tag: 212"));
         }
 
         [Test]
@@ -390,7 +390,7 @@ namespace UnitTests
         [Test]
         public void MsgType()
         {
-            Assert.AreEqual("B", QuickFix.FIX42.News.MsgType);
+            Assert.That(QuickFix.FIX42.News.MsgType, Is.EqualTo("B"));
         }
 
         [Test]
@@ -399,8 +399,8 @@ namespace UnitTests
             string m1 = "8=FIX4.2|9999=99999|".Replace('|', Message.SOH);;
             string m2 = "987=pants|xxxxxxxxxxxxxxxxxxxxxx".Replace('|', Message.SOH);;
 
-            Assert.AreEqual("FIX4.2", Message.ExtractBeginString(m1));
-            Assert.AreEqual("pants", Message.ExtractBeginString(m2));
+            Assert.That(Message.ExtractBeginString(m1), Is.EqualTo("FIX4.2"));
+            Assert.That(Message.ExtractBeginString(m2), Is.EqualTo("pants"));
         }
 
         [Test]
@@ -419,20 +419,20 @@ namespace UnitTests
             n.FromString(s, true, dd, dd, _defaultMsgFactory);
 
             // string values are good?
-            Assert.AreEqual("Y", n.SolicitedFlag.ToString()); //bool, 377
-            Assert.AreEqual("1", n.Side.ToString()); //char, 54
-            Assert.AreEqual("20110901-13:41:31.804", n.TransactTime.ToString()); //datetime, 60
-            Assert.AreEqual("5.5", n.OrderQty.ToString()); //decimal, 38
-            Assert.AreEqual("1", n.PutOrCall.ToString()); //int, 201
-            Assert.AreEqual("asdf", n.ClOrdID.ToString()); //string, 11
+            Assert.That(n.SolicitedFlag.ToString(), Is.EqualTo("Y")); //bool, 377
+            Assert.That(n.Side.ToString(), Is.EqualTo("1")); //char, 54
+            Assert.That(n.TransactTime.ToString(), Is.EqualTo("20110901-13:41:31.804")); //datetime, 60
+            Assert.That(n.OrderQty.ToString(), Is.EqualTo("5.5")); //decimal, 38
+            Assert.That(n.PutOrCall.ToString(), Is.EqualTo("1")); //int, 201
+            Assert.That(n.ClOrdID.ToString(), Is.EqualTo("asdf")); //string, 11
 
             // type-converted values are good?
-            Assert.AreEqual(true, n.SolicitedFlag.Value);
-            Assert.AreEqual('1', n.Side.Value);
-            Assert.AreEqual(DateTime.Parse("2011-09-01 13:41:31.804"), n.TransactTime.Value);
-            Assert.AreEqual(5.5m, n.OrderQty.Value);
-            Assert.AreEqual(1, n.PutOrCall.Value);
-            Assert.AreEqual("asdf", n.ClOrdID.Value);
+            Assert.That(n.SolicitedFlag.Value, Is.EqualTo(true));
+            Assert.That(n.Side.Value, Is.EqualTo('1'));
+            Assert.That(n.TransactTime.Value, Is.EqualTo(DateTime.Parse("2011-09-01 13:41:31.804")));
+            Assert.That(n.OrderQty.Value, Is.EqualTo(5.5m));
+            Assert.That(n.PutOrCall.Value, Is.EqualTo(1));
+            Assert.That(n.ClOrdID.Value, Is.EqualTo("asdf"));
         }
 
         [Test]
@@ -442,16 +442,16 @@ namespace UnitTests
             int n = 0;
 
             var x = QuickFix.Message.ExtractField(msgstr, ref n);
-            Assert.AreEqual(8, n);
-            Assert.AreEqual("100=200", x.ToStringField());
+            Assert.That(n, Is.EqualTo(8));
+            Assert.That(x.ToStringField(), Is.EqualTo("100=200"));
 
             x = QuickFix.Message.ExtractField(msgstr, ref n);
-            Assert.AreEqual(16, n);
-            Assert.AreEqual("300=400", x.ToStringField());
+            Assert.That(n, Is.EqualTo(16));
+            Assert.That(x.ToStringField(), Is.EqualTo("300=400"));
 
             x = QuickFix.Message.ExtractField(msgstr, ref n);
-            Assert.AreEqual(24, n);
-            Assert.AreEqual("500=600", x.ToStringField());
+            Assert.That(n, Is.EqualTo(24));
+            Assert.That(x.ToStringField(), Is.EqualTo("500=600"));
         }
 
         [Test]
@@ -475,7 +475,7 @@ namespace UnitTests
 
             string raw = news.ConstructString();
 
-            StringAssert.Contains("33=2|58=line1|354=3|355=aaa|58=line2|355=bbb|", raw.Replace(Message.SOH, '|'));
+            Assert.That(raw.Replace(Message.SOH, '|'), Does.Contain("33=2|58=line1|354=3|355=aaa|58=line2|355=bbb|"));
         }
 
         [Test]
@@ -493,7 +493,7 @@ namespace UnitTests
             news.AddGroup(group);
 
             string raw = news.ConstructString();
-            StringAssert.Contains("|33=2|58=line1|58=line2|", raw.Replace(Message.SOH, '|'));
+            Assert.That(raw.Replace(Message.SOH, '|'), Does.Contain("|33=2|58=line1|58=line2|"));
         }
 
         [Test]
@@ -584,12 +584,12 @@ namespace UnitTests
         public void GetMsgTypeTest() {
             string msgStr = ("8=FIX.4.4|9=104|35=W|34=3|49=sender|52=20110909-09:09:09.999|56=target"
                              + "55=sym|268=1|269=0|272=20111012|273=22:15:30.444|10=19|").Replace('|', Message.SOH);
-            Assert.AreEqual("W", Message.GetMsgType(msgStr));
+            Assert.That(Message.GetMsgType(msgStr), Is.EqualTo("W"));
 
             // invalid 35 value, let it ride
             string msgStr2 = ("8=FIX.4.4|9=68|35=*|34=3|49=sender|52=20110909-09:09:09.999|56=target"
                               + "55=sym|268=0|10=9|").Replace('|', Message.SOH);
-            Assert.AreEqual("*", Message.GetMsgType(msgStr2));
+            Assert.That(Message.GetMsgType(msgStr2), Is.EqualTo("*"));
         }
 
         [Test]
@@ -618,7 +618,7 @@ namespace UnitTests
             string msgString = msg.ConstructString();
             string expected = "146=2|55=FOO1|48=secid1|55=FOO2|48=secid2|".Replace('|', Message.SOH);
 
-            StringAssert.Contains(expected, msgString);
+            Assert.That(msgString, Does.Contain(expected));
         }
 
         [Test]
@@ -653,7 +653,7 @@ namespace UnitTests
             string expected = "146=2|55=FOO1|65=sfx1|48=secid1|22=src1|55=FOO2|65=sfx2|48=secid2|22=src2|"
                 .Replace('|', Message.SOH);
 
-            StringAssert.Contains(expected, msgString);
+            Assert.That(msgString, Does.Contain(expected));
         }
 
         [Test]
@@ -662,7 +662,7 @@ namespace UnitTests
             QuickFix.FIX50.News msg = new();
             msg.Headline = new Headline("FOO");
 
-            StringAssert.StartsWith("8=FIXT.1.1" + Message.SOH, msg.ConstructString());
+            Assert.That(msg.ConstructString(), Does.StartWith("8=FIXT.1.1" + Message.SOH));
         }
 
         [Test]
@@ -702,7 +702,7 @@ namespace UnitTests
             });
 
             //Console.WriteLine(ci.ToString());
-            StringAssert.Contains(expected, msgString);
+            Assert.That(msgString, Does.Contain(expected));
         }
 
         [Test]
@@ -716,16 +716,16 @@ namespace UnitTests
                              + "148=AAAAAAA|33=2|58=L1|58=L2|10=016|").Replace('|', Message.SOH);
             QuickFix.FIX42.News msg = new QuickFix.FIX42.News();
             msg.FromString(msgStr, false, dd, dd, _defaultMsgFactory);
-            Assert.AreEqual(2, msg.GroupCount(Tags.LinesOfText)); // for sanity
+            Assert.That(msg.GroupCount(Tags.LinesOfText), Is.EqualTo(2)); // for sanity
 
             // the test
             var grp1 = msg.GetGroup(1, Tags.LinesOfText);
-            Assert.IsInstanceOf<QuickFix.FIX42.News.LinesOfTextGroup>(grp1);
-            Assert.AreEqual("L1", (grp1 as QuickFix.FIX42.News.LinesOfTextGroup)!.Text.Value);
+            Assert.That(grp1, Is.InstanceOf<QuickFix.FIX42.News.LinesOfTextGroup>());
+            Assert.That((grp1 as QuickFix.FIX42.News.LinesOfTextGroup)!.Text.Value, Is.EqualTo("L1"));
 
             var grp2 = msg.GetGroup(2, Tags.LinesOfText);
-            Assert.IsInstanceOf<QuickFix.FIX42.News.LinesOfTextGroup>(grp2);
-            Assert.AreEqual("L2", (grp2 as QuickFix.FIX42.News.LinesOfTextGroup)!.Text.Value);
+            Assert.That(grp2, Is.InstanceOf<QuickFix.FIX42.News.LinesOfTextGroup>());
+            Assert.That((grp2 as QuickFix.FIX42.News.LinesOfTextGroup)!.Text.Value, Is.EqualTo("L2"));
         }
 
         [Test]
@@ -739,16 +739,16 @@ namespace UnitTests
                              + "148=AAAAAAA|33=2|58=L1|58=L2|10=016|").Replace('|', Message.SOH);
             QuickFix.FIX42.News msg = new QuickFix.FIX42.News();
             msg.FromString(msgStr, false, dd, dd, _defaultMsgFactory);
-            Assert.AreEqual(2, msg.GroupCount(Tags.LinesOfText)); // for sanity
+            Assert.That(msg.GroupCount(Tags.LinesOfText), Is.EqualTo(2)); // for sanity
 
             // the test
             QuickFix.FIX42.News.LinesOfTextGroup grp = new QuickFix.FIX42.News.LinesOfTextGroup(); // for return value
 
             msg.GetGroup(1, grp);
-            Assert.AreEqual("L1", grp.Text.Value);
+            Assert.That(grp.Text.Value, Is.EqualTo("L1"));
 
             msg.GetGroup(2, grp);
-            Assert.AreEqual("L2", grp.Text.Value);
+            Assert.That(grp.Text.Value, Is.EqualTo("L2"));
         }
 
         [Test]
@@ -769,8 +769,8 @@ namespace UnitTests
 
             GroupDelimiterTagException ex =
                 Assert.Throws<GroupDelimiterTagException>(delegate { msg.FromString(msgStr, true, dd, dd, _defaultMsgFactory); })!;
-            Assert.AreEqual(702, ex.Field);
-            Assert.AreEqual("Group 702's first entry does not start with delimiter 703", ex.Message);
+            Assert.That(ex.Field, Is.EqualTo(702));
+            Assert.That(ex.Message, Is.EqualTo("Group 702's first entry does not start with delimiter 703"));
         }
 
         [Test]
@@ -792,9 +792,9 @@ namespace UnitTests
             msg.FromString(msgStr, true, dd, dd, _defaultMsgFactory);
             QuickFix.FIX44.MarketDataIncrementalRefresh.NoMDEntriesGroup gentry1 = new();
             msg.GetGroup(1, gentry1);
-            Assert.AreEqual(new DateTime(2012, 10, 24), gentry1.MDEntryDate.Value);
-            Assert.AreEqual(new DateTime(2012, 10, 24, 7, 30, 47).TimeOfDay, gentry1.MDEntryTime.Value.TimeOfDay);
-            Assert.AreEqual(new DateTime(2012, 10, 24, 7, 30, 47), gentry1.MDEntryDate.Value + gentry1.MDEntryTime.Value.TimeOfDay);
+            Assert.That(gentry1.MDEntryDate.Value, Is.EqualTo(new DateTime(2012, 10, 24)));
+            Assert.That(gentry1.MDEntryTime.Value.TimeOfDay, Is.EqualTo(new DateTime(2012, 10, 24, 7, 30, 47).TimeOfDay));
+            Assert.That(gentry1.MDEntryDate.Value + gentry1.MDEntryTime.Value.TimeOfDay, Is.EqualTo(new DateTime(2012, 10, 24, 7, 30, 47)));
         }
 
         [Test]
@@ -840,7 +840,7 @@ namespace UnitTests
                  + "269=1|270=108.08|15=EUR|271=884000|272=20121024|273=07:30:47|276=I|282=BEARGB21XXX|299=15467902|")
                 .Replace('|', Message.SOH);
 
-            StringAssert.Contains(expected, msgString);
+            Assert.That(msgString, Does.Contain(expected));
         }
 
         [Test]
@@ -858,7 +858,7 @@ namespace UnitTests
             QuickFix.FIX44.ExecutionReport msg = new QuickFix.FIX44.ExecutionReport();
             msg.FromString(msgStr, true, dd, dd, _defaultMsgFactory);
 
-            Assert.AreEqual(0.23, msg.Factor.Value);
+            Assert.That(msg.Factor.Value, Is.EqualTo(0.23));
         }
 
         [Test]
@@ -876,11 +876,11 @@ namespace UnitTests
             QuickFix.FIX42.Heartbeat heartbeat = new QuickFix.FIX42.Heartbeat();
             heartbeat.FromString(hbStr, true, dd, dd, _defaultMsgFactory);
 
-            Assert.False(news.IsAdmin());
-            Assert.True(news.IsApp());
+            Assert.That(news.IsAdmin(), Is.False);
+            Assert.That(news.IsApp(), Is.True);
 
-            Assert.True(heartbeat.IsAdmin());
-            Assert.False(heartbeat.IsApp());
+            Assert.That(heartbeat.IsAdmin(), Is.True);
+            Assert.That(heartbeat.IsApp(), Is.False);
         }
 
         [Test]
@@ -902,15 +902,14 @@ namespace UnitTests
             msg.FromString(msgStr, false, dd, dd, _defaultMsgFactory);
 
             // make sure no fields were dropped in parsing
-            Assert.AreEqual(msgStr.Length, msg.ConstructString().Length);
+            Assert.That(msg.ConstructString().Length, Is.EqualTo(msgStr.Length));
 
             // make sure repeating groups are not rearranged
             // 1 level deep
-            StringAssert.Contains("55=ABC|65=CD|48=securityid|22=1|".Replace('|', Message.SOH), msg.ConstructString());
+            Assert.That(msg.ConstructString(), Does.Contain("55=ABC|65=CD|48=securityid|22=1|".Replace('|', Message.SOH)));
+
             // 2 levels deep
-            StringAssert.Contains(
-                "311=underlyingsymbol|312=WI|309=underlyingsecurityid|305=1|".Replace('|', Message.SOH),
-                msg.ConstructString());
+            Assert.That(msg.ConstructString(), Does.Contain("311=underlyingsymbol|312=WI|309=underlyingsecurityid|305=1|".Replace('|', Message.SOH)));
         }
 
         [Test]
@@ -922,14 +921,14 @@ namespace UnitTests
             var allocAccountType = new AllocAccountType(AllocAccountType.HOUSE_TRADER);
             message.SetFields(new IField[] { allocAccount, allocAccountType, allocId });
 
-            Assert.AreEqual(true, message.IsSetField(Tags.AllocID));
-            Assert.AreEqual("123456", message.GetString(Tags.AllocID));
+            Assert.That(message.IsSetField(Tags.AllocID), Is.EqualTo(true));
+            Assert.That(message.GetString(Tags.AllocID), Is.EqualTo("123456"));
 
-            Assert.AreEqual(true, message.IsSetField(Tags.AllocAccount));
-            Assert.AreEqual("QuickFixAccount", message.GetString(Tags.AllocAccount));
+            Assert.That(message.IsSetField(Tags.AllocAccount), Is.EqualTo(true));
+            Assert.That(message.GetString(Tags.AllocAccount), Is.EqualTo("QuickFixAccount"));
 
-            Assert.AreEqual(true, message.IsSetField(Tags.AllocAccountType));
-            Assert.AreEqual(AllocAccountType.HOUSE_TRADER, message.GetInt(Tags.AllocAccountType));
+            Assert.That(message.IsSetField(Tags.AllocAccountType), Is.EqualTo(true));
+            Assert.That(message.GetInt(Tags.AllocAccountType), Is.EqualTo(AllocAccountType.HOUSE_TRADER));
         }
 
         [Test]
@@ -943,7 +942,7 @@ namespace UnitTests
             msg.Trailer.SetField(new SignatureLength(4));
 
             string foo = msg.ConstructString().Replace(Message.SOH, '|');
-            StringAssert.EndsWith("|10=099|", foo);
+            Assert.That(foo, Does.EndWith("|10=099|"));
         }
 
         [Test]
@@ -1053,7 +1052,7 @@ namespace UnitTests
             QuickFix.FIX44.News msg = CreateStringResultInput();
             // ToString() does not add BodyLength or CheckSum -- it does not change object state
             string expected = "8=FIX.4.4|35=B|148=myHeadline|33=2|58=line1|58=line2|";
-            Assert.AreEqual(expected, msg.ToString().Replace(Message.SOH, '|'));
+            Assert.That(expected, Is.EqualTo(msg.ToString().Replace(Message.SOH, '|')));
         }
 
         [Test]
@@ -1061,10 +1060,10 @@ namespace UnitTests
             QuickFix.FIX44.News msg = CreateStringResultInput();
             // ConstructString() adds BodyLength and CheckSum
             string expected = "8=FIX.4.4|9=43|35=B|148=myHeadline|33=2|58=line1|58=line2|10=161|";
-            Assert.AreEqual(expected, msg.ConstructString().Replace(Message.SOH, '|'));
+            Assert.That(expected, Is.EqualTo(msg.ConstructString().Replace(Message.SOH, '|')));
 
             // the object state is changed
-            Assert.AreEqual(expected, msg.ToString().Replace(Message.SOH, '|'));
+            Assert.That(expected, Is.EqualTo(msg.ToString().Replace(Message.SOH, '|')));
         }
     }
 }

--- a/UnitTests/MessageToXmlTests.cs
+++ b/UnitTests/MessageToXmlTests.cs
@@ -19,7 +19,7 @@ namespace UnitTests
             msg.FromString(str1, true, null, null, _defaultMsgFactory);
 
             string expected = @"<message><header><field number=""8""><![CDATA[FIX.4.2]]></field><field number=""9""><![CDATA[55]]></field><field number=""34""><![CDATA[3]]></field><field number=""35""><![CDATA[0]]></field><field number=""49""><![CDATA[TW]]></field><field number=""52""><![CDATA[20000426-12:05:06]]></field><field number=""56""><![CDATA[ISLD]]></field></header><body><field number=""1""><![CDATA[acct123]]></field></body><trailer><field number=""10""><![CDATA[123]]></field></trailer></message>";
-            Assert.AreEqual(expected, msg.ToXML());
+            Assert.That(msg.ToXML(), Is.EqualTo(expected));
         }
 
 
@@ -53,10 +53,10 @@ namespace UnitTests
             msg.FromString(msgStr, true, dd, dd, null); // <-- null factory!
 
             string expected = @"<message><header><field name=""BeginString"" number=""8""><![CDATA[FIX.4.4]]></field><field name=""BodyLength"" number=""9""><![CDATA[638]]></field><field name=""MsgSeqNum"" number=""34""><![CDATA[360]]></field><field name=""MsgType"" number=""35""><![CDATA[8]]></field><field name=""SenderCompID"" number=""49""><![CDATA[BLPTSOX]]></field><field name=""SendingTime"" number=""52""><![CDATA[20130321-15:21:23]]></field><field name=""TargetCompID"" number=""56""><![CDATA[THINKTSOX]]></field><field name=""TargetSubID"" number=""57""><![CDATA[6804469]]></field><field name=""DeliverToCompID"" number=""128""><![CDATA[ZERO]]></field></header><body><field name=""AvgPx"" number=""6""><![CDATA[122.255]]></field><field name=""ClOrdID"" number=""11""><![CDATA[61101189]]></field><field name=""CumQty"" number=""14""><![CDATA[1990000]]></field><field name=""Currency"" number=""15""><![CDATA[GBP]]></field><field name=""ExecID"" number=""17""><![CDATA[VCON:20130321:50018:5:12]]></field><field name=""SecurityIDSource"" number=""22""><![CDATA[4]]></field><field name=""LastPx"" number=""31""><![CDATA[122.255]]></field><field name=""LastQty"" number=""32""><![CDATA[1990000]]></field><field name=""OrderID"" number=""37""><![CDATA[116]]></field><field name=""OrderQty"" number=""38""><![CDATA[1990000]]></field><field name=""OrdStatus"" number=""39""><![CDATA[2]]></field><field name=""SecurityID"" number=""48""><![CDATA[GB0032452392]]></field><field name=""Side"" number=""54""><![CDATA[1]]></field><field name=""Symbol"" number=""55""><![CDATA[[N/A]]]></field><field name=""TransactTime"" number=""60""><![CDATA[20130321-15:21:23]]></field><field name=""SettlDate"" number=""64""><![CDATA[20130322]]></field><field name=""TradeDate"" number=""75""><![CDATA[20130321]]></field><field name=""Issuer"" number=""106""><![CDATA[UK TSY 4 1/4% 2036]]></field><field name=""NetMoney"" number=""118""><![CDATA[2436321.85]]></field><field name=""ExecType"" number=""150""><![CDATA[F]]></field><field name=""LeavesQty"" number=""151""><![CDATA[0]]></field><field name=""NumDaysInterest"" number=""157""><![CDATA[15]]></field><field name=""AccruedInterestAmt"" number=""159""><![CDATA[3447.35]]></field><field name=""OrderQty2"" number=""192""><![CDATA[0]]></field><field name=""SecondaryOrderID"" number=""198""><![CDATA[3739:20130321:50018:5]]></field><field name=""CouponRate"" number=""223""><![CDATA[0.0425]]></field><field name=""Factor"" number=""228""><![CDATA[1]]></field><field name=""Yield"" number=""236""><![CDATA[0.0291371041]]></field><field name=""Concession"" number=""238""><![CDATA[0]]></field><field name=""GrossTradeAmt"" number=""381""><![CDATA[2432874.5]]></field><field name=""PriceType"" number=""423""><![CDATA[1]]></field><field name=""NoPartyIDs"" number=""453""><![CDATA[6]]></field><field name=""CountryOfIssue"" number=""470""><![CDATA[GB]]></field><field name=""MaturityDate"" number=""541""><![CDATA[20360307]]></field><group><field name=""PartyIDSource"" number=""447""><![CDATA[D]]></field><field name=""PartyID"" number=""448""><![CDATA[VCON]]></field><field name=""PartyRole"" number=""452""><![CDATA[1]]></field><field name=""NoPartySubIDs"" number=""802""><![CDATA[1]]></field><group><field name=""PartySubID"" number=""523""><![CDATA[14]]></field><field name=""PartySubIDType"" number=""803""><![CDATA[4]]></field></group></group><group><field name=""PartyIDSource"" number=""447""><![CDATA[D]]></field><field name=""PartyID"" number=""448""><![CDATA[TFOLIO:6804469]]></field><field name=""PartyRole"" number=""452""><![CDATA[12]]></field></group><group><field name=""PartyIDSource"" number=""447""><![CDATA[D]]></field><field name=""PartyID"" number=""448""><![CDATA[TFOLIO]]></field><field name=""PartyRole"" number=""452""><![CDATA[11]]></field></group><group><field name=""PartyIDSource"" number=""447""><![CDATA[D]]></field><field name=""PartyID"" number=""448""><![CDATA[THINKFOLIO LTD]]></field><field name=""PartyRole"" number=""452""><![CDATA[13]]></field></group><group><field name=""PartyIDSource"" number=""447""><![CDATA[D]]></field><field name=""PartyID"" number=""448""><![CDATA[SXT]]></field><field name=""PartyRole"" number=""452""><![CDATA[16]]></field></group><group><field name=""PartyIDSource"" number=""447""><![CDATA[D]]></field><field name=""PartyID"" number=""448""><![CDATA[TFOLIO:6804469]]></field><field name=""PartyRole"" number=""452""><![CDATA[36]]></field></group></body><trailer><field name=""CheckSum"" number=""10""><![CDATA[152]]></field></trailer></message>";
-            Assert.AreEqual(expected, msg.ToXML(dataDictionary: dd));
+            Assert.That(msg.ToXML(dataDictionary: dd), Is.EqualTo(expected));
 
             // If no DD, then output can't have field names
-            StringAssert.Contains(@"<field number=""35"">", msg.ToXML());
+            Assert.That(msg.ToXML(), Does.Contain(@"<field number=""35"">"));
         }
 
         [Test]
@@ -90,19 +90,18 @@ namespace UnitTests
 
             // CASE 1: params (dd, false) => tags converted to names, enums are not converted
             const string expected = "{\"Header\":{\"BeginString\":\"FIX.4.4\",\"BodyLength\":\"638\",\"MsgSeqNum\":\"360\",\"MsgType\":\"8\",\"SenderCompID\":\"BLPTSOX\",\"SendingTime\":\"20130321-15:21:23\",\"TargetCompID\":\"THINKTSOX\",\"TargetSubID\":\"6804469\",\"DeliverToCompID\":\"ZERO\"},\"Body\":{\"AvgPx\":\"122.255\",\"ClOrdID\":\"61101189\",\"CumQty\":\"1990000\",\"Currency\":\"GBP\",\"ExecID\":\"VCON:20130321:50018:5:12\",\"SecurityIDSource\":\"4\",\"LastPx\":\"122.255\",\"LastQty\":\"1990000\",\"OrderID\":\"116\",\"OrderQty\":\"1990000\",\"OrdStatus\":\"2\",\"SecurityID\":\"GB0032452392\",\"Side\":\"1\",\"Symbol\":\"[N/A]\",\"TransactTime\":\"20130321-15:21:23\",\"SettlDate\":\"20130322\",\"TradeDate\":\"20130321\",\"Issuer\":\"UK TSY 4 1/4% 2036\",\"NetMoney\":\"2436321.85\",\"ExecType\":\"F\",\"LeavesQty\":\"0\",\"NumDaysInterest\":\"15\",\"AccruedInterestAmt\":\"3447.35\",\"OrderQty2\":\"0\",\"SecondaryOrderID\":\"3739:20130321:50018:5\",\"CouponRate\":\"0.0425\",\"Factor\":\"1\",\"Yield\":\"0.0291371041\",\"Concession\":\"0\",\"GrossTradeAmt\":\"2432874.5\",\"PriceType\":\"1\",\"CountryOfIssue\":\"GB\",\"MaturityDate\":\"20360307\",\"NoPartyIDs\":[{\"PartyIDSource\":\"D\",\"PartyID\":\"VCON\",\"PartyRole\":\"1\",\"NoPartySubIDs\":[{\"PartySubID\":\"14\",\"PartySubIDType\":\"4\"}]},{\"PartyIDSource\":\"D\",\"PartyID\":\"TFOLIO:6804469\",\"PartyRole\":\"12\"},{\"PartyIDSource\":\"D\",\"PartyID\":\"TFOLIO\",\"PartyRole\":\"11\"},{\"PartyIDSource\":\"D\",\"PartyID\":\"THINKFOLIO LTD\",\"PartyRole\":\"13\"},{\"PartyIDSource\":\"D\",\"PartyID\":\"SXT\",\"PartyRole\":\"16\"},{\"PartyIDSource\":\"D\",\"PartyID\":\"TFOLIO:6804469\",\"PartyRole\":\"36\"}]},\"Trailer\":{}}";
-            Assert.AreEqual(expected, msg.ToJSON(dataDictionary: dd, convertEnumsToDescriptions: false));
+            Assert.That(msg.ToJSON(dataDictionary: dd, convertEnumsToDescriptions: false), Is.EqualTo(expected));
 
             // CASE 2: params (dd, true) => tags converted to names, enums are converted to names
-            StringAssert.Contains("\"MsgType\":\"EXECUTION_REPORT\"", msg.ToJSON(dataDictionary: dd, convertEnumsToDescriptions: true));
+            Assert.That(msg.ToJSON(dataDictionary: dd, convertEnumsToDescriptions: true), Does.Contain("\"MsgType\":\"EXECUTION_REPORT\""));
 
             // CASE 3: params (null, false) => tags are numbers, enums are not converted
-            StringAssert.Contains("\"35\":\"8\"", msg.ToJSON(dataDictionary: null));
+            Assert.That(msg.ToJSON(dataDictionary: null), Does.Contain("\"35\":\"8\""));
 
             // EXCEPTION CASE: params (null, true) => Exception
             var ex = Assert.Throws<ArgumentNullException>(delegate { msg.ToJSON(null, true); })!;
-            StringAssert.Contains(
-                "Must be non-null if 'convertEnumsToDescriptions' is true. (Parameter 'dataDictionary')",
-                ex.Message);
+            Assert.That(ex.Message,
+                Does.Contain("Must be non-null if 'convertEnumsToDescriptions' is true. (Parameter 'dataDictionary')"));
         }
     }
 }

--- a/UnitTests/ParserTest.cs
+++ b/UnitTests/ParserTest.cs
@@ -28,28 +28,28 @@ namespace UnitTests
 
             int len = 0;
             int pos = 0;
-            Assert.True(parser.ExtractLength(out len, out pos, normalLength));
-            Assert.AreEqual(12, len);
-            Assert.AreEqual(15, pos);
+            Assert.That(parser.ExtractLength(out len, out pos, normalLength), Is.True);
+            Assert.That(len, Is.EqualTo(12));
+            Assert.That(pos, Is.EqualTo(15));
 
-            Assert.True(parser.ExtractLength(out len, out pos, zeroLength));
-            Assert.AreEqual(0, len);
-            Assert.AreEqual(14, pos);
+            Assert.That(parser.ExtractLength(out len, out pos, zeroLength), Is.True);
+            Assert.That(len, Is.EqualTo(0));
+            Assert.That(pos, Is.EqualTo(14));
 
             Assert.Throws<QuickFix.MessageParseError>(delegate { parser.ExtractLength(out len, out pos, badLength); });
-            Assert.AreEqual(0, pos);
+            Assert.That(pos, Is.EqualTo(0));
 
             Assert.Throws<QuickFix.MessageParseError>(delegate { parser.ExtractLength(out len, out pos, negativeLength); });
-            Assert.AreEqual(0, pos);
+            Assert.That(pos, Is.EqualTo(0));
 
-            Assert.False(parser.ExtractLength(out len, out pos, incomplete_1));
-            Assert.AreEqual(0, pos);
+            Assert.That(parser.ExtractLength(out len, out pos, incomplete_1), Is.False);
+            Assert.That(pos, Is.EqualTo(0));
 
-            Assert.False(parser.ExtractLength(out len, out pos, incomplete_2));
-            Assert.AreEqual(0, pos);
+            Assert.That(parser.ExtractLength(out len, out pos, incomplete_2), Is.False);
+            Assert.That(pos, Is.EqualTo(0));
 
-            Assert.False(parser.ExtractLength(out len, out pos, ""));
-            Assert.AreEqual(0, pos);
+            Assert.That(parser.ExtractLength(out len, out pos, ""), Is.False);
+            Assert.That(pos, Is.EqualTo(0));
         }
 
         [Test]
@@ -82,11 +82,11 @@ namespace UnitTests
 
                 for (int i = 0; i < batchSize; i++)
                 {
-                    Assert.True(parser.ReadFixMessage(out string message));
-                    Assert.AreEqual(batch[i], message);
+                    Assert.That(parser.ReadFixMessage(out string message), Is.True);
+                    Assert.That(message, Is.EqualTo(batch[i]));
                 }
 
-                Assert.False(parser.ReadFixMessage(out _));
+                Assert.That(parser.ReadFixMessage(out _), Is.False);
             }
         }
 
@@ -110,14 +110,14 @@ namespace UnitTests
             for(int i = 0; i < messageParts.Count - 1; i++)
             {
                 parser.AddToStream(CharEncoding.DefaultEncoding.GetBytes(messageParts[i]));
-                Assert.False(parser.ReadFixMessage(out _));
+                Assert.That(parser.ReadFixMessage(out _), Is.False);
             }
 
             string expectedMessage = string.Join("", messageParts.Skip(1));
 
             parser.AddToStream(CharEncoding.DefaultEncoding.GetBytes(messageParts[^1]));
-            Assert.True(parser.ReadFixMessage(out string actualMessage));
-            Assert.AreEqual(expectedMessage, actualMessage);
+            Assert.That(parser.ReadFixMessage(out string actualMessage), Is.True);
+            Assert.That(actualMessage, Is.EqualTo(expectedMessage));
         }
 
         [Test]
@@ -132,8 +132,8 @@ namespace UnitTests
             Assert.Throws<QuickFix.MessageParseError>(delegate { parser.ReadFixMessage(out _); });
             
             // nothing thrown now because the previous call removes bad data from buffer:
-            Assert.True(parser.ReadFixMessage(out string readFixMsg));
-            Assert.AreEqual(normalLength, readFixMsg);
+            Assert.That(parser.ReadFixMessage(out string readFixMsg), Is.True);
+            Assert.That(readFixMsg, Is.EqualTo(normalLength));
         }
 
         [Test]
@@ -142,8 +142,8 @@ namespace UnitTests
             string[] fixMsgFields1 = { "8=FIX.4.4", "9=19", "35=B", "148=Ole!", "33=0", "10=0" };
             string fixMsg1 = String.Join(Message.SOH, fixMsgFields1) + Message.SOH;
 
-            Assert.AreEqual("é", "\x00E9");
-            Assert.AreEqual("é", "\xE9");
+            Assert.That("\x00E9", Is.EqualTo("é"));
+            Assert.That("\xE9", Is.EqualTo("é"));
 
             // In 1.8 and earlier, the default encoding was UTF-8, which treated "é" as 2 bytes,
             // and this message had 9=20, which didn't agree with other implementations.
@@ -157,12 +157,12 @@ namespace UnitTests
             parser.AddToStream(combined, combined.Length);
 
             string readFixMsg1;
-            Assert.True(parser.ReadFixMessage(out readFixMsg1));
-            Assert.AreEqual(fixMsg1, readFixMsg1);
+            Assert.That(parser.ReadFixMessage(out readFixMsg1), Is.True);
+            Assert.That(readFixMsg1, Is.EqualTo(fixMsg1));
 
             string readFixMsg2;
-            Assert.True(parser.ReadFixMessage(out readFixMsg2), "parser.ReadFixMessage(readFixMsg2) failure");
-            Assert.AreEqual(fixMsg2, readFixMsg2);
+            Assert.That(parser.ReadFixMessage(out readFixMsg2), Is.True, "parser.ReadFixMessage(readFixMsg2) failure");
+            Assert.That(readFixMsg2, Is.EqualTo(fixMsg2));
         }
 
         [Test] // Issue #282 investigation
@@ -176,8 +176,8 @@ namespace UnitTests
             parser.AddToStream(bytesMsg, bytesMsg.Length);
 
             string readFixMsg1;
-            Assert.True(parser.ReadFixMessage(out readFixMsg1));
-            Assert.AreEqual(fixMsg1, readFixMsg1);
+            Assert.That(parser.ReadFixMessage(out readFixMsg1), Is.True);
+            Assert.That(readFixMsg1, Is.EqualTo(fixMsg1));
         }
     }
 }

--- a/UnitTests/SessionDynamicTest.cs
+++ b/UnitTests/SessionDynamicTest.cs
@@ -380,17 +380,17 @@ namespace UnitTests
             // Ensure we can log on 1st session to 1st port
             using (var socket11 = ConnectToEngine(AcceptPort))
             {
-                Assert.IsTrue(socket11.Connected, "Failed to connect to 1st accept port");
+                Assert.That(socket11.Connected, Is.True, "Failed to connect to 1st accept port");
                 SendLogon(socket11, StaticAcceptorCompId);
-                Assert.IsTrue(WaitForLogonStatus(StaticAcceptorCompId), "Failed to logon 1st acceptor session");
+                Assert.That(WaitForLogonStatus(StaticAcceptorCompId), Is.True, "Failed to logon 1st acceptor session");
             }
 
             // Ensure we can't log on 2nd session to 1st port
             using (var socket12 = ConnectToEngine(AcceptPort))
             {
-                Assert.IsTrue(socket12.Connected, "Failed to connect to 1st accept port");
+                Assert.That(socket12.Connected, Is.True, "Failed to connect to 1st accept port");
                 SendLogon(socket12, StaticAcceptorCompId2);
-                Assert.IsTrue(WaitForDisconnect(socket12), "Server failed to disconnect 2nd CompID from 1st port");
+                Assert.That(WaitForDisconnect(socket12), Is.True, "Server failed to disconnect 2nd CompID from 1st port");
             }
         }
 
@@ -412,7 +412,7 @@ namespace UnitTests
             var socket = ConnectToEngine(AcceptPort2);
             SendLogon(socket, dynamicCompId);
 
-            Assert.IsTrue(WaitForLogonStatus(dynamicCompId), "Failed to logon dynamic added acceptor session with another port");
+            Assert.That(WaitForLogonStatus(dynamicCompId), Is.True, "Failed to logon dynamic added acceptor session with another port");
         }
         
         [Test]
@@ -425,46 +425,46 @@ namespace UnitTests
             // Ensure we can log on statically (normally) configured acceptor
             var socket01 = ConnectToEngine();
             SendLogon(socket01, StaticAcceptorCompId);
-            Assert.IsTrue(WaitForLogonStatus(StaticAcceptorCompId), "Failed to logon static acceptor session");
+            Assert.That(WaitForLogonStatus(StaticAcceptorCompId), Is.True, "Failed to logon static acceptor session");
 
             // Ensure that attempt to log on as yet un-added dynamic acceptor fails
             var socket02 = ConnectToEngine();
             string dynamicCompId = "acc10";
             SendLogon(socket02, dynamicCompId);
-            Assert.IsTrue(WaitForDisconnect(socket02), "Server failed to disconnect unconfigured CompID");
-            Assert.False(HasReceivedMessage(dynamicCompId), "Unexpected message received for unconfigured CompID");
+            Assert.That(WaitForDisconnect(socket02), Is.True, "Server failed to disconnect unconfigured CompID");
+            Assert.That(HasReceivedMessage(dynamicCompId), Is.False, "Unexpected message received for unconfigured CompID");
 
             // Add the dynamic acceptor and ensure that we can now log on
             SessionID sessionId = CreateSessionId(dynamicCompId);
             SettingsDictionary sessionConfig = CreateSessionConfig(false);
-            Assert.IsTrue(_acceptor.AddSession(sessionId, sessionConfig), "Failed to add dynamic session to acceptor");
+            Assert.That(_acceptor.AddSession(sessionId, sessionConfig), Is.True, "Failed to add dynamic session to acceptor");
             var socket03 = ConnectToEngine();
             SendLogon(socket03, dynamicCompId);
-            Assert.IsTrue(WaitForLogonStatus(dynamicCompId), "Failed to logon dynamic acceptor session");
+            Assert.That(WaitForLogonStatus(dynamicCompId), Is.True, "Failed to logon dynamic acceptor session");
 
             // Ensure that we can't add the same session again
-            Assert.IsFalse(_acceptor.AddSession(sessionId, sessionConfig), "Added dynamic session twice");
+            Assert.That(_acceptor.AddSession(sessionId, sessionConfig), Is.False, "Added dynamic session twice");
 
             // Now that dynamic acceptor is logged on, ensure that unforced attempt to remove session fails
-            Assert.IsFalse(_acceptor.RemoveSession(sessionId, false), "Unexpected success removing active session");
-            Assert.IsTrue(socket03.Connected, "Unexpected loss of connection");
+            Assert.That(_acceptor.RemoveSession(sessionId, false), Is.False, "Unexpected success removing active session");
+            Assert.That(socket03.Connected, Is.True, "Unexpected loss of connection");
 
             // Ensure that forced attempt to remove session dynamic session succeeds, even though it is in logged on state
-            Assert.IsTrue(_acceptor.RemoveSession(sessionId, true), "Failed to remove active session");
-            Assert.IsTrue(WaitForDisconnect(socket03), "Socket still connected after session removed");
-            Assert.IsFalse(IsLoggedOn(dynamicCompId), "Session still logged on after being removed");
+            Assert.That(_acceptor.RemoveSession(sessionId, true), Is.True, "Failed to remove active session");
+            Assert.That(WaitForDisconnect(socket03), Is.True, "Socket still connected after session removed");
+            Assert.That(IsLoggedOn(dynamicCompId), Is.False, "Session still logged on after being removed");
 
             // Ensure that we can perform unforced removal of a dynamic session that is not logged on.
             string dynamicCompId2 = "acc20";
             var sessionId2 = CreateSessionId(dynamicCompId2);
-            Assert.IsTrue(_acceptor.AddSession(sessionId2, CreateSessionConfig(false)), "Failed to add dynamic session to acceptor");
-            Assert.IsTrue(_acceptor.RemoveSession(sessionId2, false), "Failed to remove inactive session");
+            Assert.That(_acceptor.AddSession(sessionId2, CreateSessionConfig(false)), Is.True, "Failed to add dynamic session to acceptor");
+            Assert.That(_acceptor.RemoveSession(sessionId2, false), Is.True, "Failed to remove inactive session");
 
             // Ensure that we can remove statically configured session
-            Assert.IsTrue(IsLoggedOn(StaticAcceptorCompId), "Unexpected logoff");
-            Assert.IsTrue(_acceptor.RemoveSession(CreateSessionId(StaticAcceptorCompId), true), "Failed to remove active session");
-            Assert.IsTrue(WaitForDisconnect(socket01), "Socket still connected after session removed");
-            Assert.IsFalse(IsLoggedOn(StaticAcceptorCompId), "Session still logged on after being removed");
+            Assert.That(IsLoggedOn(StaticAcceptorCompId), Is.True, "Unexpected logoff");
+            Assert.That(_acceptor.RemoveSession(CreateSessionId(StaticAcceptorCompId), true), Is.True, "Failed to remove active session");
+            Assert.That(WaitForDisconnect(socket01), Is.True, "Socket still connected after session removed");
+            Assert.That(IsLoggedOn(StaticAcceptorCompId), Is.False, "Session still logged on after being removed");
         }
 
         [Test]
@@ -476,47 +476,47 @@ namespace UnitTests
                 throw new AssertionException("_initiator is null");
 
             // Ensure we can log on statically (normally) configured initiator
-            Assert.IsTrue(WaitForLogonMessage(StaticInitiatorCompId), "Failed to get logon message for static initiator session");
+            Assert.That(WaitForLogonMessage(StaticInitiatorCompId), Is.True, "Failed to get logon message for static initiator session");
             SendInitiatorLogon(StaticInitiatorCompId);
 
             // Add the dynamic initator and ensure that we can log on
             string dynamicCompId = "ini10";
             var sessionId = CreateSessionId(dynamicCompId);
             var sessionConfig = CreateSessionConfig(true);
-            Assert.IsTrue(_initiator.AddSession(sessionId, sessionConfig), "Failed to add dynamic session to initiator");
-            Assert.IsTrue(WaitForLogonMessage(dynamicCompId), "Failed to get logon message for dynamic initiator session");
+            Assert.That(_initiator.AddSession(sessionId, sessionConfig), Is.True, "Failed to add dynamic session to initiator");
+            Assert.That(WaitForLogonMessage(dynamicCompId), Is.True, "Failed to get logon message for dynamic initiator session");
             SendInitiatorLogon(dynamicCompId);
-            Assert.IsTrue(WaitForLogonStatus(dynamicCompId), "Failed to logon dynamic initiator session");
+            Assert.That(WaitForLogonStatus(dynamicCompId), Is.True, "Failed to logon dynamic initiator session");
 
             // Ensure that we can't add the same session again
-            Assert.IsFalse(_initiator.AddSession(sessionId, sessionConfig), "Added dynamic session twice");
+            Assert.That(_initiator.AddSession(sessionId, sessionConfig), Is.False, "Added dynamic session twice");
 
             // Now that dynamic initiator is logged on, ensure that unforced attempt to remove session fails
-            Assert.IsFalse(_initiator.RemoveSession(sessionId, false), "Unexpected success removing active session");
-            Assert.IsTrue(IsLoggedOn(dynamicCompId), "Unexpected logoff");
+            Assert.That(_initiator.RemoveSession(sessionId, false), Is.False, "Unexpected success removing active session");
+            Assert.That(IsLoggedOn(dynamicCompId), Is.True, "Unexpected logoff");
 
             // Ensure that forced attempt to remove session dynamic session succeeds, even though it is in logged on state
-            Assert.IsTrue(_initiator.RemoveSession(sessionId, true), "Failed to remove active session");
-            Assert.IsTrue(WaitForDisconnect(dynamicCompId), "Socket still connected after session removed");
-            Assert.IsFalse(IsLoggedOn(dynamicCompId), "Session still logged on after being removed");
+            Assert.That(_initiator.RemoveSession(sessionId, true), Is.True, "Failed to remove active session");
+            Assert.That(WaitForDisconnect(dynamicCompId), Is.True, "Socket still connected after session removed");
+            Assert.That(IsLoggedOn(dynamicCompId), Is.False, "Session still logged on after being removed");
 
             // Ensure that we can perform unforced removal of a dynamic session that is not logged on.
             string dynamicCompId2 = "ini20";
             var sessionId2 = CreateSessionId(dynamicCompId2);
-            Assert.IsTrue(_initiator.AddSession(sessionId2, CreateSessionConfig(true)), "Failed to add dynamic session to initiator");
-            Assert.IsTrue(WaitForLogonMessage(dynamicCompId2), "Failed to get logon message for dynamic initiator session");
-            Assert.IsFalse(IsLoggedOn(dynamicCompId2), "Session logged on");
-            Assert.IsTrue(_initiator.RemoveSession(sessionId2, false), "Failed to remove inactive session");
-            Assert.IsTrue(WaitForDisconnect(dynamicCompId2), "Socket still connected after session removed");
+            Assert.That(_initiator.AddSession(sessionId2, CreateSessionConfig(true)), Is.True, "Failed to add dynamic session to initiator");
+            Assert.That(WaitForLogonMessage(dynamicCompId2), Is.True, "Failed to get logon message for dynamic initiator session");
+            Assert.That(IsLoggedOn(dynamicCompId2), Is.False, "Session logged on");
+            Assert.That(_initiator.RemoveSession(sessionId2, false), Is.True, "Failed to remove inactive session");
+            Assert.That(WaitForDisconnect(dynamicCompId2), Is.True, "Socket still connected after session removed");
 
             // Ensure that we can remove statically configured session
-            Assert.IsTrue(IsLoggedOn(StaticInitiatorCompId), "Unexpected loss of connection");
-            Assert.IsTrue(_initiator.RemoveSession(CreateSessionId(StaticInitiatorCompId), true), "Failed to remove active session");
-            Assert.IsTrue(WaitForDisconnect(StaticInitiatorCompId), "Socket still connected after session removed");
-            Assert.IsFalse(IsLoggedOn(StaticInitiatorCompId), "Session still logged on after being removed");
+            Assert.That(IsLoggedOn(StaticInitiatorCompId), Is.True, "Unexpected loss of connection");
+            Assert.That(_initiator.RemoveSession(CreateSessionId(StaticInitiatorCompId), true), Is.True, "Failed to remove active session");
+            Assert.That(WaitForDisconnect(StaticInitiatorCompId), Is.True, "Socket still connected after session removed");
+            Assert.That(IsLoggedOn(StaticInitiatorCompId), Is.False, "Session still logged on after being removed");
 
             // Check that log directory default setting has been effective
-            Assert.Greater(System.IO.Directory.GetFiles(_logPath, QuickFix.Values.BeginString_FIX42 + "*.log").Length, 0);
+            Assert.That(System.IO.Directory.GetFiles(_logPath, QuickFix.Values.BeginString_FIX42 + "*.log").Length, Is.GreaterThan(0));
         }
     }
 }

--- a/UnitTests/SessionScheduleTests.cs
+++ b/UnitTests/SessionScheduleTests.cs
@@ -45,15 +45,15 @@ namespace UnitTests
         {
             SettingsDictionary settings = new SettingsDictionary();
             Exception ex = Assert.Throws(typeof(ConfigError), delegate { new SessionSchedule(settings); })!;
-            StringAssert.Contains("No value for key: StartTime", ex.Message);
+            Assert.That(ex.Message, Does.Contain("No value for key: StartTime"));
 
             settings.SetString(SessionSettings.START_TIME, "00:00:00");
             ex = Assert.Throws(typeof(ConfigError), delegate { new SessionSchedule(settings); })!;
-            StringAssert.Contains("No value for key: EndTime", ex.Message);
+            Assert.That(ex.Message, Does.Contain("No value for key: EndTime"));
 
             settings.SetString(SessionSettings.END_TIME, "00:0blkajsdf");
             ex = Assert.Throws(typeof(ConfigError), delegate { new SessionSchedule(settings); })!;
-            StringAssert.Contains("String '00:0blkajsdf' was not recognized as a valid TimeSpan", ex.Message);
+            Assert.That(ex.Message, Does.Contain("String '00:0blkajsdf' was not recognized as a valid TimeSpan"));
 
             settings.SetString(SessionSettings.END_TIME, "00:00:00");
             Assert.DoesNotThrow(delegate { new SessionSchedule(settings); });
@@ -68,7 +68,7 @@ namespace UnitTests
 
             settings.SetDay(SessionSettings.START_DAY, DayOfWeek.Thursday);
             Exception ex = Assert.Throws(typeof(ConfigError), delegate { new SessionSchedule(settings); })!;
-            StringAssert.Contains("StartDay used without EndDay", ex.Message);
+            Assert.That(ex.Message, Does.Contain("StartDay used without EndDay"));
 
             settings.SetDay(SessionSettings.END_DAY, DayOfWeek.Friday);
             Assert.DoesNotThrow(delegate { new SessionSchedule(settings); });
@@ -81,7 +81,7 @@ namespace UnitTests
             settings.SetString(SessionSettings.WEEKDAYS, "Sun,Tue,Fri");
 
             Exception ex = Assert.Throws(typeof(ConfigError), delegate { new SessionSchedule(settings); })!;
-            StringAssert.Contains("No value for key: StartTime", ex.Message);
+            Assert.That(ex.Message, Does.Contain("No value for key: StartTime"));
 
             settings.SetString(SessionSettings.START_TIME, "00:00:00");
             settings.SetString(SessionSettings.END_TIME, "00:00:00");
@@ -89,7 +89,7 @@ namespace UnitTests
 
             settings.SetString(SessionSettings.START_DAY, "Tue");
             ex = Assert.Throws(typeof(ConfigError), delegate { new SessionSchedule(settings); })!;
-            StringAssert.Contains("StartDay/EndDay are not compatible with 'Weekdays' setting", ex.Message);
+            Assert.That(ex.Message, Does.Contain("StartDay/EndDay are not compatible with 'Weekdays' setting"));
         }
 
         [Test]
@@ -101,13 +101,13 @@ namespace UnitTests
 
             settings.SetString(SessionSettings.START_DAY, "Monday");
             Exception ex = Assert.Throws(typeof(ConfigError), delegate { new SessionSchedule(settings); })!;
-            StringAssert.Contains("NonStopSession is not compatible with StartDay/EndDay and StartTime/EndTime", ex.Message);
+            Assert.That(ex.Message, Does.Contain("NonStopSession is not compatible with StartDay/EndDay and StartTime/EndTime"));
 
             settings = new SettingsDictionary();
             settings.SetBool(SessionSettings.NON_STOP_SESSION, true);
             settings.SetString(SessionSettings.START_TIME, "05:00:00");
             ex = Assert.Throws(typeof(ConfigError), delegate { new SessionSchedule(settings); })!;
-            StringAssert.Contains("NonStopSession is not compatible with StartDay/EndDay and StartTime/EndTime", ex.Message);
+            Assert.That(ex.Message, Does.Contain("NonStopSession is not compatible with StartDay/EndDay and StartTime/EndTime"));
         }
 
         [Test]
@@ -119,10 +119,10 @@ namespace UnitTests
 
             SessionSchedule sched = new SessionSchedule(settings);
 
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2011, 10, 17, 9, 43, 0, DateTimeKind.Utc)));
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2011, 10, 18, 9, 43, 0, DateTimeKind.Utc)));
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2011, 10, 18, 0, 0, 0, DateTimeKind.Utc)));
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2011, 10, 18, 23, 59, 59, DateTimeKind.Utc)));
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 17, 9, 43, 0, DateTimeKind.Utc)), Is.True);
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 18, 9, 43, 0, DateTimeKind.Utc)), Is.True);
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 18, 0, 0, 0, DateTimeKind.Utc)), Is.True);
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 18, 23, 59, 59, DateTimeKind.Utc)), Is.True);
         }
 
         [Test]
@@ -137,18 +137,18 @@ namespace UnitTests
             SessionSchedule sched = new SessionSchedule(settings);
 
             //a sunday
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2011, 10, 16, 9, 43, 0, DateTimeKind.Utc)));
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2011, 10, 16, 23, 59, 59, DateTimeKind.Utc)));
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2011, 10, 16, 0, 0, 0, DateTimeKind.Utc)));
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 16, 9, 43, 0, DateTimeKind.Utc)), Is.True);
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 16, 23, 59, 59, DateTimeKind.Utc)), Is.True);
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 16, 0, 0, 0, DateTimeKind.Utc)), Is.True);
 
             //a monday
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2011, 10, 17, 9, 43, 0, DateTimeKind.Utc)));
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2011, 10, 17, 23, 59, 59, DateTimeKind.Utc)));
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2011, 10, 17, 0, 0, 0, DateTimeKind.Utc)));
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 17, 9, 43, 0, DateTimeKind.Utc)), Is.True);
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 17, 23, 59, 59, DateTimeKind.Utc)), Is.True);
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 17, 0, 0, 0, DateTimeKind.Utc)), Is.True);
 
             //a tuesday
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2011, 10, 18, 9, 43, 0, DateTimeKind.Utc)));
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2011, 10, 18, 0, 0, 0, DateTimeKind.Utc)));
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 18, 9, 43, 0, DateTimeKind.Utc)), Is.True);
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 18, 0, 0, 0, DateTimeKind.Utc)), Is.True);
         }
 
         [Test]
@@ -163,17 +163,17 @@ namespace UnitTests
             SessionSchedule sched = new SessionSchedule(settings);
 
             //a sunday
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2011, 10, 16, 23, 59, 59, DateTimeKind.Utc)));
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2011, 10, 16, 0, 0, 0, DateTimeKind.Utc)));
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 16, 23, 59, 59, DateTimeKind.Utc)), Is.True);
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 16, 0, 0, 0, DateTimeKind.Utc)), Is.True);
 
             //a monday
-            Assert.IsFalse(sched.IsSessionTime(new DateTime(2011, 10, 17, 0, 0, 1, DateTimeKind.Utc)));
-            Assert.IsFalse(sched.IsSessionTime(new DateTime(2011, 10, 17, 4, 0, 1, DateTimeKind.Utc)));
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2011, 10, 17, 23, 59, 59, DateTimeKind.Utc)));
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 17, 0, 0, 1, DateTimeKind.Utc)), Is.False);
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 17, 4, 0, 1, DateTimeKind.Utc)), Is.False);
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 17, 23, 59, 59, DateTimeKind.Utc)), Is.True);
 
             //a tuesday
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2011, 10, 18, 9, 43, 0, DateTimeKind.Utc)));
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2011, 10, 18, 0, 0, 0, DateTimeKind.Utc)));
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 18, 9, 43, 0, DateTimeKind.Utc)), Is.True);
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 18, 0, 0, 0, DateTimeKind.Utc)), Is.True);
         }
 
         [Test]
@@ -188,17 +188,17 @@ namespace UnitTests
             SessionSchedule sched = new SessionSchedule(settings);
 
             //a sunday
-            Assert.IsFalse(sched.IsSessionTime(new DateTime(2011, 10, 16, 23, 59, 59, DateTimeKind.Utc)));
-            Assert.IsFalse(sched.IsSessionTime(new DateTime(2011, 10, 16, 0, 0, 0, DateTimeKind.Utc)));
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 16, 23, 59, 59, DateTimeKind.Utc)), Is.False);
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 16, 0, 0, 0, DateTimeKind.Utc)), Is.False);
 
             //a monday
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2011, 10, 17, 0, 0, 1, DateTimeKind.Utc)));
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2011, 10, 17, 4, 0, 1, DateTimeKind.Utc)));
-            Assert.IsFalse(sched.IsSessionTime(new DateTime(2011, 10, 17, 6, 59, 59, DateTimeKind.Utc)));
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 17, 0, 0, 1, DateTimeKind.Utc)), Is.True);
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 17, 4, 0, 1, DateTimeKind.Utc)), Is.True);
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 17, 6, 59, 59, DateTimeKind.Utc)), Is.False);
 
             //a tuesday
-            Assert.IsFalse(sched.IsSessionTime(new DateTime(2011, 10, 18, 9, 43, 0, DateTimeKind.Utc)));
-            Assert.IsFalse(sched.IsSessionTime(new DateTime(2011, 10, 18, 0, 0, 0, DateTimeKind.Utc)));
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 18, 9, 43, 0, DateTimeKind.Utc)), Is.False);
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 18, 0, 0, 0, DateTimeKind.Utc)), Is.False);
         }
 
 
@@ -216,16 +216,16 @@ namespace UnitTests
             SessionSchedule sched = new SessionSchedule(settings);
 
             //a monday
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2011, 10, 17, 0, 0, 0, DateTimeKind.Utc)));
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2011, 10, 17, 9, 43, 0, DateTimeKind.Utc)));
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 17, 0, 0, 0, DateTimeKind.Utc)), Is.True);
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 17, 9, 43, 0, DateTimeKind.Utc)), Is.True);
 
             // a thursday
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2011, 10, 20, 23, 59, 59, DateTimeKind.Utc)));
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 20, 23, 59, 59, DateTimeKind.Utc)), Is.True);
 
             //a fri, sat, sun
-            Assert.IsFalse(sched.IsSessionTime(new DateTime(2011, 10, 21, 23, 59, 59, DateTimeKind.Utc)));
-            Assert.IsFalse(sched.IsSessionTime(new DateTime(2011, 10, 22, 0, 0, 0, DateTimeKind.Utc)));
-            Assert.IsFalse(sched.IsSessionTime(new DateTime(2011, 10, 16, 9, 43, 0, DateTimeKind.Utc)));
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 21, 23, 59, 59, DateTimeKind.Utc)), Is.False);
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 22, 0, 0, 0, DateTimeKind.Utc)), Is.False);
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 16, 9, 43, 0, DateTimeKind.Utc)), Is.False);
         }
 
         [Test]
@@ -242,17 +242,17 @@ namespace UnitTests
             SessionSchedule sched = new SessionSchedule(settings);
 
             //wed-monday
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2011, 10, 19, 9, 43, 0, DateTimeKind.Utc)));
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2011, 10, 20, 9, 43, 0, DateTimeKind.Utc)));
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2011, 10, 21, 9, 43, 0, DateTimeKind.Utc)));
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2011, 10, 22, 9, 43, 0, DateTimeKind.Utc)));
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2011, 10, 16, 9, 43, 0, DateTimeKind.Utc)));
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 19, 9, 43, 0, DateTimeKind.Utc)), Is.True);
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 20, 9, 43, 0, DateTimeKind.Utc)), Is.True);
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 21, 9, 43, 0, DateTimeKind.Utc)), Is.True);
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 22, 9, 43, 0, DateTimeKind.Utc)), Is.True);
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 16, 9, 43, 0, DateTimeKind.Utc)), Is.True);
 
             //monday
-            Assert.IsFalse(sched.IsSessionTime(new DateTime(2011, 10, 17, 9, 43, 0, DateTimeKind.Utc)));
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 17, 9, 43, 0, DateTimeKind.Utc)), Is.False);
 
             //tuesday
-            Assert.IsFalse(sched.IsSessionTime(new DateTime(2011, 10, 18, 9, 43, 0, DateTimeKind.Utc)));
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 18, 9, 43, 0, DateTimeKind.Utc)), Is.False);
         }
 
         [Test]
@@ -269,24 +269,24 @@ namespace UnitTests
             SessionSchedule sched = new SessionSchedule(settings);
 
             //Monday Scenarios
-            Assert.IsFalse(sched.IsSessionTime(new DateTime(2011, 10, 17, 6, 59, 0, DateTimeKind.Utc)));
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2011, 10, 17, 7, 30, 0, DateTimeKind.Utc)));
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2011, 10, 17, 15, 30, 0, DateTimeKind.Utc)));
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 17, 6, 59, 0, DateTimeKind.Utc)), Is.False);
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 17, 7, 30, 0, DateTimeKind.Utc)), Is.True);
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 17, 15, 30, 0, DateTimeKind.Utc)), Is.True);
 
             //Midweek Scenarios
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2011, 10, 19, 6, 59, 0, DateTimeKind.Utc)));
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2011, 10, 19, 7, 30, 0, DateTimeKind.Utc)));
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2011, 10, 19, 15, 30, 0, DateTimeKind.Utc)));
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 19, 6, 59, 0, DateTimeKind.Utc)), Is.True);
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 19, 7, 30, 0, DateTimeKind.Utc)), Is.True);
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 19, 15, 30, 0, DateTimeKind.Utc)), Is.True);
 
             //Friday Scenarios
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2011, 10, 21, 6, 59, 0, DateTimeKind.Utc)));
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2011, 10, 21, 7, 30, 0, DateTimeKind.Utc)));
-            Assert.IsFalse(sched.IsSessionTime(new DateTime(2011, 10, 21, 15, 30, 0, DateTimeKind.Utc)));
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 21, 6, 59, 0, DateTimeKind.Utc)), Is.True);
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 21, 7, 30, 0, DateTimeKind.Utc)), Is.True);
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 21, 15, 30, 0, DateTimeKind.Utc)), Is.False);
 
             //Weekend
-            Assert.IsFalse(sched.IsSessionTime(new DateTime(2011, 10, 22, 6, 59, 0, DateTimeKind.Utc)));
-            Assert.IsFalse(sched.IsSessionTime(new DateTime(2011, 10, 22, 7, 30, 0, DateTimeKind.Utc)));
-            Assert.IsFalse(sched.IsSessionTime(new DateTime(2011, 10, 22, 15, 30, 0, DateTimeKind.Utc)));
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 22, 6, 59, 0, DateTimeKind.Utc)), Is.False);
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 22, 7, 30, 0, DateTimeKind.Utc)), Is.False);
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 22, 15, 30, 0, DateTimeKind.Utc)), Is.False);
         }
 
         [Test]
@@ -303,14 +303,14 @@ namespace UnitTests
             SessionSchedule sched = new SessionSchedule(settings);
 
             //weekdays
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2011, 10, 17, 15, 30, 0, DateTimeKind.Utc)));
-            Assert.IsFalse(sched.IsSessionTime(new DateTime(2011, 10, 17, 6, 30, 0, DateTimeKind.Utc)), "foo");
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 17, 15, 30, 0, DateTimeKind.Utc)), Is.True);
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 17, 6, 30, 0, DateTimeKind.Utc)), Is.False, "foo");
 
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2011, 10, 21, 5, 30, 59, DateTimeKind.Utc)));
-            Assert.IsFalse(sched.IsSessionTime(new DateTime(2011, 10, 21, 15, 30, 59, DateTimeKind.Utc)));
-            Assert.IsFalse(sched.IsSessionTime(new DateTime(2011, 10, 22, 6, 59, 59, DateTimeKind.Utc)));
-            Assert.IsFalse(sched.IsSessionTime(new DateTime(2011, 10, 22, 7, 00, 1, DateTimeKind.Utc)));
-            Assert.IsFalse(sched.IsSessionTime(new DateTime(2011, 10, 22, 15, 30, 0, DateTimeKind.Utc)));
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 21, 5, 30, 59, DateTimeKind.Utc)), Is.True);
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 21, 15, 30, 59, DateTimeKind.Utc)), Is.False);
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 22, 6, 59, 59, DateTimeKind.Utc)), Is.False);
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 22, 7, 00, 1, DateTimeKind.Utc)), Is.False);
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 22, 15, 30, 0, DateTimeKind.Utc)), Is.False);
         }
 
 
@@ -323,12 +323,12 @@ namespace UnitTests
 
             SessionSchedule sched = new SessionSchedule(settings);
 
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2011, 10, 17, 0, 12, 0, DateTimeKind.Utc)));
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2011, 10, 17, 5, 43, 0, DateTimeKind.Utc)));
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2011, 10, 18, 6, 0, 23, DateTimeKind.Utc)));
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 17, 0, 12, 0, DateTimeKind.Utc)), Is.True);
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 17, 5, 43, 0, DateTimeKind.Utc)), Is.True);
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 18, 6, 0, 23, DateTimeKind.Utc)), Is.True);
 
-            Assert.IsFalse(sched.IsSessionTime(new DateTime(2011, 10, 18, 0, 11, 0, DateTimeKind.Utc)));
-            Assert.IsFalse(sched.IsSessionTime(new DateTime(2011, 10, 18, 6, 0, 24, DateTimeKind.Utc)));
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 18, 0, 11, 0, DateTimeKind.Utc)), Is.False);
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 18, 6, 0, 24, DateTimeKind.Utc)), Is.False);
         }
 
         [Test]
@@ -340,12 +340,12 @@ namespace UnitTests
 
             SessionSchedule sched = new SessionSchedule(settings);
 
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2011, 10, 17, 6, 0, 23, DateTimeKind.Utc)));
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2011, 10, 17, 8, 43, 0, DateTimeKind.Utc)));
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2011, 10, 18, 0, 12, 00, DateTimeKind.Utc)));
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 17, 6, 0, 23, DateTimeKind.Utc)), Is.True);
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 17, 8, 43, 0, DateTimeKind.Utc)), Is.True);
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 18, 0, 12, 00, DateTimeKind.Utc)), Is.True);
 
-            Assert.IsFalse(sched.IsSessionTime(new DateTime(2011, 10, 18, 0, 12, 1, DateTimeKind.Utc)));
-            Assert.IsFalse(sched.IsSessionTime(new DateTime(2011, 10, 18, 6, 0, 22, DateTimeKind.Utc)));
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 18, 0, 12, 1, DateTimeKind.Utc)), Is.False);
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 18, 6, 0, 22, DateTimeKind.Utc)), Is.False);
 
         }
 
@@ -383,10 +383,10 @@ namespace UnitTests
 
             SessionSchedule sched = new SessionSchedule(settings);
 
-            Assert.IsFalse(sched.IsSessionTime(new DateTime(2011, 10, 17, 13, 29, 59, DateTimeKind.Utc)));
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2011, 10, 17, 13, 30, 0, DateTimeKind.Utc)));
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2011, 10, 17, 20, 0, 0, DateTimeKind.Utc)));
-            Assert.IsFalse(sched.IsSessionTime(new DateTime(2011, 10, 17, 20, 0, 1, DateTimeKind.Utc)));
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 17, 13, 29, 59, DateTimeKind.Utc)), Is.False);
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 17, 13, 30, 0, DateTimeKind.Utc)), Is.True);
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 17, 20, 0, 0, DateTimeKind.Utc)), Is.True);
+            Assert.That(sched.IsSessionTime(new DateTime(2011, 10, 17, 20, 0, 1, DateTimeKind.Utc)), Is.False);
         }
 
         [Test]
@@ -412,12 +412,12 @@ namespace UnitTests
             settings.SetString(SessionSettings.END_TIME, "16:00:00");
             SessionSchedule sched = new SessionSchedule(settings);
 
-            Assert.AreEqual("20121018-16:00:00",
-                sched.NextEndTime(new DateTime(2012, 10, 18, 15, 59, 59, DateTimeKind.Utc)).ToString(DtFmt));
-            Assert.AreEqual("20121018-16:00:00",
-                sched.NextEndTime(new DateTime(2012, 10, 18, 16, 00, 00, DateTimeKind.Utc)).ToString(DtFmt));
-            Assert.AreEqual("20121019-16:00:00",
-                sched.NextEndTime(new DateTime(2012, 10, 18, 16, 00, 01, DateTimeKind.Utc)).ToString(DtFmt));
+            Assert.That(sched.NextEndTime(new DateTime(2012, 10, 18, 15, 59, 59, DateTimeKind.Utc)).ToString(DtFmt),
+                Is.EqualTo("20121018-16:00:00"));
+            Assert.That(sched.NextEndTime(new DateTime(2012, 10, 18, 16, 00, 00, DateTimeKind.Utc)).ToString(DtFmt),
+                Is.EqualTo("20121018-16:00:00"));
+            Assert.That(sched.NextEndTime(new DateTime(2012, 10, 18, 16, 00, 01, DateTimeKind.Utc)).ToString(DtFmt),
+                Is.EqualTo("20121019-16:00:00"));
 
             // ==========
             // Settings file is specified in a zone (est, -5)
@@ -427,12 +427,12 @@ namespace UnitTests
             settings.SetString(SessionSettings.TIME_ZONE, EasternStandardTimeZoneId); //-5
             sched = new SessionSchedule(settings);
 
-            Assert.AreEqual("20121218-11:00:00",
-                sched.NextEndTime(new DateTime(2012, 12, 18, 15, 59, 59, DateTimeKind.Utc)).ToString(DtFmt));
-            Assert.AreEqual("20121218-11:00:00",
-                sched.NextEndTime(new DateTime(2012, 12, 18, 16, 00, 00, DateTimeKind.Utc)).ToString(DtFmt));
-            Assert.AreEqual("20121219-11:00:00",
-                sched.NextEndTime(new DateTime(2012, 12, 18, 16, 00, 01, DateTimeKind.Utc)).ToString(DtFmt));
+            Assert.That(sched.NextEndTime(new DateTime(2012, 12, 18, 15, 59, 59, DateTimeKind.Utc)).ToString(DtFmt),
+                Is.EqualTo("20121218-11:00:00"));
+            Assert.That(sched.NextEndTime(new DateTime(2012, 12, 18, 16, 00, 00, DateTimeKind.Utc)).ToString(DtFmt),
+                Is.EqualTo("20121218-11:00:00"));
+            Assert.That(sched.NextEndTime(new DateTime(2012, 12, 18, 16, 00, 01, DateTimeKind.Utc)).ToString(DtFmt),
+                Is.EqualTo("20121219-11:00:00"));
 
             // ==========
             // Time zone during Daylight Savings
@@ -442,12 +442,12 @@ namespace UnitTests
             settings.SetString(SessionSettings.TIME_ZONE, EasternStandardTimeZoneId); //-4 for DST
             sched = new SessionSchedule(settings);
 
-            Assert.AreEqual("20120618-12:00:00",
-                sched.NextEndTime(new DateTime(2012, 06, 18, 15, 59, 59, DateTimeKind.Utc)).ToString(DtFmt));
-            Assert.AreEqual("20120618-12:00:00",
-                sched.NextEndTime(new DateTime(2012, 06, 18, 16, 00, 00, DateTimeKind.Utc)).ToString(DtFmt));
-            Assert.AreEqual("20120619-12:00:00",
-                sched.NextEndTime(new DateTime(2012, 06, 18, 16, 00, 01, DateTimeKind.Utc)).ToString(DtFmt));
+            Assert.That(sched.NextEndTime(new DateTime(2012, 06, 18, 15, 59, 59, DateTimeKind.Utc)).ToString(DtFmt),
+                Is.EqualTo("20120618-12:00:00"));
+            Assert.That(sched.NextEndTime(new DateTime(2012, 06, 18, 16, 00, 00, DateTimeKind.Utc)).ToString(DtFmt),
+                Is.EqualTo("20120618-12:00:00"));
+            Assert.That(sched.NextEndTime(new DateTime(2012, 06, 18, 16, 00, 01, DateTimeKind.Utc)).ToString(DtFmt),
+                Is.EqualTo("20120619-12:00:00"));
         }
 
         [Test]
@@ -461,12 +461,12 @@ namespace UnitTests
             SessionSchedule sched = new SessionSchedule(settings);
 
             // Oct 15 and 22 are Mondays, 19 and 26 are Fridays
-            Assert.AreEqual("20121019-16:00:00",
-                sched.NextEndTime(new DateTime(2012, 10, 19, 15, 59, 59, DateTimeKind.Utc)).ToString(DtFmt));
-            Assert.AreEqual("20121019-16:00:00",
-                sched.NextEndTime(new DateTime(2012, 10, 19, 16, 00, 00, DateTimeKind.Utc)).ToString(DtFmt));
-            Assert.AreEqual("20121026-16:00:00",
-                sched.NextEndTime(new DateTime(2012, 10, 19, 16, 00, 01, DateTimeKind.Utc)).ToString(DtFmt));
+            Assert.That(sched.NextEndTime(new DateTime(2012, 10, 19, 15, 59, 59, DateTimeKind.Utc)).ToString(DtFmt),
+                Is.EqualTo("20121019-16:00:00"));
+            Assert.That(sched.NextEndTime(new DateTime(2012, 10, 19, 16, 00, 00, DateTimeKind.Utc)).ToString(DtFmt),
+                Is.EqualTo("20121019-16:00:00"));
+            Assert.That(sched.NextEndTime(new DateTime(2012, 10, 19, 16, 00, 01, DateTimeKind.Utc)).ToString(DtFmt),
+                Is.EqualTo("20121026-16:00:00"));
 
             // ==========
             // Settings file is specified in a zone (est, -5)
@@ -479,12 +479,12 @@ namespace UnitTests
             sched = new SessionSchedule(settings);
 
             // Dec 14 and 21 are Fridays
-            Assert.AreEqual("20121214-11:00:00",
-                sched.NextEndTime(new DateTime(2012, 12, 14, 15, 59, 59, DateTimeKind.Utc)).ToString(DtFmt));
-            Assert.AreEqual("20121214-11:00:00",
-                sched.NextEndTime(new DateTime(2012, 12, 14, 16, 00, 00, DateTimeKind.Utc)).ToString(DtFmt));
-            Assert.AreEqual("20121221-11:00:00",
-                sched.NextEndTime(new DateTime(2012, 12, 14, 16, 00, 01, DateTimeKind.Utc)).ToString(DtFmt));
+            Assert.That(sched.NextEndTime(new DateTime(2012, 12, 14, 15, 59, 59, DateTimeKind.Utc)).ToString(DtFmt),
+                Is.EqualTo("20121214-11:00:00"));
+            Assert.That(sched.NextEndTime(new DateTime(2012, 12, 14, 16, 00, 00, DateTimeKind.Utc)).ToString(DtFmt),
+                Is.EqualTo("20121214-11:00:00"));
+            Assert.That(sched.NextEndTime(new DateTime(2012, 12, 14, 16, 00, 01, DateTimeKind.Utc)).ToString(DtFmt),
+                Is.EqualTo("20121221-11:00:00"));
 
             // ==========
             // Time zone during Daylight Savings
@@ -497,13 +497,12 @@ namespace UnitTests
             sched = new SessionSchedule(settings);
 
             // June 15 and 22 are Fridays
-            Assert.AreEqual("20120615-12:00:00",
-                sched.NextEndTime(new DateTime(2012, 06, 15, 15, 59, 59, DateTimeKind.Utc)).ToString(DtFmt));
-            Assert.AreEqual("20120615-12:00:00",
-                sched.NextEndTime(new DateTime(2012, 06, 15, 16, 00, 00, DateTimeKind.Utc)).ToString(DtFmt));
-            Assert.AreEqual("20120622-12:00:00",
-                sched.NextEndTime(new DateTime(2012, 06, 15, 16, 00, 01, DateTimeKind.Utc)).ToString(DtFmt));
-
+            Assert.That(sched.NextEndTime(new DateTime(2012, 06, 15, 15, 59, 59, DateTimeKind.Utc)).ToString(DtFmt),
+                Is.EqualTo("20120615-12:00:00"));
+            Assert.That(sched.NextEndTime(new DateTime(2012, 06, 15, 16, 00, 00, DateTimeKind.Utc)).ToString(DtFmt),
+                Is.EqualTo("20120615-12:00:00"));
+            Assert.That(sched.NextEndTime(new DateTime(2012, 06, 15, 16, 00, 01, DateTimeKind.Utc)).ToString(DtFmt),
+                Is.EqualTo("20120622-12:00:00"));
         }
 
         [Test]
@@ -532,18 +531,18 @@ namespace UnitTests
             settings.SetString(SessionSettings.END_TIME, "16:00:00");
             SessionSchedule sched = new SessionSchedule(settings);
 
-            Assert.False(sched.IsNewSession(
+            Assert.That(sched.IsNewSession(
                 new DateTime(2012, 10, 18, 15, 59, 58, DateTimeKind.Utc),
-                new DateTime(2012, 10, 18, 15, 59, 59, DateTimeKind.Utc)));
-            Assert.False(sched.IsNewSession(
+                new DateTime(2012, 10, 18, 15, 59, 59, DateTimeKind.Utc)), Is.False);
+            Assert.That(sched.IsNewSession(
                 new DateTime(2012, 10, 18, 15, 59, 59, DateTimeKind.Utc),
-                new DateTime(2012, 10, 18, 16, 00, 00, DateTimeKind.Utc)));
-            Assert.True(sched.IsNewSession(
+                new DateTime(2012, 10, 18, 16, 00, 00, DateTimeKind.Utc)), Is.False);
+            Assert.That(sched.IsNewSession(
                 new DateTime(2012, 10, 18, 16, 00, 00, DateTimeKind.Utc),
-                new DateTime(2012, 10, 18, 16, 00, 01, DateTimeKind.Utc)));
-            Assert.False(sched.IsNewSession(
+                new DateTime(2012, 10, 18, 16, 00, 01, DateTimeKind.Utc)), Is.True);
+            Assert.That(sched.IsNewSession(
                 new DateTime(2012, 10, 18, 16, 00, 01, DateTimeKind.Utc),
-                new DateTime(2012, 10, 18, 16, 00, 02, DateTimeKind.Utc)));
+                new DateTime(2012, 10, 18, 16, 00, 02, DateTimeKind.Utc)), Is.False);
 
             // ==========
             // Settings file is specified in a zone (est, -5)
@@ -553,18 +552,18 @@ namespace UnitTests
             settings.SetString(SessionSettings.TIME_ZONE, EasternStandardTimeZoneId); //-5
             sched = new SessionSchedule(settings);
 
-            Assert.False(sched.IsNewSession(
+            Assert.That(sched.IsNewSession(
                 new DateTime(2012, 12, 18, 15, 59, 58, DateTimeKind.Utc),
-                new DateTime(2012, 12, 18, 15, 59, 59, DateTimeKind.Utc)));
-            Assert.False(sched.IsNewSession(
+                new DateTime(2012, 12, 18, 15, 59, 59, DateTimeKind.Utc)), Is.False);
+            Assert.That(sched.IsNewSession(
                 new DateTime(2012, 12, 18, 15, 59, 59, DateTimeKind.Utc),
-                new DateTime(2012, 12, 18, 16, 00, 00, DateTimeKind.Utc)));
-            Assert.True(sched.IsNewSession(
+                new DateTime(2012, 12, 18, 16, 00, 00, DateTimeKind.Utc)), Is.False);
+            Assert.That(sched.IsNewSession(
                 new DateTime(2012, 12, 18, 16, 00, 00, DateTimeKind.Utc),
-                new DateTime(2012, 12, 18, 16, 00, 01, DateTimeKind.Utc)));
-            Assert.False(sched.IsNewSession(
+                new DateTime(2012, 12, 18, 16, 00, 01, DateTimeKind.Utc)), Is.True);
+            Assert.That(sched.IsNewSession(
                 new DateTime(2012, 12, 18, 16, 00, 01, DateTimeKind.Utc),
-                new DateTime(2012, 12, 18, 16, 00, 02, DateTimeKind.Utc)));
+                new DateTime(2012, 12, 18, 16, 00, 02, DateTimeKind.Utc)), Is.False);
 
             // ==========
             // Time zone during Daylight savings
@@ -574,18 +573,18 @@ namespace UnitTests
             settings.SetString(SessionSettings.TIME_ZONE, EasternStandardTimeZoneId); //-4 during dst
             sched = new SessionSchedule(settings);
 
-            Assert.False(sched.IsNewSession(
+            Assert.That(sched.IsNewSession(
                 new DateTime(2012, 06, 18, 15, 59, 58, DateTimeKind.Utc),
-                new DateTime(2012, 06, 18, 15, 59, 59, DateTimeKind.Utc)));
-            Assert.False(sched.IsNewSession(
+                new DateTime(2012, 06, 18, 15, 59, 59, DateTimeKind.Utc)), Is.False);
+            Assert.That(sched.IsNewSession(
                 new DateTime(2012, 06, 18, 15, 59, 59, DateTimeKind.Utc),
-                new DateTime(2012, 06, 18, 16, 00, 00, DateTimeKind.Utc)));
-            Assert.True(sched.IsNewSession(
+                new DateTime(2012, 06, 18, 16, 00, 00, DateTimeKind.Utc)), Is.False);
+            Assert.That(sched.IsNewSession(
                 new DateTime(2012, 06, 18, 16, 00, 00, DateTimeKind.Utc),
-                new DateTime(2012, 06, 18, 16, 00, 01, DateTimeKind.Utc)));
-            Assert.False(sched.IsNewSession(
+                new DateTime(2012, 06, 18, 16, 00, 01, DateTimeKind.Utc)), Is.True);
+            Assert.That(sched.IsNewSession(
                 new DateTime(2012, 06, 18, 16, 00, 01, DateTimeKind.Utc),
-                new DateTime(2012, 06, 18, 16, 00, 02, DateTimeKind.Utc)));
+                new DateTime(2012, 06, 18, 16, 00, 02, DateTimeKind.Utc)), Is.False);
         }
 
         [Test]
@@ -604,7 +603,7 @@ namespace UnitTests
 
             // 2) if settings is UTC, don't convert
             DateTime d2 = new DateTime(2013, 01, 15, 12, 00, 00, DateTimeKind.Utc);
-            Assert.AreEqual(d2, sched.AdjustUtcDateTime(d2));
+            Assert.That(sched.AdjustUtcDateTime(d2), Is.EqualTo(d2));
 
             // 3) if settings has a TimeZone, convert to TimeZone
             settings = new SettingsDictionary();
@@ -653,7 +652,7 @@ namespace UnitTests
             DateTime d5expected = d5.ToLocalTime();
             DateTime d5actual = sched.AdjustUtcDateTime(d5);
             Util.UtcDateTimeSerializerTests.AssertHackyDateTimeEquality(d5expected, d5actual);
-            Assert.AreEqual(DateTimeKind.Local, d5actual.Kind);
+            Assert.That(d5actual.Kind, Is.EqualTo(DateTimeKind.Local));
         }
 
         [Test]
@@ -667,20 +666,20 @@ namespace UnitTests
             SessionSchedule sched = new SessionSchedule(settings);
 
             // bounds of Tuesday
-            Assert.IsFalse(sched.IsSessionTime(new DateTime(2024, 05, 21, 07, 59, 59, DateTimeKind.Utc)));
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2024, 05, 21, 08, 00, 00, DateTimeKind.Utc)));
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2024, 05, 21, 08, 00, 10, DateTimeKind.Utc)));
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2024, 05, 21, 16, 59, 59, DateTimeKind.Utc)));
-            Assert.IsFalse(sched.IsSessionTime(new DateTime(2024, 05, 21, 17, 00, 00, DateTimeKind.Utc)));
-            Assert.IsFalse(sched.IsSessionTime(new DateTime(2024, 05, 21, 17, 00, 10, DateTimeKind.Utc)));
+            Assert.That(sched.IsSessionTime(new DateTime(2024, 05, 21, 07, 59, 59, DateTimeKind.Utc)), Is.False);
+            Assert.That(sched.IsSessionTime(new DateTime(2024, 05, 21, 08, 00, 00, DateTimeKind.Utc)), Is.True);
+            Assert.That(sched.IsSessionTime(new DateTime(2024, 05, 21, 08, 00, 10, DateTimeKind.Utc)), Is.True);
+            Assert.That(sched.IsSessionTime(new DateTime(2024, 05, 21, 16, 59, 59, DateTimeKind.Utc)), Is.True);
+            Assert.That(sched.IsSessionTime(new DateTime(2024, 05, 21, 17, 00, 00, DateTimeKind.Utc)), Is.False);
+            Assert.That(sched.IsSessionTime(new DateTime(2024, 05, 21, 17, 00, 10, DateTimeKind.Utc)), Is.False);
 
             // bounds of Thursday
-            Assert.IsFalse(sched.IsSessionTime(new DateTime(2024, 05, 23, 07, 59, 59, DateTimeKind.Utc)));
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2024, 05, 23, 08, 00, 00, DateTimeKind.Utc)));
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2024, 05, 23, 08, 00, 10, DateTimeKind.Utc)));
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2024, 05, 23, 16, 59, 59, DateTimeKind.Utc)));
-            Assert.IsFalse(sched.IsSessionTime(new DateTime(2024, 05, 23, 17, 00, 00, DateTimeKind.Utc)));
-            Assert.IsFalse(sched.IsSessionTime(new DateTime(2024, 05, 23, 17, 00, 10, DateTimeKind.Utc)));
+            Assert.That(sched.IsSessionTime(new DateTime(2024, 05, 23, 07, 59, 59, DateTimeKind.Utc)), Is.False);
+            Assert.That(sched.IsSessionTime(new DateTime(2024, 05, 23, 08, 00, 00, DateTimeKind.Utc)), Is.True);
+            Assert.That(sched.IsSessionTime(new DateTime(2024, 05, 23, 08, 00, 10, DateTimeKind.Utc)), Is.True);
+            Assert.That(sched.IsSessionTime(new DateTime(2024, 05, 23, 16, 59, 59, DateTimeKind.Utc)), Is.True);
+            Assert.That(sched.IsSessionTime(new DateTime(2024, 05, 23, 17, 00, 00, DateTimeKind.Utc)), Is.False);
+            Assert.That(sched.IsSessionTime(new DateTime(2024, 05, 23, 17, 00, 10, DateTimeKind.Utc)), Is.False);
         }
 
         [Test]
@@ -694,20 +693,20 @@ namespace UnitTests
             SessionSchedule sched = new SessionSchedule(settings);
 
             // bounds of Tuesday-Wednesday
-            Assert.IsFalse(sched.IsSessionTime(new DateTime(2024, 05, 21, 16, 59, 59, DateTimeKind.Utc)));
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2024, 05, 21, 17, 00, 00, DateTimeKind.Utc)));
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2024, 05, 21, 17, 00, 10, DateTimeKind.Utc)));
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2024, 05, 22, 10, 59, 59, DateTimeKind.Utc)));
-            Assert.IsFalse(sched.IsSessionTime(new DateTime(2024, 05, 22, 11, 00, 00, DateTimeKind.Utc)));
-            Assert.IsFalse(sched.IsSessionTime(new DateTime(2024, 05, 22, 11, 00, 10, DateTimeKind.Utc)));
+            Assert.That(sched.IsSessionTime(new DateTime(2024, 05, 21, 16, 59, 59, DateTimeKind.Utc)), Is.False);
+            Assert.That(sched.IsSessionTime(new DateTime(2024, 05, 21, 17, 00, 00, DateTimeKind.Utc)), Is.True);
+            Assert.That(sched.IsSessionTime(new DateTime(2024, 05, 21, 17, 00, 10, DateTimeKind.Utc)), Is.True);
+            Assert.That(sched.IsSessionTime(new DateTime(2024, 05, 22, 10, 59, 59, DateTimeKind.Utc)), Is.True);
+            Assert.That(sched.IsSessionTime(new DateTime(2024, 05, 22, 11, 00, 00, DateTimeKind.Utc)), Is.False);
+            Assert.That(sched.IsSessionTime(new DateTime(2024, 05, 22, 11, 00, 10, DateTimeKind.Utc)), Is.False);
 
             // bounds of Thursday-Friday
-            Assert.IsFalse(sched.IsSessionTime(new DateTime(2024, 05, 23, 16, 59, 59, DateTimeKind.Utc)));
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2024, 05, 23, 17, 00, 00, DateTimeKind.Utc)));
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2024, 05, 23, 17, 00, 10, DateTimeKind.Utc)));
-            Assert.IsTrue(sched.IsSessionTime(new DateTime(2024, 05, 24, 10, 59, 59, DateTimeKind.Utc)));
-            Assert.IsFalse(sched.IsSessionTime(new DateTime(2024, 05, 24, 11, 00, 00, DateTimeKind.Utc)));
-            Assert.IsFalse(sched.IsSessionTime(new DateTime(2024, 05, 24, 11, 00, 10, DateTimeKind.Utc)));
+            Assert.That(sched.IsSessionTime(new DateTime(2024, 05, 23, 16, 59, 59, DateTimeKind.Utc)), Is.False);
+            Assert.That(sched.IsSessionTime(new DateTime(2024, 05, 23, 17, 00, 00, DateTimeKind.Utc)), Is.True);
+            Assert.That(sched.IsSessionTime(new DateTime(2024, 05, 23, 17, 00, 10, DateTimeKind.Utc)), Is.True);
+            Assert.That(sched.IsSessionTime(new DateTime(2024, 05, 24, 10, 59, 59, DateTimeKind.Utc)), Is.True);
+            Assert.That(sched.IsSessionTime(new DateTime(2024, 05, 24, 11, 00, 00, DateTimeKind.Utc)), Is.False);
+            Assert.That(sched.IsSessionTime(new DateTime(2024, 05, 24, 11, 00, 10, DateTimeKind.Utc)), Is.False);
         }
     }
 }

--- a/UnitTests/SessionSettingsTest.cs
+++ b/UnitTests/SessionSettingsTest.cs
@@ -278,7 +278,7 @@ namespace UnitTests
             Assert.That(settings.Get(id).GetString("EndTime"), Is.EqualTo("05:59:00"));
 
             id = settings.GetSessions().First();
-            Assert.NotNull(id);
+            Assert.That(id, Is.Not.Null);
             Assert.That(id.BeginString, Is.EqualTo("FIX.4.2"));
             Assert.That(id.SenderCompID, Is.EqualTo("Company"));
             Assert.That(id.SenderSubID, Is.EqualTo("FixedIncome"));

--- a/UnitTests/SessionStateTest.cs
+++ b/UnitTests/SessionStateTest.cs
@@ -26,11 +26,11 @@ namespace UnitTests
             System.DateTime lastReceivedTime = now;
 
             now = now.AddMilliseconds(heartBtIntMillis);
-            Assert.False(SessionState.TimedOut(now, heartBtIntMillis, lastReceivedTime));
+            Assert.That(SessionState.TimedOut(now, heartBtIntMillis, lastReceivedTime), Is.False);
             now = now.AddMilliseconds(heartBtIntMillis);
-            Assert.False(SessionState.TimedOut(now, heartBtIntMillis, lastReceivedTime));
+            Assert.That(SessionState.TimedOut(now, heartBtIntMillis, lastReceivedTime), Is.False);
             now = now.AddMilliseconds(heartBtIntMillis);
-            Assert.True(SessionState.TimedOut(now, heartBtIntMillis, lastReceivedTime));
+            Assert.That(SessionState.TimedOut(now, heartBtIntMillis, lastReceivedTime), Is.True);
         }
         
         [Test]
@@ -42,11 +42,11 @@ namespace UnitTests
             System.DateTime lastRecvTime = now;
 
             now = now.AddMilliseconds(4000);
-            Assert.False(SessionState.LogonTimedOut(now, logonTimeout, lastRecvTime));
+            Assert.That(SessionState.LogonTimedOut(now, logonTimeout, lastRecvTime), Is.False);
             now = now.AddMilliseconds(1000);
-            Assert.True(SessionState.LogonTimedOut(now, logonTimeout, lastRecvTime));
+            Assert.That(SessionState.LogonTimedOut(now, logonTimeout, lastRecvTime), Is.True);
             now = now.AddMilliseconds(1);
-            Assert.True(SessionState.LogonTimedOut(now, logonTimeout, lastRecvTime));
+            Assert.That(SessionState.LogonTimedOut(now, logonTimeout, lastRecvTime), Is.True);
         }
 
         [Test]
@@ -59,12 +59,12 @@ namespace UnitTests
             System.DateTime lastSentTime = now;
 
             now = now.AddMilliseconds(1000);
-            Assert.False(SessionState.LogoutTimedOut(now, sentLogout, logoutTimeout, lastSentTime));
+            Assert.That(SessionState.LogoutTimedOut(now, sentLogout, logoutTimeout, lastSentTime), Is.False);
             now = now.AddMilliseconds(1000);
-            Assert.True(SessionState.LogoutTimedOut(now, sentLogout, logoutTimeout, lastSentTime));
+            Assert.That(SessionState.LogoutTimedOut(now, sentLogout, logoutTimeout, lastSentTime), Is.True);
            
             sentLogout = false; 
-            Assert.False(SessionState.LogoutTimedOut(now, sentLogout, logoutTimeout, lastSentTime));
+            Assert.That(SessionState.LogoutTimedOut(now, sentLogout, logoutTimeout, lastSentTime), Is.False);
         }
 
         [Test]
@@ -77,14 +77,14 @@ namespace UnitTests
             System.DateTime lastReceivedTime = now;
 
             now = now.AddMilliseconds(heartBtIntMillis);
-            Assert.False(SessionState.NeedTestRequest(now, heartBtIntMillis, lastReceivedTime, testRequestCounter));
+            Assert.That(SessionState.NeedTestRequest(now, heartBtIntMillis, lastReceivedTime, testRequestCounter), Is.False);
             now = now.AddMilliseconds(heartBtIntMillis);
-            Assert.True(SessionState.NeedTestRequest(now, heartBtIntMillis, lastReceivedTime, testRequestCounter));
+            Assert.That(SessionState.NeedTestRequest(now, heartBtIntMillis, lastReceivedTime, testRequestCounter), Is.True);
 
             testRequestCounter += 1;
-            Assert.False(SessionState.NeedTestRequest(now, heartBtIntMillis, lastReceivedTime, testRequestCounter));
+            Assert.That(SessionState.NeedTestRequest(now, heartBtIntMillis, lastReceivedTime, testRequestCounter), Is.False);
             now = now.AddMilliseconds(heartBtIntMillis);
-            Assert.True(SessionState.NeedTestRequest(now, heartBtIntMillis, lastReceivedTime, testRequestCounter));
+            Assert.That(SessionState.NeedTestRequest(now, heartBtIntMillis, lastReceivedTime, testRequestCounter), Is.True);
 
         }
 
@@ -98,18 +98,18 @@ namespace UnitTests
             System.DateTime lastSentTime = now;
 
             now = now.AddMilliseconds(heartBtIntMillis / 3);
-            Assert.False(SessionState.NeedHeartbeat(now, heartBtIntMillis, lastSentTime, testRequestCounter));
+            Assert.That(SessionState.NeedHeartbeat(now, heartBtIntMillis, lastSentTime, testRequestCounter), Is.False);
             now = now.AddMilliseconds(heartBtIntMillis / 3);
-            Assert.False(SessionState.NeedHeartbeat(now, heartBtIntMillis, lastSentTime, testRequestCounter));
+            Assert.That(SessionState.NeedHeartbeat(now, heartBtIntMillis, lastSentTime, testRequestCounter), Is.False);
             now = now.AddMilliseconds(heartBtIntMillis / 2);
-            Assert.True(SessionState.NeedHeartbeat(now, heartBtIntMillis, lastSentTime, testRequestCounter));
+            Assert.That(SessionState.NeedHeartbeat(now, heartBtIntMillis, lastSentTime, testRequestCounter), Is.True);
 
             testRequestCounter = 1;
-            Assert.False(SessionState.NeedHeartbeat(now, heartBtIntMillis, lastSentTime, testRequestCounter));
+            Assert.That(SessionState.NeedHeartbeat(now, heartBtIntMillis, lastSentTime, testRequestCounter), Is.False);
             now = now.AddMilliseconds(2 * heartBtIntMillis);
-            Assert.False(SessionState.NeedHeartbeat(now, heartBtIntMillis, lastSentTime, testRequestCounter));
+            Assert.That(SessionState.NeedHeartbeat(now, heartBtIntMillis, lastSentTime, testRequestCounter), Is.False);
             testRequestCounter = 0;
-            Assert.True(SessionState.NeedHeartbeat(now, heartBtIntMillis, lastSentTime, testRequestCounter));
+            Assert.That(SessionState.NeedHeartbeat(now, heartBtIntMillis, lastSentTime, testRequestCounter), Is.True);
         }
 
         [Test]
@@ -122,13 +122,13 @@ namespace UnitTests
             System.DateTime lastReceivedTime = now;
 
             now = now.AddMilliseconds(heartBtIntMillis - 1);
-            Assert.True(SessionState.WithinHeartbeat(now, heartBtIntMillis, lastSentTime, lastReceivedTime));
+            Assert.That(SessionState.WithinHeartbeat(now, heartBtIntMillis, lastSentTime, lastReceivedTime), Is.True);
             now = now.AddMilliseconds(1);
-            Assert.False(SessionState.WithinHeartbeat(now, heartBtIntMillis, lastSentTime, lastReceivedTime));
+            Assert.That(SessionState.WithinHeartbeat(now, heartBtIntMillis, lastSentTime, lastReceivedTime), Is.False);
 
             lastSentTime = lastSentTime.AddMilliseconds(1);
             lastReceivedTime = lastReceivedTime.AddMilliseconds(1);
-            Assert.True(SessionState.WithinHeartbeat(now, heartBtIntMillis, lastSentTime, lastReceivedTime));
+            Assert.That(SessionState.WithinHeartbeat(now, heartBtIntMillis, lastSentTime, lastReceivedTime), Is.True);
         }
 
         [Test]
@@ -211,10 +211,10 @@ namespace UnitTests
             , new object[]{getEvent, state});
 
             //wait till done and assert results
-            Assert.True(setEvent.WaitOne(10000), "Get or Set hung/timed out during concurrent usage");
-            Assert.True(getEvent.WaitOne(10000), "Get or Set hung/timed out during concurrent usage");
-            Assert.AreEqual(setTable, getTable, "Garbled data read in concurrent set and get (like between resendrequest and send)");
-            Assert.AreEqual(errorsTable.Count, 0, "IOException occured in concurrent set and get (like between resendrequest and send)");
+            Assert.That(setEvent.WaitOne(10000), Is.True, "Get or Set hung/timed out during concurrent usage");
+            Assert.That(getEvent.WaitOne(10000), Is.True, "Get or Set hung/timed out during concurrent usage");
+            Assert.That(getTable, Is.EqualTo(setTable), "Garbled data read in concurrent set and get (like between resendrequest and send)");
+            Assert.That(0, Is.EqualTo(errorsTable.Count), "IOException occured in concurrent set and get (like between resendrequest and send)");
 
             //Tear down filestore
             state.Dispose();

--- a/UnitTests/SessionTest.cs
+++ b/UnitTests/SessionTest.cs
@@ -276,7 +276,7 @@ public class SessionTest
 
         SendResendRequest(1, 4);
         Assert.That(SENT_SEQUENCE_RESET());
-        Assert.IsFalse(RESENT());
+        Assert.That(RESENT(), Is.False);
     }
 
     [Test]
@@ -326,22 +326,22 @@ public class SessionTest
         _responder.MsgLookup.Clear();
         SendResendRequest(1, 100);
 
-        Assert.AreEqual(_responder.GetCount(QuickFix.Fields.MsgType.NEWORDERSINGLE), orderCount);
-        Assert.AreEqual(_responder.GetCount(QuickFix.Fields.MsgType.SEQUENCE_RESET), gapStarts.Length);
+        Assert.That(orderCount, Is.EqualTo(_responder.GetCount(QuickFix.Fields.MsgType.NEWORDERSINGLE)));
+        Assert.That(gapStarts.Length, Is.EqualTo(_responder.GetCount(QuickFix.Fields.MsgType.SEQUENCE_RESET)));
 
         int count = -1;
         foreach (QuickFix.Message sequenceResestMsg in _responder.MsgLookup[QuickFix.Fields.MsgType.SEQUENCE_RESET])
         {
-            Assert.AreEqual(sequenceResestMsg.GetString(QuickFix.Fields.Tags.GapFillFlag), "Y");
-            Assert.AreEqual(sequenceResestMsg.Header.GetULong(QuickFix.Fields.Tags.MsgSeqNum), gapStarts[++count]);
-            Assert.AreEqual(sequenceResestMsg.GetInt(QuickFix.Fields.Tags.NewSeqNo), gapEnds[count]);
+            Assert.That("Y", Is.EqualTo(sequenceResestMsg.GetString(QuickFix.Fields.Tags.GapFillFlag)));
+            Assert.That(gapStarts[++count], Is.EqualTo(sequenceResestMsg.Header.GetULong(QuickFix.Fields.Tags.MsgSeqNum)));
+            Assert.That(gapEnds[count], Is.EqualTo(sequenceResestMsg.GetInt(QuickFix.Fields.Tags.NewSeqNo)));
         }
     }
 
     [Test]
     public void TestResendSessionLevelReject()
     {
-        Assert.False(_session!.ResendSessionLevelRejects); // check for correct default
+        Assert.That(_session!.ResendSessionLevelRejects, Is.False); // check for correct default
         Logon();
 
         QuickFix.FIX42.Reject reject = new QuickFix.FIX42.Reject(
@@ -359,7 +359,7 @@ public class SessionTest
         _responder.MsgLookup.Clear();
         _session.ResendSessionLevelRejects = false;
         SendResendRequest(1, 100);
-        Assert.False(_responder.MsgLookup.ContainsKey(QuickFix.Fields.MsgType.REJECT));
+        Assert.That(_responder.MsgLookup.ContainsKey(QuickFix.Fields.MsgType.REJECT), Is.False);
     }
 
     public void AssertMsInTag(string msgType, int tag, bool shouldHaveMs)
@@ -711,7 +711,7 @@ public class SessionTest
 
         SendTheMessage(sr);
 
-        Assert.False(_responder.MsgLookup.ContainsKey(QuickFix.Fields.MsgType.REJECT));
+        Assert.That(_responder.MsgLookup.ContainsKey(QuickFix.Fields.MsgType.REJECT), Is.False);
     }
     [Test]
     public void TestToAppDoNotSend()
@@ -727,7 +727,7 @@ public class SessionTest
 
         _application.DoNotSendException = new QuickFix.DoNotSend();
         _session!.Send(order);
-        Assert.False(SENT_NOS());
+        Assert.That(SENT_NOS(), Is.False);
     }
 
     [Test]
@@ -743,13 +743,13 @@ public class SessionTest
              new QuickFix.Fields.OrdType(QuickFix.Fields.OrdType.LIMIT));
 
         _session!.Send(order);
-        Assert.True(SENT_NOS());
+        Assert.That(SENT_NOS(), Is.True);
 
         _responder.MsgLookup.Remove(QuickFix.Fields.MsgType.NEWORDERSINGLE);
         _application.DoNotSendException = new QuickFix.DoNotSend();
 
         SendResendRequest(1, 0);
-        Assert.False(SENT_NOS());
+        Assert.That(SENT_NOS(), Is.False);
     }
 
 
@@ -778,8 +778,8 @@ public class SessionTest
         _session.Next(order.ConstructString());
 
         Assert.That(mockApp.InterceptedMessageTypes.Count, Is.EqualTo(2));
-        Assert.True(mockApp.InterceptedMessageTypes.Contains(QuickFix.Fields.MsgType.LOGON));
-        Assert.True(mockApp.InterceptedMessageTypes.Contains(QuickFix.Fields.MsgType.NEWORDERSINGLE));
+        Assert.That(mockApp.InterceptedMessageTypes.Contains(QuickFix.Fields.MsgType.LOGON), Is.True);
+        Assert.That(mockApp.InterceptedMessageTypes.Contains(QuickFix.Fields.MsgType.NEWORDERSINGLE), Is.True);
     }
 
     [Test]

--- a/UnitTests/SettingsDictionaryTests.cs
+++ b/UnitTests/SettingsDictionaryTests.cs
@@ -48,8 +48,8 @@ public class SettingsDictionaryTests
         d.SetDouble("DOUBLEKEY1", 12.3);
         d.SetDouble("DOUBLEKEY2", 987362.987362);
 
-        Assert.AreEqual("12.3", d.GetString("DOUBLEKEY1"));
-        Assert.AreEqual("987362.987362", d.GetString("DOUBLEKEY2"));
+        Assert.That(d.GetString("DOUBLEKEY1"), Is.EqualTo("12.3"));
+        Assert.That(d.GetString("DOUBLEKEY2"), Is.EqualTo("987362.987362"));
     }
 
     [Test]
@@ -89,9 +89,9 @@ public class SettingsDictionaryTests
         SettingsDictionary d = new();
         d.SetBool("BOOLKEY-T", true);
         d.SetBool("BOOLKEY-F", false);
-        Assert.IsTrue(d.IsBoolPresentAndTrue("BOOLKEY-T"));
-        Assert.IsFalse(d.IsBoolPresentAndTrue("BOOLKEY-F"));
-        Assert.IsFalse(d.IsBoolPresentAndTrue("nonexistent key"));
+        Assert.That(d.IsBoolPresentAndTrue("BOOLKEY-T"), Is.True);
+        Assert.That(d.IsBoolPresentAndTrue("BOOLKEY-F"), Is.False);
+        Assert.That(d.IsBoolPresentAndTrue("nonexistent key"), Is.False);
     }
 
     [Test]
@@ -116,7 +116,7 @@ public class SettingsDictionaryTests
 
         d.SetString("DAY_X", "invalid");
         var ex = Assert.Throws(typeof(ArgumentException), delegate { d.GetDay("DAY_X"); });
-        StringAssert.Contains("Cannot recognize this day: 'invalid'", ex!.Message);
+        Assert.That(ex!.Message, Does.Contain("Cannot recognize this day: 'invalid'"));
     }
 
     [Test]
@@ -129,7 +129,7 @@ public class SettingsDictionaryTests
         Assert.That(d.GetString("DAY4"), Is.EqualTo("Thursday"));
 
         var ex = Assert.Throws(typeof(ArgumentException), delegate { d.SetDay("X", (DayOfWeek)9); });
-        StringAssert.Contains("Not a valid DayOfWeek value", ex!.Message);
+        Assert.That(ex!.Message, Does.Contain("Not a valid DayOfWeek value"));
     }
 
     [Test]
@@ -154,26 +154,26 @@ public class SettingsDictionaryTests
     {
         SettingsDictionary first = new("MyName");
         SettingsDictionary second = new("MyName");
-        Assert.True(first.Equals(second));
+        Assert.That(first.Equals(second), Is.True);
 
         first.SetString("THIRDKEY", "FIRST");
         second.SetString("THIRDKEY", "SECOND");
-        Assert.False(first.Equals(second));
+        Assert.That(first.Equals(second), Is.False);
 
         first.SetString("THIRDKEY", "SECOND");
-        Assert.True(first.Equals(second));
+        Assert.That(first.Equals(second), Is.True);
 
         first.SetString("FIRSTKEY", "FIRSTVALUE");
         second.SetString("SECONDKEY", "SECONDVALUE");
-        Assert.False(first.Equals(second));
+        Assert.That(first.Equals(second), Is.False);
 
         first.SetString("SECONDKEY", "SECONDVALUE");
         second.SetString("FIRSTKEY", "FIRSTVALUE");
-        Assert.True(first.Equals(second));
+        Assert.That(first.Equals(second), Is.True);
 
         SettingsDictionary third = new("Name1");
         SettingsDictionary fourth = new("Name2");
-        Assert.False(third.Equals(fourth));
+        Assert.That(third.Equals(fourth), Is.False);
     }
 
     [Test]
@@ -184,8 +184,8 @@ public class SettingsDictionaryTests
 
         SettingsDictionary dupe = new("dupe", orig);
 
-        Assert.AreEqual(2, dupe.Count);
-        Assert.AreEqual("One", dupe.GetString("uNo"));
-        Assert.AreEqual("2", dupe.GetString("DOs"));
+        Assert.That(dupe.Count, Is.EqualTo(2));
+        Assert.That(dupe.GetString("uNo"), Is.EqualTo("One"));
+        Assert.That(dupe.GetString("DOs"), Is.EqualTo("2"));
     }
 }

--- a/UnitTests/SettingsTest.cs
+++ b/UnitTests/SettingsTest.cs
@@ -69,17 +69,17 @@ what=huh";
             Settings settings = new Settings(new System.IO.StringReader(configuration));
 
             LinkedList<QuickFix.SettingsDictionary> byLower = settings.Get("foo");
-            Assert.AreEqual(1, byLower.Count);
-            Assert.AreEqual(2, byLower.First!.Value.Count);
-            Assert.AreEqual("uno", byLower.First.Value.GetString("one"));
-            Assert.AreEqual("dos", byLower.First.Value.GetString("two"));
+            Assert.That(byLower.Count, Is.EqualTo(1));
+            Assert.That(byLower.First!.Value.Count, Is.EqualTo(2));
+            Assert.That(byLower.First.Value.GetString("one"), Is.EqualTo("uno"));
+            Assert.That(byLower.First.Value.GetString("two"), Is.EqualTo("dos"));
 
             // too lazy to write a QuickFix.Dictionary#Equals method (which would only be used by this test)
             LinkedList<QuickFix.SettingsDictionary> byUpper = settings.Get("FOO");
-            Assert.AreEqual(byLower.Count, byUpper.Count);
-            Assert.AreEqual(byLower.First.Value.Count, byUpper.First!.Value.Count);
-            Assert.AreEqual(byUpper.First.Value.GetString("one"), byUpper.First.Value.GetString("one"));
-            Assert.AreEqual(byUpper.First.Value.GetString("two"), byUpper.First.Value.GetString("two"));
+            Assert.That(byUpper.Count, Is.EqualTo(byLower.Count));
+            Assert.That(byUpper.First.Value.Count, Is.EqualTo(byLower.First!.Value.Count));
+            Assert.That(byUpper.First.Value.GetString("one"), Is.EqualTo(byUpper.First.Value.GetString("one")));
+            Assert.That(byUpper.First.Value.GetString("two"), Is.EqualTo(byUpper.First.Value.GetString("two")));
         }
     }
 }

--- a/UnitTests/SocketSettingsTest.cs
+++ b/UnitTests/SocketSettingsTest.cs
@@ -12,21 +12,21 @@ namespace UnitTests
         {
             SocketSettings socketSettings = new SocketSettings();
 
-            Assert.IsFalse(socketSettings.SocketIgnoreProxy);
-            Assert.IsTrue(socketSettings.SocketNodelay);
-            Assert.IsNull(socketSettings.SocketReceiveBufferSize);
-            Assert.IsNull(socketSettings.SocketSendBufferSize);
-            Assert.IsNull(socketSettings.SocketReceiveTimeout);
-            Assert.IsNull(socketSettings.SocketSendTimeout);
-            Assert.IsNull(socketSettings.ServerCommonName);
-            Assert.IsTrue(socketSettings.ValidateCertificates);
-            Assert.IsNull(socketSettings.CertificatePath);
-            Assert.IsNull(socketSettings.CertificatePassword);
-            Assert.AreEqual(SslProtocols.None, socketSettings.SslProtocol);
-            Assert.IsTrue(socketSettings.CheckCertificateRevocation);
-            Assert.IsFalse(socketSettings.UseSSL);
-            Assert.IsNull(socketSettings.CACertificatePath);
-            Assert.IsTrue(socketSettings.RequireClientCertificate);
+            Assert.That(socketSettings.SocketIgnoreProxy, Is.False);
+            Assert.That(socketSettings.SocketNodelay, Is.True);
+            Assert.That(socketSettings.SocketReceiveBufferSize, Is.Null);
+            Assert.That(socketSettings.SocketSendBufferSize, Is.Null);
+            Assert.That(socketSettings.SocketReceiveTimeout, Is.Null);
+            Assert.That(socketSettings.SocketSendTimeout, Is.Null);
+            Assert.That(socketSettings.ServerCommonName, Is.Null);
+            Assert.That(socketSettings.ValidateCertificates, Is.True);
+            Assert.That(socketSettings.CertificatePath, Is.Null);
+            Assert.That(socketSettings.CertificatePassword, Is.Null);
+            Assert.That(socketSettings.SslProtocol, Is.EqualTo(SslProtocols.None));
+            Assert.That(socketSettings.CheckCertificateRevocation, Is.True);
+            Assert.That(socketSettings.UseSSL, Is.False);
+            Assert.That(socketSettings.CACertificatePath, Is.Null);
+            Assert.That(socketSettings.RequireClientCertificate, Is.True);
         }
 
         private SettingsDictionary BaseTestDict()
@@ -56,21 +56,21 @@ namespace UnitTests
             SocketSettings socketSettings = new SocketSettings();
             socketSettings.Configure(BaseTestDict());
 
-            Assert.IsFalse(socketSettings.SocketIgnoreProxy);
-            Assert.IsFalse(socketSettings.SocketNodelay);
-            Assert.AreEqual(1, socketSettings.SocketReceiveBufferSize);
-            Assert.AreEqual(2, socketSettings.SocketSendBufferSize);
-            Assert.AreEqual(3, socketSettings.SocketReceiveTimeout);
-            Assert.AreEqual(4, socketSettings.SocketSendTimeout);
-            Assert.AreEqual("SSL_SERVERNAME", socketSettings.ServerCommonName);
-            Assert.IsFalse(socketSettings.ValidateCertificates);
-            Assert.AreEqual("SSL_CERTIFICATE", socketSettings.CertificatePath);
-            Assert.AreEqual("SSL_CA_CERTIFICATE", socketSettings.CACertificatePath);
-            Assert.AreEqual("SSL_CERTIFICATE_PASSWORD", socketSettings.CertificatePassword);
-            Assert.AreEqual(SslProtocols.Tls12, socketSettings.SslProtocol);
-            Assert.IsFalse(socketSettings.CheckCertificateRevocation);
-            Assert.IsTrue(socketSettings.UseSSL);
-            Assert.IsFalse(socketSettings.RequireClientCertificate);
+            Assert.That(socketSettings.SocketIgnoreProxy, Is.False);
+            Assert.That(socketSettings.SocketNodelay, Is.False);
+            Assert.That(socketSettings.SocketReceiveBufferSize, Is.EqualTo(1));
+            Assert.That(socketSettings.SocketSendBufferSize, Is.EqualTo(2));
+            Assert.That(socketSettings.SocketReceiveTimeout, Is.EqualTo(3));
+            Assert.That(socketSettings.SocketSendTimeout, Is.EqualTo(4));
+            Assert.That(socketSettings.ServerCommonName, Is.EqualTo("SSL_SERVERNAME"));
+            Assert.That(socketSettings.ValidateCertificates, Is.False);
+            Assert.That(socketSettings.CertificatePath, Is.EqualTo("SSL_CERTIFICATE"));
+            Assert.That(socketSettings.CACertificatePath, Is.EqualTo("SSL_CA_CERTIFICATE"));
+            Assert.That(socketSettings.CertificatePassword, Is.EqualTo("SSL_CERTIFICATE_PASSWORD"));
+            Assert.That(socketSettings.SslProtocol, Is.EqualTo(SslProtocols.Tls12));
+            Assert.That(socketSettings.CheckCertificateRevocation, Is.False);
+            Assert.That(socketSettings.UseSSL, Is.True);
+            Assert.That(socketSettings.RequireClientCertificate, Is.False);
         }
 
         private SocketSettings CreateWithSslConfig(bool sslValidateCertificates, bool sslCheckCertificateRevocation)
@@ -88,21 +88,21 @@ namespace UnitTests
         {
             // SSLValidateCertificates=true does not affect SSLCheckCertificateRevocation
             var socketSettings = CreateWithSslConfig(true, false);
-            Assert.IsTrue(socketSettings.ValidateCertificates);
-            Assert.IsFalse(socketSettings.CheckCertificateRevocation);
+            Assert.That(socketSettings.ValidateCertificates, Is.True);
+            Assert.That(socketSettings.CheckCertificateRevocation, Is.False);
 
             socketSettings = CreateWithSslConfig(true, true);
-            Assert.IsTrue(socketSettings.ValidateCertificates);
-            Assert.IsTrue(socketSettings.CheckCertificateRevocation);
+            Assert.That(socketSettings.ValidateCertificates, Is.True);
+            Assert.That(socketSettings.CheckCertificateRevocation, Is.True);
 
             // SSLValidateCertificates=false means SSLCheckCertificateRevocation must be false
             socketSettings = CreateWithSslConfig(false, true);
-            Assert.IsFalse(socketSettings.ValidateCertificates);
-            Assert.IsFalse(socketSettings.CheckCertificateRevocation);
+            Assert.That(socketSettings.ValidateCertificates, Is.False);
+            Assert.That(socketSettings.CheckCertificateRevocation, Is.False);
 
             socketSettings = CreateWithSslConfig(false, false);
-            Assert.IsFalse(socketSettings.ValidateCertificates);
-            Assert.IsFalse(socketSettings.CheckCertificateRevocation);
+            Assert.That(socketSettings.ValidateCertificates, Is.False);
+            Assert.That(socketSettings.CheckCertificateRevocation, Is.False);
         }
     }
 }

--- a/UnitTests/ThreadedSocketReactorTests.cs
+++ b/UnitTests/ThreadedSocketReactorTests.cs
@@ -54,7 +54,7 @@ namespace UnitTests
             var stdOut = GetStdOut();
             var ex = Assert.Throws<SocketException>(delegate { testingObject.Run(); })!;
 
-            StringAssert.StartsWith("<event> Error starting listener:", stdOut.ToString());
+            Assert.That(stdOut.ToString(), Does.StartWith("<event> Error starting listener:"));
             Assert.That(ex.SocketErrorCode, Is.EqualTo(SocketError.AddressAlreadyInUse));
         }
 

--- a/UnitTests/ThreadedSocketReactorTests.cs
+++ b/UnitTests/ThreadedSocketReactorTests.cs
@@ -57,7 +57,7 @@ namespace UnitTests
             var ex = Assert.Throws<SocketException>(delegate { testingObject.Run(); })!;
 
             StringAssert.StartsWith("<event> Error starting listener:", stdOut.ToString());
-            StringAssert.StartsWith("Address already in use", ex.Message);
+            Assert.That(ex.SocketErrorCode, Is.EqualTo(SocketError.AddressAlreadyInUse));
         }
 
         [TearDown]

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -15,9 +15,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+    <PackageReference Include="NUnit" Version="4.2.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/UnitTests/Util/ExceptionExtensionsTests.cs
+++ b/UnitTests/Util/ExceptionExtensionsTests.cs
@@ -13,9 +13,9 @@ namespace UnitTests.Util
                 "Outer exception, see inner exception",
                 new Exception("My inner exception message"));
 
-            Assert.AreEqual(
-                exception.GetFullMessage(),
-                "Outer exception, see inner exception --> My inner exception message");
+            Assert.That(
+                "Outer exception, see inner exception --> My inner exception message",
+                Is.EqualTo(exception.GetFullMessage()));
         }
 
         [Test]
@@ -23,7 +23,7 @@ namespace UnitTests.Util
         {
             var exception = new Exception("My exception message");
 
-            Assert.AreEqual(exception.GetFullMessage(), "My exception message");
+            Assert.That("My exception message", Is.EqualTo(exception.GetFullMessage()));
         }
     }
 }

--- a/UnitTests/Util/UtcDateTimeSerializerTests.cs
+++ b/UnitTests/Util/UtcDateTimeSerializerTests.cs
@@ -16,12 +16,12 @@ namespace UnitTests.Util
         /// <param name="d2"></param>
         static public void AssertHackyDateTimeEquality(DateTime d1, DateTime d2)
         {
-            Assert.AreEqual(d1.Kind, d2.Kind, "kind");
-            Assert.AreEqual(d1.Date, d2.Date, "date");
-            Assert.AreEqual(d1.Hour, d2.Hour, "hours");
-            Assert.AreEqual(d1.Minute, d2.Minute, "minutes");
-            Assert.AreEqual(d1.Second, d2.Second, "seconds");
-            Assert.AreEqual(d1.Millisecond, d2.Millisecond, "milliseconds");
+            Assert.That(d2.Kind, Is.EqualTo(d1.Kind), "kind");
+            Assert.That(d2.Date, Is.EqualTo(d1.Date), "date");
+            Assert.That(d2.Hour, Is.EqualTo(d1.Hour), "hours");
+            Assert.That(d2.Minute, Is.EqualTo(d1.Minute), "minutes");
+            Assert.That(d2.Second, Is.EqualTo(d1.Second), "seconds");
+            Assert.That(d2.Millisecond, Is.EqualTo(d1.Millisecond), "milliseconds");
         }
 
         [Test]


### PR DESCRIPTION
- Upgrade the unit testing framework to the latest version.
- Removed obsolete Assert's methods.