### PR TITLE
Connect Initiator Session Immediately (Ignore RECONNECT_INTERVAL on First Attempt)

### DIFF
--- a/QuickFIXn/Transport/SocketInitiator.cs
+++ b/QuickFIXn/Transport/SocketInitiator.cs
@@ -33,7 +33,10 @@ namespace QuickFix.Transport
             : base(application, storeFactory, settings, logFactoryNullable, messageFactoryNullable)
         { }
 
-        public void ForceInstantConnect() => this._forceInstantConnect = true;
+        public void ForceInstantConnect()
+        {
+          SetForceInstantConnect(true);
+        }
 
         public static void SocketInitiatorThreadStart(object? socketInitiatorThread)
         {
@@ -146,6 +149,14 @@ namespace QuickFix.Transport
             }
         }
 
+        private void SetForceInstantConnect(bool value)
+        {
+            lock (_sync)
+            {
+              this._forceInstantConnect = value;
+            }
+        }
+
         #region Initiator Methods
         
         /// <summary>
@@ -180,7 +191,7 @@ namespace QuickFix.Transport
                     {
                         Connect();
                         _lastConnectTimeDt = nowDt;
-                        _forceInstantConnect = false;
+                        SetForceInstantConnect(false);
                     }
                 }
                 catch (Exception e)


### PR DESCRIPTION
Our RECONNECT_INTERVAL is set to 30 seconds. If the active connection disconnects, we do not want to reconnect immediately; we want to wait a bit, so that is OK.

But, when an Initiator session is enabled (in our environment manually by user) and started at first, it also follows the configured RECONNECT_INTERVAL before attempting to establish a connection. This means that even on the first connection attempt after enabling the session, the system waits for the specified interval instead of connecting immediately. This tends to take a while, since the user can enable session at the begining of the RECONNECT_INTERVAL and has to wait those 30 seconds before anything happens...