### PR TITLE
Option not to send admin messages

### DIFF
--- a/QuickFIXn/IApplication.cs
+++ b/QuickFIXn/IApplication.cs
@@ -9,8 +9,10 @@
         /// This callback provides you with a peek at the administrative messages
         /// that are being sent from your FIX engine to the counter party. This is
         /// normally not useful for an application however it is provided for any
-        /// logging you may wish to do. You may add fields in an adminstrative
+        /// logging you may wish to do. You may add fields in an administrative
         /// message before it is sent.
+        /// In some rare cases, it might be useful to throw a DoNotSend exception
+        /// in this function to suppress sending of the message by the application.
         /// </summary>
         /// <param name="message"></param>
         /// <param name="sessionID"></param>

--- a/QuickFIXn/Session.cs
+++ b/QuickFIXn/Session.cs
@@ -1539,7 +1539,14 @@ namespace QuickFix
 
                 if (Message.IsAdminMsgType(msgType))
                 {
-                    Application.ToAdmin(message, SessionID);
+                    try
+                    {
+                        Application.ToAdmin(message, SessionID);
+                    }
+                    catch (DoNotSend)
+                    {
+                        return false;
+                    }
 
                     if (MsgType.LOGON.Equals(msgType) && !_state.ReceivedReset)
                     {

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -61,6 +61,7 @@ What's New
 * #392 - move tcpListener.Start from ThreadedSocketReactor.Run to .Start() so application doesn't
          crash if an exception occurs when starting the listener (hlibman-connamara)
 * #658 - new "AllowUnknownEnumValues" setting (akamyshanov/rakker91/hlibman-connamara)
+* #925 - Make ToAdmin() support DoNotSend (zsojma)
 
 ### v1.12.0
 

--- a/UnitTests/SessionTest.cs
+++ b/UnitTests/SessionTest.cs
@@ -713,6 +713,7 @@ public class SessionTest
 
         Assert.That(_responder.MsgLookup.ContainsKey(QuickFix.Fields.MsgType.REJECT), Is.False);
     }
+
     [Test]
     public void TestToAppDoNotSend()
     {
@@ -725,7 +726,7 @@ public class SessionTest
              new QuickFix.Fields.TransactTime(),
              new QuickFix.Fields.OrdType(QuickFix.Fields.OrdType.LIMIT));
 
-        _application.DoNotSendException = new QuickFix.DoNotSend();
+        _application.ToAppException = new QuickFix.DoNotSend();
         _session!.Send(order);
         Assert.That(SENT_NOS(), Is.False);
     }
@@ -746,12 +747,22 @@ public class SessionTest
         Assert.That(SENT_NOS(), Is.True);
 
         _responder.MsgLookup.Remove(QuickFix.Fields.MsgType.NEWORDERSINGLE);
-        _application.DoNotSendException = new QuickFix.DoNotSend();
+        _application.ToAppException = new QuickFix.DoNotSend();
 
         SendResendRequest(1, 0);
         Assert.That(SENT_NOS(), Is.False);
     }
 
+    [Test]
+    public void TestToAdminDoNotSend()
+    {
+        Logon();
+        QuickFix.FIX42.Reject reject = new();
+
+        _application.ToAdminException = new QuickFix.DoNotSend();
+        _session!.Send(reject);
+        Assert.That(SENT_REJECT(), Is.False);
+    }
 
     [Test]
     public void TestApplicationExtension()

--- a/UnitTests/SessionTestSupport/MockApplication.cs
+++ b/UnitTests/SessionTestSupport/MockApplication.cs
@@ -6,9 +6,14 @@ internal class MockApplication : QuickFix.IApplication
 {
     public Exception? FromAppException { get; set; }
     public Exception? FromAdminException { get; set; }
-    public QuickFix.DoNotSend? DoNotSendException { get; set; }
+    public Exception? ToAppException { get; set; }
+    public Exception? ToAdminException { get; set; }
 
-    public void ToAdmin(QuickFix.Message message, QuickFix.SessionID sessionId) { }
+    public void ToAdmin(QuickFix.Message message, QuickFix.SessionID sessionId)
+    {
+        if (ToAdminException is not null)
+            throw ToAdminException;
+    }
 
     public void FromAdmin(QuickFix.Message message, QuickFix.SessionID sessionId)
     {
@@ -18,8 +23,8 @@ internal class MockApplication : QuickFix.IApplication
 
     public void ToApp(QuickFix.Message message, QuickFix.SessionID sessionId)
     {
-        if (DoNotSendException is not null)
-            throw DoNotSendException;
+        if (ToAppException is not null)
+            throw ToAppException;
     }
 
     public void FromApp(QuickFix.Message message, QuickFix.SessionID sessionId)


### PR DESCRIPTION
Our liquidity provider disables our market data session when they receive a reject from us. Because QuickFix automatically sends reject admin messages in some cases, we need to have a way to suppress it.

If this is not a viable solution, pls let me know how can we do that. Thanks