### PR TITLE
fix #900: NonSessionLog error with CompositeLog

### DIFF
--- a/QuickFIXn/Logger/CompositeLogFactory.cs
+++ b/QuickFIXn/Logger/CompositeLogFactory.cs
@@ -26,6 +26,6 @@ public class CompositeLogFactory : ILogFactory
     }
 
     public ILog CreateNonSessionLog() {
-        return new CompositeLog(_factories.Select(f => f.Create(new SessionID("Non", "Session", "Log"))).ToArray());
+        return new CompositeLog(_factories.Select(f => f.CreateNonSessionLog()).ToArray());
     }
 }

--- a/QuickFIXn/Logger/NonSessionLog.cs
+++ b/QuickFIXn/Logger/NonSessionLog.cs
@@ -2,7 +2,7 @@ namespace QuickFix.Logger;
 
 /// <summary>
 /// A logger that can be used when the calling logic cannot identify a session (which is rare).
-/// Does not create a file until first write.
+/// Does not create a log artifact until first write.
 /// </summary>
 public class NonSessionLog {
 

--- a/QuickFIXn/SettingsDictionary.cs
+++ b/QuickFIXn/SettingsDictionary.cs
@@ -25,6 +25,10 @@ public class SettingsDictionary : System.Collections.IEnumerable
         : this("unnamed")
     { }
 
+    /// <summary>
+    /// Create a new SettingsDictionary withy specified name
+    /// </summary>
+    /// <param name="name">Section name (usually "DEFAULT" or "SESSION")</param>
     public SettingsDictionary(string name)
         : this(name, new Dictionary<string,string>())
     { }
@@ -33,7 +37,7 @@ public class SettingsDictionary : System.Collections.IEnumerable
     /// Create a new SettingsDictionary with specified name but data copied from
     /// the dataSource SettingsDictionary
     /// </summary>
-    /// <param name="name"></param>
+    /// <param name="name">Section name (usually "DEFAULT" or "SESSION")</param>
     /// <param name="dataSource"></param>
     public SettingsDictionary(string name, SettingsDictionary dataSource)
         : this(name, dataSource._data)

--- a/UnitTests/Logger/FileLogTests.cs
+++ b/UnitTests/Logger/FileLogTests.cs
@@ -66,6 +66,9 @@ public class FileLogTests
 
         Assert.That(File.Exists(Path.Combine(logDirectory, "FIX.4.2-SENDERCOMP-TARGETCOMP.event.current.log")));
         Assert.That(File.Exists(Path.Combine(logDirectory, "FIX.4.2-SENDERCOMP-TARGETCOMP.messages.current.log")));
+
+        // cleanup
+        Directory.Delete(logDirectory, true);
     }
 
     [Test]

--- a/UnitTests/Logger/NonSessionLogTests.cs
+++ b/UnitTests/Logger/NonSessionLogTests.cs
@@ -1,0 +1,65 @@
+using System.IO;
+using NUnit.Framework;
+using QuickFix.Logger;
+
+namespace UnitTests.Logger;
+
+[TestFixture]
+public class NonSessionLogTests {
+    private readonly string _logDirectory = Path.Combine(TestContext.CurrentContext.TestDirectory, "log");
+
+    private FileLogFactory CreateFileLogFactory() {
+        if (Directory.Exists(_logDirectory))
+            Directory.Delete(_logDirectory, true);
+
+        string configString = $"""
+                               [DEFAULT]
+                               ConnectionType=initiator
+                               FileLogPath={_logDirectory}
+
+                               [SESSION]
+                               BeginString=FIX.4.2
+                               SenderCompID=SENDERCOMP
+                               TargetCompID=TARGETCOMP
+                               """;
+
+        QuickFix.SessionSettings settings = new QuickFix.SessionSettings(
+            new StringReader(configString));
+
+        return new FileLogFactory(settings);
+    }
+
+    [Test]
+    public void TestWithFileLogFactory() {
+        FileLogFactory flf = CreateFileLogFactory();
+        NonSessionLog nslog = new NonSessionLog(flf);
+
+        // Log artifact not created before first log-write
+        Assert.False(Directory.Exists(_logDirectory));
+
+        // Log artifact exists after first log-write
+        nslog.OnEvent("some text");
+        Assert.True(Directory.Exists(_logDirectory));
+        Assert.True(File.Exists(Path.Combine(_logDirectory, "Non-Session-Log.event.current.log")));
+
+        // cleanup
+        Directory.Delete(_logDirectory, true);
+    }
+
+    [Test]
+    public void TestWithCompositeLogFactory() {
+        CompositeLogFactory clf = new CompositeLogFactory([CreateFileLogFactory(), new NullLogFactory()]);
+        NonSessionLog nslog = new NonSessionLog(clf);
+
+        // Log artifact not created before first log-write
+        Assert.False(Directory.Exists(_logDirectory));
+
+        // Log artifact exists after first log-write
+        nslog.OnEvent("some text");
+        Assert.True(Directory.Exists(_logDirectory));
+        Assert.True(File.Exists(Path.Combine(_logDirectory, "Non-Session-Log.event.current.log")));
+
+        // cleanup
+        Directory.Delete(_logDirectory, true);
+    }
+}


### PR DESCRIPTION
 #900

CompositeLog was using IFactory.Create instead of IFactory.CreateNonSessionLog