### PR TITLE
solve issue #309: obey a GapFill even if it replaces a message that was processed off the queue

### DIFF
--- a/AcceptanceTest/ATApplication.cs
+++ b/AcceptanceTest/ATApplication.cs
@@ -134,13 +134,22 @@ namespace AcceptanceTest
 
         private void ProcessNews(Message msg, SessionID sessionId)
         {
-            if (msg.IsSetField(QuickFix.Fields.Tags.Headline) && (msg.GetString(QuickFix.Fields.Tags.Headline) == "STOPME"))
+            string headlineUpcase = msg.GetString(Tags.Headline).ToUpperInvariant();
+
+            if (headlineUpcase.Contains("STOPME"))
             {
-                if (this.StopMeEvent != null)
-                    StopMeEvent();
+                StopMeEvent?.Invoke();
+                return;
             }
-            else
-                Echo(msg, sessionId);
+
+            if(headlineUpcase.Contains("NOECHO")
+               || headlineUpcase.Contains("NO-ECHO")
+               || headlineUpcase.Contains("NO_ECHO"))
+            {
+                return;
+            }
+
+            Echo(msg, sessionId);
         }
 
         public void OnMessage(QuickFix.FIX44.TradeCaptureReportRequest msg, SessionID sessionId)

--- a/AcceptanceTest/definitions/server/fix44/issue309_GapFillSkip.def
+++ b/AcceptanceTest/definitions/server/fix44/issue309_GapFillSkip.def
@@ -1,0 +1,33 @@
+# issue 309
+# When a GapFill skips over seqnos past the ExpectedNextTargetSeqNum,
+#   the engine needs to skip with it.
+
+iCONNECT
+I8=FIX.4.435=A34=149=TW52=<TIME>56=ISLD98=0108=2
+E8=FIX.4.435=A34=149=ISLD52=00000000-00:00:00.00056=TW98=0108=210=0
+
+# News msg to bump the seq up
+I8=FIX.4.435=B34=249=TW52=<TIME>56=ISLD148=no_echo33=0
+
+# Heartbeat with seq 5 (when 3 is expected)
+I8=FIX.4.435=034=549=TW52=<TIME>56=ISLD
+
+# Expect ResendRequest for 3+
+E8=FIX.4.435=234=249=ISLD52=00000000-00:00:00.00056=TW7=316=010=0
+
+# Resend 3 and 4
+I8=FIX.4.435=B34=343=Y49=TW52=<TIME>56=ISLD148=no_echo33=0
+I8=FIX.4.435=B34=443=Y49=TW52=<TIME>56=ISLD148=no_echo33=0
+sleep(0.2)
+
+# Session now processes the Heartbeat (seq=5) from its queue
+E8=FIX.4.435=034=349=ISLD52=00000000-00:00:00.00056=TW10=0
+
+# Counterparty is still resending - it is on 5 now.
+# 5 is that heartbeat, an admin msg, so send a GapFill instead.
+# The EndSeqNo is 7, completely skipping over 6.
+I8=FIX.4.435=434=549=TW52=<TIME>56=ISLD43=Y122=<TIME-1>36=7123=Y
+
+# Ensure that client obeyed the SequenceReset and set NextExpected=7
+I8=FIX.4.435=B34=749=TW52=<TIME>56=ISLD148=foo33=0
+E8=FIX.4.435=B34=449=ISLD52=00000000-00:00:00.00056=TW33=0148=foo

--- a/QuickFIXn/Session.cs
+++ b/QuickFIXn/Session.cs
@@ -510,6 +510,7 @@ namespace QuickFix
         public void Next(string msgStr)
         {
             NextMessage(msgStr);
+            _state.LastProcessedMessageWasQueued = false;
             NextQueued();
         }
 
@@ -930,8 +931,20 @@ namespace QuickFix
                     }
                     if (checkTooLow && IsTargetTooLow(msgSeqNum))
                     {
-                        DoTargetTooLow(msg, msgSeqNum);
-                        return false;
+                        if (_state.LastProcessedMessageWasQueued
+                            && msg.Header.GetString(35) == MsgType.SEQUENCE_RESET
+                            && msg.GetBoolean(Tags.GapFillFlag))
+                        {
+                            Log.OnEvent($"SequenceReset-GapFill 34={msgSeqNum} is too low" +
+                                        $" (expected {_state.NextTargetMsgSeqNum})," +
+                                        $" but in this case I'm going to obey it anyway");
+                            // This is an uncommon situation, see #309
+                        }
+                        else
+                        {
+                            DoTargetTooLow(msg, msgSeqNum);
+                            return false;
+                        }
                     }
 
                     if (IsResendRequested)
