### PR TITLE
(squash/update of #909) Read message type from fix string without regex

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -46,6 +46,7 @@ What's New
 * #891 - make NonSessionLog implement IDisposable and fix the IOException (VAllens)
 * #893 - Upgrade the unit testing framework to the latest version and remove obsolete Assert methods (VAllens)
 * #907 - A fix to make body-less messages work, specifically 35=n aka XMLnonFIX (gbirchmeier)
+* #910 - faster Message.GetMsgType that doesn't use Regex (jkulubya)
 
 ### v1.12.0
 

--- a/UnitTests/MessageTests.cs
+++ b/UnitTests/MessageTests.cs
@@ -580,16 +580,23 @@ namespace UnitTests
             Assert.That(getSessionId.TargetLocationID, Is.EqualTo(""));
         }
 
-        [Test]
-        public void GetMsgTypeTest() {
-            string msgStr = ("8=FIX.4.4|9=104|35=W|34=3|49=sender|52=20110909-09:09:09.999|56=target"
-                             + "55=sym|268=1|269=0|272=20111012|273=22:15:30.444|10=19|").Replace('|', Message.SOH);
-            Assert.That(Message.GetMsgType(msgStr), Is.EqualTo("W"));
+        [TestCase("8=FIX.4.4|9=104|35=W|34=3|49=sender|52=20110909-09:09:09.999|56=target|55=sym|268=1|269=0|272=20111012|273=22:15:30.444|10=19|", "W")]
+        [TestCase("8=FIX.4.4|9=104|35=AW|34=3|49=sender|52=20110909-09:09:09.999|56=target|55=sym|268=1|269=0|272=20111012|273=22:15:30.444|10=19|", "AW")]
+        [TestCase("8=FIX.4.4|9=68|35=*|34=3|49=sender|52=20110909-09:09:09.999|56=target|55=sym|268=0|10=9|", "*")]
+        public void GetMsgTypeTest(string message, string expectedMessageType)
+        {
+            var msgStr = message.Replace('|', Message.SOH);
+            Assert.That(Message.GetMsgType(msgStr), Is.EqualTo(expectedMessageType));
+        }
 
-            // invalid 35 value, let it ride
-            string msgStr2 = ("8=FIX.4.4|9=68|35=*|34=3|49=sender|52=20110909-09:09:09.999|56=target"
-                              + "55=sym|268=0|10=9|").Replace('|', Message.SOH);
-            Assert.That(Message.GetMsgType(msgStr2), Is.EqualTo("*"));
+        [TestCase("")]
+        [TestCase("8=FIX.4.4|9=68|34=3|49=sender|52=20110909-09:09:09.999|56=target|55=sym|268=0|10=9|")]
+        [TestCase("8=FIX.4.4|9=68|35=|34=3|49=sender|52=20110909-09:09:09.999|56=target|55=sym|268=0|10=9|")]
+        [TestCase("8=FIX.4.4|9=68|35=")]
+        public void GetInvalidMsgTypeTest(string message)
+        {
+            var msgStr = message.Replace('|', Message.SOH);
+            Assert.Throws<MessageParseError>(() => Message.GetMsgType(msgStr));
         }
 
         [Test]


### PR DESCRIPTION
closes #909 -- this PR is the same content, squashed into one commit, plus release notes and a little cleanup

attn @jkulubya

## Original description from #909:

I'm investigating how to have the message type as part of the log's context when a message is sent/received in #899, and that might require calling GetMsgType on the hot path. This pr removes the regex from that method, in case that's the way forward. 
```
BenchmarkDotNet v0.14.0, NixOS 24.11 (Vicuna)
    11th Gen Intel Core i7-1165G7 2.80GHz, 1 CPU, 8 logical and 4 physical cores
    .NET SDK 8.0.307
      [Host]     : .NET 8.0.11 (8.0.1124.51707), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
      DefaultJob : .NET 8.0.11 (8.0.1124.51707), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI

    | Method | Mean      | Error    | StdDev    | Gen0   | Allocated |
    |------- |----------:|---------:|----------:|-------:|----------:|
    | Manual |  35.33 ns | 2.754 ns |  8.122 ns | 0.0038 |      24 B |
    | Regex  | 322.38 ns | 9.405 ns | 25.265 ns | 0.0648 |     408 B |
```
Manual is this PR, Regex is current code.