### PR TITLE
Remove lock from ScreenLog

### DIFF
--- a/QuickFIXn/Logger/ScreenLog.cs
+++ b/QuickFIXn/Logger/ScreenLog.cs
@@ -5,7 +5,6 @@
 /// </summary>
 public class ScreenLog : ILog
 {
-    private readonly object _sync = new ();
     private readonly bool _logIncoming;
     private readonly bool _logOutgoing;
     private readonly bool _logEvent;
@@ -27,10 +26,7 @@ public class ScreenLog : ILog
         if (!_logIncoming)
             return;
 
-        lock (_sync)
-        {
-            System.Console.WriteLine("<incoming> " + msg.Replace(Message.SOH, '|'));
-        }
+        System.Console.WriteLine("<incoming> " + msg.Replace(Message.SOH, '|'));
     }
 
     public void OnOutgoing(string msg)
@@ -38,10 +34,7 @@ public class ScreenLog : ILog
         if (!_logOutgoing)
             return;
 
-        lock (_sync)
-        {
-            System.Console.WriteLine("<outgoing> " + msg.Replace(Message.SOH, '|'));
-        }
+        System.Console.WriteLine("<outgoing> " + msg.Replace(Message.SOH, '|'));
     }
 
     public void OnEvent(string s)
@@ -49,10 +42,7 @@ public class ScreenLog : ILog
         if (!_logEvent)
             return;
 
-        lock (_sync)
-        {
-            System.Console.WriteLine("<event> " + s);
-        }
+        System.Console.WriteLine("<event> " + s);
     }
     #endregion
 
@@ -66,6 +56,5 @@ public class ScreenLog : ILog
     {
         // Nothing to dispose of...
     }
-    ~ScreenLog() => Dispose(false);
     #endregion
 }

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -62,6 +62,7 @@ What's New
          crash if an exception occurs when starting the listener (hlibman-connamara)
 * #658 - new "AllowUnknownEnumValues" setting (akamyshanov/rakker91/hlibman-connamara)
 * #925 - Make ToAdmin() support DoNotSend (zsojma)
+* #927 - Remove lock from ScreenLog as Console.WriteLine is thread safe and remove unnecessary Dispose call (Rob-Hague)
 
 ### v1.12.0
 


### PR DESCRIPTION
Console.WriteLine is static and can safely be called from multiple threads