@@ -1539,6 +1552,7 @@ namespace QuickFix
                 {
                     NextMessage(msg.ConstructString());
                 }
+                _state.LastProcessedMessageWasQueued = true;
                 return true;
             }
             return false;

--- a/QuickFIXn/SessionState.cs
+++ b/QuickFIXn/SessionState.cs
@@ -48,6 +48,12 @@ namespace QuickFix
 
         public ILog Log { get; }
 
+        /// <summary>
+        /// True if the last message processed was an admin message from the queue.
+        /// Needed for an obscure SequenceReset scenario (see issue #390).
+        /// </summary>
+        internal bool LastProcessedMessageWasQueued { get; set; }
+
         #endregion
 
         #region Synchronized Properties

--- a/UnitTests/SessionTest.cs
+++ b/UnitTests/SessionTest.cs
@@ -192,9 +192,12 @@ public class SessionTest
         _session!.Next(CreateNOSMessage(_seqNum++).ConstructString());
     }
 
-    public void SendNOSMessage(SeqNumType n)
+    public void SendNOSMessage(SeqNumType n, bool possDupFlag=false)
     {
-        _session!.Next(CreateNOSMessage(n).ConstructString());
+        var msg = CreateNOSMessage(n);
+        if (possDupFlag)
+            msg.Header.SetField(new QuickFix.Fields.PossDupFlag(possDupFlag));
+        _session!.Next(msg.ConstructString());
     }
 
     public void SendResendRequest(SeqNumType begin, SeqNumType end)
@@ -213,10 +216,14 @@ public class SessionTest
 
     private void SendTheMessage(QuickFix.Message msg)
     {
+        SendTheMessage(msg, _seqNum++);
+    }
+
+    private void SendTheMessage(QuickFix.Message msg, SeqNumType seqNum)
+    {
         msg.Header.SetField(new QuickFix.Fields.TargetCompID(_sessionId.SenderCompID));
         msg.Header.SetField(new QuickFix.Fields.SenderCompID(_sessionId.TargetCompID));
-        msg.Header.SetField(new QuickFix.Fields.MsgSeqNum(_seqNum++));
-
+        msg.Header.SetField(new QuickFix.Fields.MsgSeqNum(seqNum));
         _session!.Next(msg.ConstructString());
     }
 
@@ -960,6 +967,101 @@ public class SessionTest
             else
                 Assert.That(_session.IsResendRequested, Is.False, $"seq num {i}");
         }
