### PR TITLE
Read message type from fix string without regex

### DIFF
--- a/QuickFIXn/Message/Message.cs
+++ b/QuickFIXn/Message/Message.cs
@@ -256,17 +256,10 @@ namespace QuickFix
         /// <exception cref="MessageParseError">if 35 tag is missing or malformed</exception>
         public static string GetMsgType(string fixstring)
         {
-            // ------------------- haystack
-            // |           |
-            // v           v
-            // 2=3|3=E|35=0|55=ab|545=xx|
-            //            ^
-            //            |
-            //            ---------needle
-            //
-            // 2=3|3=E|35=0|55=ab|545=xx|   -> good message
-            // 35=5|   -> these two are garbled messages but the old regex behavior read them just fine, so the new one does as well
-            // |35=A|
+            // 2=3|3=E|35=0|55=ab|545=xx|    -> good message, msg type = 0
+            // 2=3|3=E|35=AX|55=ab|545=xx|   -> good message, msg type = AX
+            // 35=5|   -> these two are garbled messages but the old regex behavior
+            // |35=A|  -> read them just fine, so this one does as well
             var chars = fixstring.AsSpan();
             var l = 0;
             var r = 1;

--- a/QuickFIXn/Message/Message.cs
+++ b/QuickFIXn/Message/Message.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Text;
 using QuickFix.Fields;
-using System.Text.RegularExpressions;
 using System.Text.Json;
 using System.Collections.Generic;
 using QuickFix.DataDictionary;

--- a/UnitTests/MessageTests.cs
+++ b/UnitTests/MessageTests.cs
@@ -586,10 +586,14 @@ namespace UnitTests
                              + "55=sym|268=1|269=0|272=20111012|273=22:15:30.444|10=19|").Replace('|', Message.SOH);
             Assert.That(Message.GetMsgType(msgStr), Is.EqualTo("W"));
 
+            string msgStr2 = ("8=FIX.4.4|9=104|35=AW|34=3|49=sender|52=20110909-09:09:09.999|56=target"
+                             + "55=sym|268=1|269=0|272=20111012|273=22:15:30.444|10=19|").Replace('|', Message.SOH);
+            Assert.That(Message.GetMsgType(msgStr2), Is.EqualTo("AW"));
+
             // invalid 35 value, let it ride
-            string msgStr2 = ("8=FIX.4.4|9=68|35=*|34=3|49=sender|52=20110909-09:09:09.999|56=target"
+            string msgStr3 = ("8=FIX.4.4|9=68|35=*|34=3|49=sender|52=20110909-09:09:09.999|56=target"
                               + "55=sym|268=0|10=9|").Replace('|', Message.SOH);
-            Assert.That(Message.GetMsgType(msgStr2), Is.EqualTo("*"));
+            Assert.That(Message.GetMsgType(msgStr3), Is.EqualTo("*"));
         }
 
         [Test]

--- a/UnitTests/MessageTests.cs
+++ b/UnitTests/MessageTests.cs
@@ -580,20 +580,24 @@ namespace UnitTests
             Assert.That(getSessionId.TargetLocationID, Is.EqualTo(""));
         }
 
-        [Test]
-        public void GetMsgTypeTest() {
-            string msgStr = ("8=FIX.4.4|9=104|35=W|34=3|49=sender|52=20110909-09:09:09.999|56=target"
-                             + "55=sym|268=1|269=0|272=20111012|273=22:15:30.444|10=19|").Replace('|', Message.SOH);
-            Assert.That(Message.GetMsgType(msgStr), Is.EqualTo("W"));
+        [TestCase("8=FIX.4.4|9=104|35=W|34=3|49=sender|52=20110909-09:09:09.999|56=target|55=sym|268=1|269=0|272=20111012|273=22:15:30.444|10=19|", "W")]
+        [TestCase("8=FIX.4.4|9=104|35=AW|34=3|49=sender|52=20110909-09:09:09.999|56=target|55=sym|268=1|269=0|272=20111012|273=22:15:30.444|10=19|", "AW")]
+        // invalid 35 value, let it ride
+        [TestCase("8=FIX.4.4|9=68|35=*|34=3|49=sender|52=20110909-09:09:09.999|56=target|55=sym|268=0|10=9|", "*")]
+        public void GetMsgTypeTest(string message, string expectedMessageType)
+        {
+            var msgStr = message.Replace('|', Message.SOH);
+            Assert.That(Message.GetMsgType(msgStr), Is.EqualTo(expectedMessageType));;
+        }
 
-            string msgStr2 = ("8=FIX.4.4|9=104|35=AW|34=3|49=sender|52=20110909-09:09:09.999|56=target"
-                             + "55=sym|268=1|269=0|272=20111012|273=22:15:30.444|10=19|").Replace('|', Message.SOH);
-            Assert.That(Message.GetMsgType(msgStr2), Is.EqualTo("AW"));
-
-            // invalid 35 value, let it ride
-            string msgStr3 = ("8=FIX.4.4|9=68|35=*|34=3|49=sender|52=20110909-09:09:09.999|56=target"
-                              + "55=sym|268=0|10=9|").Replace('|', Message.SOH);
-            Assert.That(Message.GetMsgType(msgStr3), Is.EqualTo("*"));
+        [TestCase("")]
+        [TestCase("8=FIX.4.4|9=68|34=3|49=sender|52=20110909-09:09:09.999|56=target|55=sym|268=0|10=9|")]
+        [TestCase("8=FIX.4.4|9=68|35=|34=3|49=sender|52=20110909-09:09:09.999|56=target|55=sym|268=0|10=9|")]
+        [TestCase("8=FIX.4.4|9=68|35=")]
+        public void GetInvalidMsgTypeTest(string message)
+        {
+            var msgStr = message.Replace('|', Message.SOH);
+            Assert.Throws<MessageParseError>(() => Message.GetMsgType(msgStr));
         }
 
         [Test]


### PR DESCRIPTION
I'm investigating how to have the message type as part of the log's context when a message is sent/received in #899, and that might require calling GetMsgType on the hot path. This pr removes the regex from that method, in case that's the way forward. 
```
BenchmarkDotNet v0.14.0, NixOS 24.11 (Vicuna)
    11th Gen Intel Core i7-1165G7 2.80GHz, 1 CPU, 8 logical and 4 physical cores
    .NET SDK 8.0.307
      [Host]     : .NET 8.0.11 (8.0.1124.51707), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
      DefaultJob : .NET 8.0.11 (8.0.1124.51707), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI

    | Method | Mean      | Error    | StdDev    | Gen0   | Allocated |
    |------- |----------:|---------:|----------:|-------:|----------:|
    | Manual |  35.33 ns | 2.754 ns |  8.122 ns | 0.0038 |      24 B |
    | Regex  | 322.38 ns | 9.405 ns | 25.265 ns | 0.0648 |     408 B |
```
Manual is this PR, Regex is current code.