### PR TITLE
Make body-less messages work, specifically 35=n

### DIFF
--- a/AcceptanceTest/ReflectorClient.cs
+++ b/AcceptanceTest/ReflectorClient.cs
@@ -12,8 +12,8 @@ internal class ReflectorClient : IReflector
 {
     private static readonly Regex s_timeRegex = new(@"\<TIME([+-]\d+)\>", RegexOptions.Compiled);
     private static readonly Regex s_beginStringRegex = new(@"^8=.*?[\001]", RegexOptions.Compiled);
-    private static readonly Regex s_bodyLengthRegex = new(@"[\001]9=.*?[\001]", RegexOptions.Compiled);
-    private static readonly Regex s_checksumRegex = new(@"[\001]10=.*[\001]$", RegexOptions.Compiled);
+    private static readonly Regex s_bodyLengthRegex = new(@"^8=[^\001]*[\001]9=[^\001]*", RegexOptions.Compiled);
+    private static readonly Regex s_checksumRegex = new(@"[\001]10=[0-9]+[\001]$", RegexOptions.Compiled);
     private static readonly Dictionary<string, Regex> s_expectPatterns = new()
     {
         { "10", new Regex(@"\d{3}", RegexOptions.Compiled) },

--- a/AcceptanceTest/definitions/server/fix43/ReceiveXmlMessage.def
+++ b/AcceptanceTest/definitions/server/fix43/ReceiveXmlMessage.def
@@ -1,0 +1,18 @@
+# Engine can receive complex type 'n' messages
+# and is not confused if the xml content contains SOH or FIX tags
+
+iCONNECT
+I8=FIX.4.335=A34=149=TW52=<TIME>56=ISLD98=0108=6
+E8=FIX.4.335=A34=149=ISLD52=00000000-00:00:00.00056=TW98=0108=610=0
+
+# Receive encapsulated ExecutionReport and get News response.
+# (Need the News response to ensure that FIX parses it and passes it up to the app;
+#  without this response, the test will false pass)
+I8=FIX.4.335=n34=249=TW52=<TIME>56=ISLD212=55213=<RTRF>8=FIX.4.39=37735=834=208blah blah blah</RTRF>
+E8=FIX.4.335=B34=249=ISLD52=00000000-00:00:00.00056=TW33=0148=Successfully received 'n' message with seqNo=210=0
+
+# logout message and response
+I8=FIX.4.335=534=349=TW52=<TIME>56=ISLD
+E8=FIX.4.335=534=349=ISLD52=00000000-00:00:00.00056=TW10=0
+eDISCONNECT
+

--- a/AcceptanceTest/definitions/server/fix44/ReceiveXmlMessage.def
+++ b/AcceptanceTest/definitions/server/fix44/ReceiveXmlMessage.def
@@ -1,0 +1,18 @@
+# Engine can receive complex type 'n' messages
+# and is not confused if the xml content contains SOH or FIX tags
+
+iCONNECT
+I8=FIX.4.435=A34=149=TW52=<TIME>56=ISLD98=0108=6
+E8=FIX.4.435=A34=149=ISLD52=00000000-00:00:00.00056=TW98=0108=610=0
+
+# Receive encapsulated ExecutionReport and get News response.
+# (Need the News response to ensure that FIX parses it and passes it up to the app;
+#  without this response, the test will false pass)
+I8=FIX.4.435=n34=249=TW52=<TIME>56=ISLD212=55213=<RTRF>8=FIX.4.39=37735=834=208blah blah blah</RTRF>
+E8=FIX.4.435=B34=249=ISLD52=00000000-00:00:00.00056=TW33=0148=Successfully received 'n' message with seqNo=210=0
+
+# logout message and response
+I8=FIX.4.435=534=349=TW52=<TIME>56=ISLD
+E8=FIX.4.435=534=349=ISLD52=00000000-00:00:00.00056=TW10=0
+eDISCONNECT
+

--- a/AcceptanceTest/definitions/server/fix50/ReceiveXmlMessage.def
+++ b/AcceptanceTest/definitions/server/fix50/ReceiveXmlMessage.def
@@ -1,0 +1,18 @@
+# Engine can receive complex type 'n' messages
+# and is not confused if the xml content contains SOH or FIX tags
+
+iCONNECT
+I8=FIXT.1.135=A34=149=TW52=<TIME>56=ISLD98=0108=61137=7
+E8=FIXT.1.135=A34=149=ISLD52=00000000-00:00:00.00056=TW98=0108=61137=710=0
+
+# Receive encapsulated ExecutionReport and get News response.
+# (Need the News response to ensure that FIX parses it and passes it up to the app;
+#  without this response, the test will false pass)
+I8=FIXT.1.135=n34=249=TW52=<TIME>56=ISLD212=55213=<RTRF>8=FIX.4.39=37735=834=208blah blah blah</RTRF>
+E8=FIXT.1.135=B34=249=ISLD52=00000000-00:00:00.00056=TW33=0148=Successfully received 'n' message with seqNo=210=0
+
+# logout message and response
+I8=FIXT.1.135=534=349=TW52=<TIME>56=ISLD
+E8=FIXT.1.135=534=349=ISLD52=00000000-00:00:00.00056=TW10=0
+eDISCONNECT
+

--- a/AcceptanceTest/definitions/server/fix50sp1/ReceiveXmlMessage.def
+++ b/AcceptanceTest/definitions/server/fix50sp1/ReceiveXmlMessage.def
@@ -1,0 +1,18 @@
+# Engine can receive complex type 'n' messages
+# and is not confused if the xml content contains SOH or FIX tags
+
+iCONNECT
+I8=FIXT.1.135=A34=149=TW52=<TIME>56=ISLD98=0108=61137=8
+E8=FIXT.1.135=A34=149=ISLD52=00000000-00:00:00.00056=TW98=0108=61137=810=0
+
+# Receive encapsulated ExecutionReport and get News response.
+# (Need the News response to ensure that FIX parses it and passes it up to the app;
+#  without this response, the test will false pass)
+I8=FIXT.1.135=n34=249=TW52=<TIME>56=ISLD212=55213=<RTRF>8=FIX.4.39=37735=834=208blah blah blah</RTRF>
+E8=FIXT.1.135=B34=249=ISLD52=00000000-00:00:00.00056=TW33=0148=Successfully received 'n' message with seqNo=210=0
+
+# logout message and response
+I8=FIXT.1.135=534=349=TW52=<TIME>56=ISLD
+E8=FIXT.1.135=534=349=ISLD52=00000000-00:00:00.00056=TW10=0
+eDISCONNECT
+

--- a/AcceptanceTest/definitions/server/fix50sp2/ReceiveXmlMessage.def
+++ b/AcceptanceTest/definitions/server/fix50sp2/ReceiveXmlMessage.def
@@ -1,0 +1,18 @@
+# Engine can receive complex type 'n' messages
+# and is not confused if the xml content contains SOH or FIX tags
+
+iCONNECT
+I8=FIXT.1.135=A34=149=TW52=<TIME>56=ISLD98=0108=61137=9
+E8=FIXT.1.135=A34=149=ISLD52=00000000-00:00:00.00056=TW98=0108=61137=910=0
+
+# Receive encapsulated ExecutionReport and get News response.
+# (Need the News response to ensure that FIX parses it and passes it up to the app;
+#  without this response, the test will false pass)
+I8=FIXT.1.135=n34=249=TW52=<TIME>56=ISLD212=55213=<RTRF>8=FIX.4.39=37735=834=208blah blah blah</RTRF>
+E8=FIXT.1.135=B34=249=ISLD52=00000000-00:00:00.00056=TW33=0148=Successfully received 'n' message with seqNo=210=0
+
+# logout message and response
+I8=FIXT.1.135=534=349=TW52=<TIME>56=ISLD
+E8=FIXT.1.135=534=349=ISLD52=00000000-00:00:00.00056=TW10=0
+eDISCONNECT
+

--- a/QuickFIXn/Fields/Fields.cs
+++ b/QuickFIXn/Fields/Fields.cs
@@ -709,7 +709,7 @@ namespace QuickFix.Fields
         public const string BID_REQUEST = "k";
         public const string BID_RESPONSE = "l";
         public const string LIST_STRIKE_PRICE = "m";
-        public const string XML_MESSAGE = "n";
+        public const string XML_NON_FIX = "n";
         public const string REGISTRATION_INSTRUCTIONS = "o";
         public const string REGISTRATION_INSTRUCTIONS_RESPONSE = "p";
         public const string ORDER_MASS_CANCEL_REQUEST = "q";
@@ -859,7 +859,6 @@ namespace QuickFix.Fields
         public const string BIDREQUEST = "k";
         public const string BIDRESPONSE = "l";
         public const string LISTSTRIKEPRICE = "m";
-        public const string XML_NON_FIX = "n";
         public const string REGISTRATIONINSTRUCTIONS = "o";
         public const string REGISTRATIONINSTRUCTIONSRESPONSE = "p";
         public const string ORDERMASSCANCELREQUEST = "q";

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -45,6 +45,7 @@ What's New
 * #900 - correct CompositeLog to use IFactory.CreateNonSessionLog when appropriate (gbirchmeier)
 * #891 - make NonSessionLog implement IDisposable and fix the IOException (VAllens)
 * #893 - Upgrade the unit testing framework to the latest version and remove obsolete Assert methods (VAllens)
+* #900 - A fix to make body-less messages work, specifically 35=n aka XMLnonFIX (gbirchmeier)
 
 ### v1.12.0
 

--- a/UnitTests/DataDictionaryTests.cs
+++ b/UnitTests/DataDictionaryTests.cs
@@ -373,6 +373,21 @@ namespace UnitTests
             Assert.That(news.GetGroup(33).IsField(355), Is.True); // EncodedText
         }
 
+        [Test]
+        public void TestCheckMsgType() {
+            DataDictionary dd = new DataDictionary();
+            dd.LoadFIXSpec("FIX44");
+
+            Assert.Throws(typeof(InvalidMessageType), delegate { dd.CheckMsgType("foo"); });
+
+            // True check, case 1: DD has a <message> definition for this one
+            Assert.DoesNotThrow(delegate { dd.CheckMsgType("B"); });
+
+            // True check, case 2: Type is in field 35, but there is no Message type
+            Assert.That(dd.Messages, Does.Not.ContainKey("n")); // Sanity check; if fails, fix the test.
+            Assert.DoesNotThrow(delegate { dd.CheckMsgType("n"); });
+        }
+
         private static XmlNode MakeNode(string xmlString)
         {
             XmlDocument doc = new XmlDocument();

--- a/spec/fix/FIX43.xml
+++ b/spec/fix/FIX43.xml
@@ -2404,7 +2404,7 @@
       <value enum="k" description="BID_REQUEST" />
       <value enum="l" description="BID_RESPONSE" />
       <value enum="m" description="LIST_STRIKE_PRICE" />
-      <value enum="n" description="XML_MESSAGE" />
+      <value enum="n" description="XML_NON_FIX" />
       <value enum="o" description="REGISTRATION_INSTRUCTIONS" />
       <value enum="p" description="REGISTRATION_INSTRUCTIONS_RESPONSE" />
       <value enum="q" description="ORDER_MASS_CANCEL_REQUEST" />

--- a/spec/fix/FIX44.xml
+++ b/spec/fix/FIX44.xml
@@ -4160,7 +4160,7 @@
       <value enum="k" description="BID_REQUEST" />
       <value enum="l" description="BID_RESPONSE" />
       <value enum="m" description="LIST_STRIKE_PRICE" />
-      <value enum="n" description="XML_MESSAGE" />
+      <value enum="n" description="XML_NON_FIX" />
       <value enum="o" description="REGISTRATION_INSTRUCTIONS" />
       <value enum="p" description="REGISTRATION_INSTRUCTIONS_RESPONSE" />
       <value enum="q" description="ORDER_MASS_CANCEL_REQUEST" />

--- a/spec/fix/FIX50.xml
+++ b/spec/fix/FIX50.xml
@@ -4647,7 +4647,7 @@
    <value enum='L' description='LIST_EXECUTE' />
    <value enum='m' description='LIST_STRIKE_PRICE' />
    <value enum='M' description='LIST_STATUS_REQUEST' />
-   <value enum='n' description='XML_MESSAGE' />
+   <value enum='n' description='XML_NON_FIX' />
    <value enum='N' description='LIST_STATUS' />
    <value enum='o' description='REGISTRATION_INSTRUCTIONS' />
    <value enum='p' description='REGISTRATION_INSTRUCTIONS_RESPONSE' />

--- a/spec/fix/FIX50SP1.xml
+++ b/spec/fix/FIX50SP1.xml
@@ -5382,7 +5382,7 @@
    <value enum='L' description='LIST_EXECUTE' />
    <value enum='m' description='LIST_STRIKE_PRICE' />
    <value enum='M' description='LIST_STATUS_REQUEST' />
-   <value enum='n' description='XML_MESSAGE' />
+   <value enum='n' description='XML_NON_FIX' />
    <value enum='N' description='LIST_STATUS' />
    <value enum='o' description='REGISTRATION_INSTRUCTIONS' />
    <value enum='p' description='REGISTRATION_INSTRUCTIONS_RESPONSE' />

--- a/spec/fix/FIXT11.xml
+++ b/spec/fix/FIXT11.xml
@@ -152,7 +152,7 @@
       <value enum='k' description='BID_REQUEST'/>
       <value enum='l' description='BID_RESPONSE'/>
       <value enum='m' description='LIST_STRIKE_PRICE'/>
-      <value enum='n' description='XML_MESSAGE'/>
+      <value enum='n' description='XML_NON_FIX'/>
       <value enum='o' description='REGISTRATION_INSTRUCTIONS'/>
       <value enum='p' description='REGISTRATION_INSTRUCTIONS_RESPONSE'/>
       <value enum='q' description='ORDER_MASS_CANCEL_REQUEST'/>


### PR DESCRIPTION
* Change DataDictionary class to also check the tag 35 enum when determining if msg type is valid
* Put some null-protection around calls to DataDictionary.Message [] accessor
* ATs of course
* Renamed 35=n to "XML_NON_FIX" in the tag 35 enum in all DD xmls