+    }
+
+    [Test]
+    public void TestSequenceResetNoGapFillIsProcessed()
+    {
+        Assert.That(_session!.IgnorePossDupResendRequests, Is.EqualTo(false));
+        Logon();
+        SendNOSMessage();
+        SendNOSMessage();
+        Assert.That(_session.NextTargetMsgSeqNum, Is.EqualTo(4));
+
+        QuickFix.FIX42.SequenceReset sr = new(new QuickFix.Fields.NewSeqNo(150));
+        SendTheMessage(sr);
+
+        Assert.That(_session.NextTargetMsgSeqNum, Is.EqualTo(150));
+    }
+
+    [Test]
+    public void TestSequenceResetWithGapFillIsProcessed()
+    {
+        Assert.That(_session!.IgnorePossDupResendRequests, Is.EqualTo(false));
+        Logon();
+        SendNOSMessage();
+        SendNOSMessage();
+        Assert.That(_session.NextTargetMsgSeqNum, Is.EqualTo(4));
+
+        QuickFix.FIX42.SequenceReset sr = new(new QuickFix.Fields.NewSeqNo(150));
+        sr.GapFillFlag = new QuickFix.Fields.GapFillFlag(true);
+        SendTheMessage(sr);
+
+        Assert.That(_session.NextTargetMsgSeqNum, Is.EqualTo(150));
+    }
+
+    [Test]
+    public void TestSequenceResetDuringResendRequestIsProcessed()
+    {
+        Assert.That(_session!.IgnorePossDupResendRequests, Is.EqualTo(false));
+        _session.RequiresOrigSendingTime = false; // default is true
+        Logon();
+        SendNOSMessage(); // seq 2
+        SendNOSMessage(10); // causes ResendRequest to be sent
+        Assert.That(_session.NextTargetMsgSeqNum, Is.EqualTo(3));
+
+        var resendRequest =
+            (QuickFix.FIX42.ResendRequest)_responder.MsgLookup[QuickFix.Fields.MsgType.RESEND_REQUEST].Dequeue();
+        Assert.That(resendRequest.BeginSeqNo.Value, Is.EqualTo(3));
+        Assert.That(resendRequest.EndSeqNo.Value, Is.EqualTo(0));
+
+        // Resend & GapFill through seq=9
+        SendNOSMessage(3);
+        SendNOSMessage(4);
+        QuickFix.FIX42.SequenceReset sr = new(new QuickFix.Fields.NewSeqNo(9));
+        SendTheMessage(sr, 5);
+        SendNOSMessage(9);
+
+        // We already processed 10, so the next one is 11
+        Assert.That(_session.NextTargetMsgSeqNum, Is.EqualTo(11));
+    }
+
+    [Test]
+    public void TestGapFillShouldNotBeIgnoredIfPossDup()
+    {
+        Assert.That(_session!.IgnorePossDupResendRequests, Is.EqualTo(false));
+        _session.RequiresOrigSendingTime = false; // default is true
+        Logon();
+        SendNOSMessage(); // seq 2
+
+        QuickFix.FIX42.Heartbeat hb = new();
+        SendTheMessage(hb, 5); // seq=5, causes ResendRequest to be sent
+
+        // Verify the ResendRequest that was just sent
+        var resendRequest =
+            (QuickFix.FIX42.ResendRequest)_responder.MsgLookup[QuickFix.Fields.MsgType.RESEND_REQUEST].Dequeue();
+        Assert.That(resendRequest.BeginSeqNo.Value, Is.EqualTo(3));
+        Assert.That(resendRequest.EndSeqNo.Value, Is.EqualTo(0));
+
+        Assert.That(_session.NextTargetMsgSeqNum, Is.EqualTo(3));
+
+        // Resends
+        SendNOSMessage(3, possDupFlag: true);
+        SendNOSMessage(4, possDupFlag: true);
+        // Now the session processes the Heartbeat/seq=5 from its queue.
+        Assert.That(_session.NextTargetMsgSeqNum, Is.EqualTo(6));
+
+        // But the counterparty still needs to resend the seq=5!
+        // The 5 is a Heartbeat, an admin message, so it's a gapfill.
+        // The gapfill goes to 7, omitting ever sending a 6.
+        QuickFix.FIX42.SequenceReset sr = new(new QuickFix.Fields.NewSeqNo(7));
+        sr.Header.SetField(new QuickFix.Fields.PossDupFlag(true));
+        sr.SetField(new QuickFix.Fields.GapFillFlag(true));
+        SendTheMessage(sr, 5);
+
+        // Even though client already processed the original Heartbeat/seq=5,
+        //   it must not discard the GapFill 5.
+        Assert.That(_session.NextTargetMsgSeqNum, Is.EqualTo(7));
     }
 }
 

--- a/UnitTests/SessionTest.cs
+++ b/UnitTests/SessionTest.cs
@@ -1027,8 +1027,11 @@ public class SessionTest
     }
 
     [Test]
-    public void TestGapFillShouldNotBeIgnoredIfPossDup()
+    public void TestObeyGapFillIfItReplacesAMessageOffTheQueue()
     {
+        // issue #309: If GapFill has the same seqno of a message that was
+        //   processed off the queue, obey it anyway
+
         Assert.That(_session!.IgnorePossDupResendRequests, Is.EqualTo(false));
         _session.RequiresOrigSendingTime = false; // default is true
         Logon();
@@ -1044,6 +1047,7 @@ public class SessionTest
         Assert.That(resendRequest.EndSeqNo.Value, Is.EqualTo(0));
 
         Assert.That(_session.NextTargetMsgSeqNum, Is.EqualTo(3));
+        Assert.That(_session.IsResendRequested);
 
         // Resends
         SendNOSMessage(3, possDupFlag: true);


### PR DESCRIPTION
* resolve #309
* close #784 (because this supersedes it - attn @oclancy )