### PR TITLE
SocketInitiatorThread - restore Session disconnect during Read exception

### DIFF
--- a/QuickFIXn/SocketInitiatorThread.cs
+++ b/QuickFIXn/SocketInitiatorThread.cs
@@ -97,16 +97,21 @@ public class SocketInitiatorThread : IResponder
             ProcessStream();
             return true;
         }
-        catch (ObjectDisposedException)
+        catch (ObjectDisposedException e)
         {
             // this exception means _socket is already closed when poll() is called
             if (_isDisconnectRequested == false)
-                Disconnect();
+            {
+                if (!Session.Disposed) // should not be disposed, but just in case...
+                    Session.Disconnect(e.ToString()); // also calls this instance's Disconnect()
+                else
+                    Disconnect();
+            }
         }
         catch (Exception e)
         {
             Session.Log.OnEvent(e.ToString());
-            Disconnect();
+            Session.Disconnect(e.ToString()); // also calls this instance's Disconect()
         }
         return false;
     }

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -41,6 +41,7 @@ What's New
 * #895 - fix: When SSLCACertificate is empty an error is logged and it fails to start (dckorben)
 * #942 - fix #942: field 369 (LastMsgSeqNumProcessed) wrong in ResendRequest message (gbirchmeier)
 * #940 - Create an alternate CharEncoding.GetBytes impl which uses ArrayPool to improve memory performance (VAllens)
+* #951 - fix: restore Session disconnect during SocketInitiatorThread.Read exception (gbirchmeier/trevor-bush)
 
 ### v1.13.0
 


### PR DESCRIPTION
attn @trevor-bush 

`Session` is non-nullable as of 1.12, so we don't have to null-check it.

### Problem description

A user saw this message flow on the initiator side when running in their production env:

* connection is established and ok
* connection gets dropped somehow (not caused by initiator)
* **initiator does not call Session.Disconnect() so it still considers the session "alive"**
* connection is reestablished
* **initiator sends a TestRequest (it doesn't send a Logon because the session never disconnected)**
* **acceptor replies to TestRequest with a 35=3 reject (no error code, but 58="Session error: expect logon")**
    * a QF/n-based acceptor wouldn't do this, but the user's counterparty did
* the reject is processed by the initiator, causing `_state.LastReceivedTimeDT` to update
* initiator still thinks things are fine, there's no timeout!  It sends a heartbeat
* acceptor rejects the heartbeat (initiator updates `_state.LastReceivedTimeDT` again)
* this heartbeat/reject/heartbeat/reject cycle lasts for infinity (or until initiator is restarted)

When run against a QF/n-based acceptor, the initiator does sends the TestRequest, but the connection errors out with a Broken Pipe SocketException.  (I ctrl-c killed the acceptor app and restarted it to break the socket connection.)  The initiator should not be sending a TestRequest.

The root cause is that the connection droppage is not triggering a Session.Disconnect call.  It used to do that, but looks like it was removed in PR #836.  That was clearly a mistake.

