### PR TITLE
[Rebase 890] Fixed issue: throw IOException: The process cannot access the file 'xxxx\log\Non-Session-Log.messages.current.log' because it is being used by another process.

### DIFF
--- a/QuickFIXn/Logger/NonSessionLog.cs
+++ b/QuickFIXn/Logger/NonSessionLog.cs
@@ -4,7 +4,7 @@ namespace QuickFix.Logger;
 /// A logger that can be used when the calling logic cannot identify a session (which is rare).
 /// Does not create a log artifact until first write.
 /// </summary>
-public class NonSessionLog {
+public class NonSessionLog : System.IDisposable {
 
     private readonly ILogFactory _logFactory;
     private ILog? _log;
@@ -21,5 +21,7 @@ public class NonSessionLog {
         }
         _log.OnEvent(s);
     }
+
+    public void Dispose() => _log?.Dispose();
 }
 

--- a/QuickFIXn/Logger/NonSessionLog.cs
+++ b/QuickFIXn/Logger/NonSessionLog.cs
@@ -16,12 +16,23 @@ public class NonSessionLog : System.IDisposable {
     }
 
     internal void OnEvent(string s) {
+        if (_disposed) return;
+
         lock (_sync) {
             _log ??= _logFactory.CreateNonSessionLog();
         }
-        _log.OnEvent(s);
+        _log?.OnEvent(s);
     }
 
-    public void Dispose() => _log?.Dispose();
+    private bool _disposed;
+    public void Dispose() {
+        if (_disposed) return;
+
+        if (_log != null) {
+            _log.Dispose();
+            _log = null;
+            _disposed = true;
+        }
+    }
 }
 

--- a/QuickFIXn/SocketInitiatorThread.cs
+++ b/QuickFIXn/SocketInitiatorThread.cs
@@ -152,6 +152,12 @@ namespace QuickFix
             catch (AggregateException ex) // Timeout
             {
                 _currentReadTask = null;
+
+                if (ex.InnerException is OperationCanceledException) {
+                    // Nothing read 
+                    return 0;
+                }
+                
                 var ioException = ex.InnerException as IOException;
                 var inner = ioException?.InnerException as SocketException;
                 if (inner is not null && inner.SocketErrorCode == SocketError.TimedOut) {

--- a/QuickFIXn/ThreadedSocketAcceptor.cs
+++ b/QuickFIXn/ThreadedSocketAcceptor.cs
@@ -274,6 +274,8 @@ namespace QuickFix
             LogoutAllSessions(force);
             DisposeSessions();
             _sessions.Clear();
+            _nonSessionLog.Dispose();
+            _isStarted = false;
 
             // FIXME StopSessionTimer();
             // FIXME Session.UnregisterSessions(GetSessions());

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -43,6 +43,7 @@ What's New
 * #892 - nullable-ize UnitTests project (gbirchmeier)
      * also deprecate a AcceptorSocketDescriptor ctor due to unused param
 * #900 - correct CompositeLog to use IFactory.CreateNonSessionLog when appropriate (gbirchmeier)
+* #891 - make NonSessionLog implement IDisposable and fix the IOException (VAllens)
 
 ### v1.12.0
 

--- a/UnitTests/Logger/FileLogTests.cs
+++ b/UnitTests/Logger/FileLogTests.cs
@@ -67,7 +67,9 @@ public class FileLogTests
         Assert.That(File.Exists(Path.Combine(logDirectory, "FIX.4.2-SENDERCOMP-TARGETCOMP.event.current.log")));
         Assert.That(File.Exists(Path.Combine(logDirectory, "FIX.4.2-SENDERCOMP-TARGETCOMP.messages.current.log")));
 
-        // cleanup
+        // cleanup (don't delete log unless success)
+        _log.Dispose();
+        _log = null;
         Directory.Delete(logDirectory, true);
     }
 

--- a/UnitTests/Logger/NonSessionLogTests.cs
+++ b/UnitTests/Logger/NonSessionLogTests.cs
@@ -8,6 +8,15 @@ namespace UnitTests.Logger;
 public class NonSessionLogTests {
     private readonly string _logDirectory = Path.Combine(TestContext.CurrentContext.TestDirectory, "log");
 
+    private NonSessionLog? _nslog;
+
+    [TearDown]
+    public void Teardown()
+    {
+        _nslog?.Dispose();
+        _nslog = null;
+    }
+    
     private FileLogFactory CreateFileLogFactory() {
         if (Directory.Exists(_logDirectory))
             Directory.Delete(_logDirectory, true);
@@ -32,34 +41,38 @@ public class NonSessionLogTests {
     [Test]
     public void TestWithFileLogFactory() {
         FileLogFactory flf = CreateFileLogFactory();
-        NonSessionLog nslog = new NonSessionLog(flf);
+        _nslog = new NonSessionLog(flf);
 
         // Log artifact not created before first log-write
         Assert.False(Directory.Exists(_logDirectory));
 
         // Log artifact exists after first log-write
-        nslog.OnEvent("some text");
+        _nslog.OnEvent("some text");
         Assert.True(Directory.Exists(_logDirectory));
         Assert.True(File.Exists(Path.Combine(_logDirectory, "Non-Session-Log.event.current.log")));
 
-        // cleanup
+        // cleanup (don't delete log unless success)
+        _nslog.Dispose();
+        _nslog = null;
         Directory.Delete(_logDirectory, true);
     }
 
     [Test]
     public void TestWithCompositeLogFactory() {
         CompositeLogFactory clf = new CompositeLogFactory([CreateFileLogFactory(), new NullLogFactory()]);
-        NonSessionLog nslog = new NonSessionLog(clf);
+        _nslog = new NonSessionLog(clf);
 
         // Log artifact not created before first log-write
         Assert.False(Directory.Exists(_logDirectory));
 
         // Log artifact exists after first log-write
-        nslog.OnEvent("some text");
+        _nslog.OnEvent("some text");
         Assert.True(Directory.Exists(_logDirectory));
         Assert.True(File.Exists(Path.Combine(_logDirectory, "Non-Session-Log.event.current.log")));
 
-        // cleanup
+        // cleanup (don't delete log unless success)
+        _nslog.Dispose();
+        _nslog = null;
         Directory.Delete(_logDirectory, true);
     }
 }

--- a/UnitTests/ThreadedSocketReactorTests.cs
+++ b/UnitTests/ThreadedSocketReactorTests.cs
@@ -55,7 +55,7 @@ namespace UnitTests
             var ex = Assert.Throws<SocketException>(delegate { testingObject.Run(); })!;
 
             StringAssert.StartsWith("<event> Error starting listener:", stdOut.ToString());
-            StringAssert.StartsWith("Address already in use", ex.Message);
+            Assert.That(ex.SocketErrorCode, Is.EqualTo(SocketError.AddressAlreadyInUse));
         }
 
         [TearDown]


### PR DESCRIPTION
Attn @VAllens -- (Thanks so much for your help with this!   And I apologize for taking 2 months to get back to it.)

Rebase #890, which makes NonSessionLog implement IDisposable, which is then used to fix some IOException issues.

Then I made a few other fixes on top of that (see comments of #891 for that discussion).  Verified ***on Windows*** that all tests pass and that the test suite finishes down cleanly.

* closes #890 (because this PR supersedes it)
* resolves #891