### PR TITLE
(#742 rebase/squash) Improvements to HTTP web proxy

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -50,6 +50,7 @@ What's New
 * #516 - remove ability to toggle Session-enable via HttpServer because it never really worked (gbirchmeier)
 * #913/#741 - new FieldMap.ReadGroups for iterating on groups (NoviProg/gbirchmeier)
 * #914 - Optimize MessageCracker.IsHandlerMethod (vasily-balansea)
+* #742 - Improvements to HTTP web proxy (IanLeeClaxton)
 
 ### v1.12.0
 


### PR DESCRIPTION
@iclaxton 's original comment from PR #742:

> The current http proxy implementation has a few issues that I encountered when trying to implement behind a Squid proxy so we were unable to use it. This update should resolve the issues we encountered
> 
> Bug: proxy connect packet is malformed due to a space after HTTP/1.1.
> Feature: Pass the host name so proxy host acls can be matched.
> Feature: Switch to the WebRequest.DefaultWebProxy which allows for overriding in app.settings file and falls back to the system proxy if not configured.
> Improvement: Use ordinal comparision for IndexOf on the proxy response.

Resolves #742 (original PR, this is a rebase)