### PR TITLE
fix an obscure failure of Message.FromString that occurs when a message ends in a group (and lacks a checksum)

### DIFF
--- a/QuickFIXn/Message/Message.cs
+++ b/QuickFIXn/Message/Message.cs
@@ -594,6 +594,13 @@ namespace QuickFix
                     // f is a counter for a nested group.  Recurse!
                     pos = SetGroup(f, msgstr, pos, grp, groupSpec.GetGroupSpec(f.Tag), msgFactory);
                 }
+
+                // rare situation: if message ends on an in-group field (which means it lacks a checksum),
+                //   then this logic is needed here to actually write the group (because this loop won't run again)
+                if (pos == msgstr.Length) {
+                    fieldMap.AddGroup(grp, false);
+                    return pos;
+                }
             }
             
             return grpPos;

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -65,6 +65,7 @@ What's New
 * #927 - Remove lock from ScreenLog as Console.WriteLine is thread safe and remove unnecessary Dispose call (Rob-Hague)
 * #926 - don't init FileLog writers until first use (Rob-Hague)
 * #931 - bugfix in FixToJson example program
+* #934 - fix an obscure failure of Message.FromString when a message ends in a group (and lacks a checksum) (gbirchmeier)
 
 ### v1.12.0
 

--- a/UnitTests/MessageTests.cs
+++ b/UnitTests/MessageTests.cs
@@ -1072,5 +1072,24 @@ namespace UnitTests
             // the object state is changed
             Assert.That(expected, Is.EqualTo(msg.ToString().Replace(Message.SOH, '|')));
         }
+
+        [Test]
+        public void FromString_EndsWithGroup() {
+            QuickFix.DataDictionary.DataDictionary dd = new QuickFix.DataDictionary.DataDictionary();
+            dd.LoadFIXSpec("FIX42");
+
+            string s = ("8=FIX.4.2|9=91|35=B|34=2|49=TW|52=20111011-15:06:23.103|56=ISLD|"
+                        + "148=headline|33=1|"
+                        + "58=line1|354=3|355=uno|"
+                    // no checksum!
+                ).Replace('|', Message.SOH);
+
+            QuickFix.FIX42.News n = new QuickFix.FIX42.News();
+            n.FromString(s, false, dd, dd);
+
+            Assert.That(n.ToString().Replace(Message.SOH, '|'), Is.EqualTo(
+                "8=FIX.4.2|9=91|35=B|34=2|49=TW|52=20111011-15:06:23.103|56=ISLD|148=headline|33=1|58=line1|354=3|355=uno|"
+            ));
+        }
     }
 }


### PR DESCRIPTION
(Actually the fix is in Message.SetGroup)

Discovered by @trevor-bush when using Message.FromString to parse client messages which didn't have a checksum.  (These calls used validation=false, obviously.)