### PR TITLE
Optimize MessageCracker.IsHandlerMethod for memory

### DIFF
--- a/QuickFIXn/MessageCracker.cs
+++ b/QuickFIXn/MessageCracker.cs
@@ -53,12 +53,13 @@ namespace QuickFix
 
         public static bool IsHandlerMethod(MethodInfo m)
         {
+            ParameterInfo[] parameters;
             return m.IsPublic
+                   && m.ReturnType == typeof(void)
                    && m.Name.Equals("OnMessage")
-                   && m.GetParameters().Length == 2
-                   && m.GetParameters()[0].ParameterType.IsSubclassOf(typeof(Message))
-                   && typeof(SessionID).IsAssignableFrom(m.GetParameters()[1].ParameterType)
-                   && m.ReturnType == typeof(void);
+                   && (parameters = m.GetParameters()).Length == 2
+                   && parameters[0].ParameterType.IsSubclassOf(typeof(Message))
+                   && typeof(SessionID).IsAssignableFrom(parameters[1].ParameterType);
         }
 
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -49,6 +49,7 @@ What's New
 * #910 - faster Message.GetMsgType that doesn't use Regex (jkulubya)
 * #516 - remove ability to toggle Session-enable via HttpServer because it never really worked (gbirchmeier)
 * #913/#741 - new FieldMap.ReadGroups for iterating on groups (NoviProg/gbirchmeier)
+* #914 - Optimize MessageCracker.IsHandlerMethod (vasily-balansea)
 
 ### v1.12.0
 


### PR DESCRIPTION
MessageCracker.IsHandlerMethod is calling MethodInfo.GetParameters() method three times leading to minor memory waste. This is because GetParameters() is allocating a new array when method has parameters. If we cache parameters array then we save a bit of memory and make method a bit faster. IL code is also a bit smaller: 119 bytes vs 127.

Unit tests are passing.

Benchmark results:
```
| Method | Runtime            | Mean     | Error   | StdDev  | Allocated |
|------- |------------------- |---------:|--------:|--------:|----------:|
| Old    | .NET 8.0           | 194.1 ns | 1.63 ns | 1.44 ns |     480 B |
| New    | .NET 8.0           | 124.3 ns | 0.58 ns | 0.54 ns |     240 B |

| Old    | .NET Framework 4.8 | 518.1 ns | 0.91 ns | 0.76 ns |     481 B |
| New    | .NET Framework 4.8 | 350.0 ns | 1.26 ns | 1.12 ns |     241 B |
````

Benchmark code:
```csharp
[SimpleJob(RuntimeMoniker.Net48)]
[SimpleJob(RuntimeMoniker.Net80)]
[MemoryDiagnoser]
[HideColumns("Job", "Gen0")]
public class IsHandlerMethodBenchmark
{
    // UnitTests.MessageCrackerTests.TheseMightBeHandlerMethods
    MethodInfo[] methods = typeof(TheseMightBeHandlerMethods).GetMethods();

    [Benchmark]
    public int Old()
    {
        int count = 0;

        foreach (MethodInfo m in methods)
        {
            if (IsHandlerMethodOld(m))
            {
                count++;
            }
        }

        return count;
    }

    [Benchmark]
    public int New()
    {
        int count = 0;

        foreach (MethodInfo m in methods)
        {
            if (IsHandlerMethodNew(m))
            {
                count++;
            }
        }

        return count;
    }

    private bool IsHandlerMethodOld(MethodInfo m)
    {
        return m.IsPublic
               && m.Name.Equals("OnMessage")
               && m.GetParameters().Length == 2
               && m.GetParameters()[0].ParameterType.IsSubclassOf(typeof(Message))
               && typeof(SessionID).IsAssignableFrom(m.GetParameters()[1].ParameterType)
               && m.ReturnType == typeof(void);
    }

    private bool IsHandlerMethodNew(MethodInfo m)
    {
        ParameterInfo[] parameters;
        return m.IsPublic
                && m.ReturnType == typeof(void)
                && m.Name.Equals("OnMessage")
                && (parameters = m.GetParameters()).Length == 2
                && parameters[0].ParameterType.IsSubclassOf(typeof(Message))
                && typeof(SessionID).IsAssignableFrom(parameters[1].ParameterType);
    }
}

````

This is obviously a micro optimization since gains (memory and time) are small and unlikely to have any visible effect on application performance. Still I hope you would accept PR.