### PR TITLE
Reduce unnecessary ContainsKey function calls to avoid multiple duplicate key lookups

### DIFF
--- a/QuickFIXn/DataDictionary/DDField.cs
+++ b/QuickFIXn/DataDictionary/DDField.cs
@@ -2,91 +2,90 @@
 using System.Collections.Frozen;
 using System.Collections.Generic;
 
-namespace QuickFix.DataDictionary
+namespace QuickFix.DataDictionary;
+
+public class DDField
 {
-    public class DDField
+    /// <summary>
+    /// Represents field data from a DataDictionary file.
+    /// </summary>
+    /// <param name="tag"></param>
+    /// <param name="name"></param>
+    /// <param name="enums">dictionary of enum=>description values</param>
+    /// <param name="fixFldType"></param>
+    public DDField(int tag, String name, IReadOnlyDictionary<String, String> enums, String fixFldType)
     {
-        /// <summary>
-        /// Represents field data from a DataDictionary file.
-        /// </summary>
-        /// <param name="tag"></param>
-        /// <param name="name"></param>
-        /// <param name="enums">dictionary of enum=>description values</param>
-        /// <param name="fixFldType"></param>
-        public DDField(int tag, String name, IReadOnlyDictionary<String, String> enums, String fixFldType)
+        this.Tag = tag;
+        this.Name = name;
+        this.EnumDict = enums.ToFrozenDictionary();
+        this.FixFldType = fixFldType;
+        this.FieldType = FieldTypeFromFix(this.FixFldType, out bool isMVFWE);
+        this.IsMultipleValueFieldWithEnums = isMVFWE;
+    }
+
+    public int Tag { get; private set; }
+    public String Name { get; private set; }
+
+    public IReadOnlyDictionary<String, String> EnumDict { get; }
+
+    public String FixFldType { get; private set; }
+    public Type FieldType { get; private set; }
+
+    /// <summary>
+    /// true if FIX field has an enum and if its type is one of: {MultipleValueString,MultipleStringValue,MultipleCharValue}
+    /// </summary>
+    public bool IsMultipleValueFieldWithEnums { get; private set; }
+
+    public Boolean HasEnums()
+    {
+        return EnumDict.Count > 0;
+    }
+
+    private Type FieldTypeFromFix(String type, out bool multipleValueFieldWithEnums)
+    {
+        multipleValueFieldWithEnums = false;
+
+        switch (type)
         {
-            this.Tag = tag;
-            this.Name = name;
-            this.EnumDict = enums.ToFrozenDictionary();
-            this.FixFldType = fixFldType;
-            this.FieldType = FieldTypeFromFix(this.FixFldType, out bool isMVFWE);
-            this.IsMultipleValueFieldWithEnums = isMVFWE;
-        }
+            case "STRING": return typeof(Fields.StringField);
+            case "CHAR": return typeof(Fields.CharField);
+            case "PRICE": return typeof(Fields.DecimalField);
+            case "INT": return typeof(Fields.IntField);
+            case "AMT": return typeof(Fields.DecimalField);
+            case "QTY": return typeof(Fields.DecimalField);
+            case "CURRENCY": return typeof(Fields.StringField);
+            case "MULTIPLEVALUESTRING": multipleValueFieldWithEnums = true; return typeof(Fields.StringField);
+            case "MULTIPLESTRINGVALUE": multipleValueFieldWithEnums = true; return typeof(Fields.StringField);
+            case "MULTIPLECHARVALUE": multipleValueFieldWithEnums = true; return typeof(Fields.StringField);
+            case "EXCHANGE": return typeof(Fields.StringField);
+            case "UTCTIMESTAMP": return typeof(Fields.DateTimeField);
+            case "BOOLEAN": return typeof(Fields.BooleanField);
+            case "LOCALMKTDATE": return typeof(Fields.StringField);
+            case "LOCALMKTTIME": return typeof(Fields.StringField);
+            case "DATA": return typeof(Fields.StringField);
+            case "FLOAT": return typeof(Fields.DecimalField);
+            case "PRICEOFFSET": return typeof(Fields.DecimalField);
+            case "MONTHYEAR": return typeof(Fields.StringField);
+            case "DAYOFMONTH": return typeof(Fields.StringField);
+            case "UTCDATE": return typeof(Fields.DateOnlyField);
+            case "UTCDATEONLY": return typeof(Fields.DateOnlyField);
+            case "UTCTIMEONLY": return typeof(Fields.TimeOnlyField);
+            case "NUMINGROUP": return typeof(Fields.IntField);
+            case "PERCENTAGE": return typeof(Fields.DecimalField);
+            case "SEQNUM": return typeof(Fields.ULongField);
+            case "TAGNUM": return typeof(Fields.IntField);
+            case "LENGTH": return typeof(Fields.IntField);
+            case "COUNTRY": return typeof(Fields.StringField);
+            case "TZTIMEONLY": return typeof(Fields.StringField);
+            case "TZTIMESTAMP": return typeof(Fields.StringField);
+            case "XMLDATA": return typeof(Fields.StringField);
+            case "LANGUAGE": return typeof(Fields.StringField);
+            case "XID": return typeof(Fields.StringField);
+            case "XIDREF": return typeof(Fields.StringField);
 
-        public int Tag { get; private set; }
-        public String Name { get; private set; }
-
-        public IReadOnlyDictionary<String, String> EnumDict { get; }
-
-        public String FixFldType { get; private set; }
-        public Type FieldType { get; private set; }
-
-        /// <summary>
-        /// true if FIX field has an enum and if its type is one of: {MultipleValueString,MultipleStringValue,MultipleCharValue}
-        /// </summary>
-        public bool IsMultipleValueFieldWithEnums { get; private set; }
-
-        public Boolean HasEnums()
-        {
-            return EnumDict.Count > 0;
-        }
-
-        private Type FieldTypeFromFix(String type, out bool multipleValueFieldWithEnums)
-        {
-            multipleValueFieldWithEnums = false;
-
-            switch (type)
-            {
-                case "STRING": return typeof(Fields.StringField);
-                case "CHAR": return typeof(Fields.CharField);
-                case "PRICE": return typeof(Fields.DecimalField);
-                case "INT": return typeof(Fields.IntField);
-                case "AMT": return typeof(Fields.DecimalField);
-                case "QTY": return typeof(Fields.DecimalField);
-                case "CURRENCY": return typeof(Fields.StringField);
-                case "MULTIPLEVALUESTRING": multipleValueFieldWithEnums = true; return typeof(Fields.StringField);
-                case "MULTIPLESTRINGVALUE": multipleValueFieldWithEnums = true; return typeof(Fields.StringField);
-                case "MULTIPLECHARVALUE": multipleValueFieldWithEnums = true; return typeof(Fields.StringField);
-                case "EXCHANGE": return typeof(Fields.StringField);
-                case "UTCTIMESTAMP": return typeof(Fields.DateTimeField);
-                case "BOOLEAN": return typeof(Fields.BooleanField);
-                case "LOCALMKTDATE": return typeof(Fields.StringField);
-                case "LOCALMKTTIME": return typeof(Fields.StringField);
-                case "DATA": return typeof(Fields.StringField);
-                case "FLOAT": return typeof(Fields.DecimalField);
-                case "PRICEOFFSET": return typeof(Fields.DecimalField);
-                case "MONTHYEAR": return typeof(Fields.StringField);
-                case "DAYOFMONTH": return typeof(Fields.StringField);
-                case "UTCDATE": return typeof(Fields.DateOnlyField);
-                case "UTCDATEONLY": return typeof(Fields.DateOnlyField);
-                case "UTCTIMEONLY": return typeof(Fields.TimeOnlyField);
-                case "NUMINGROUP": return typeof(Fields.IntField);
-                case "PERCENTAGE": return typeof(Fields.DecimalField);
-                case "SEQNUM": return typeof(Fields.ULongField);
-                case "TAGNUM": return typeof(Fields.IntField);
-                case "LENGTH": return typeof(Fields.IntField);
-                case "COUNTRY": return typeof(Fields.StringField);
-                case "TZTIMEONLY": return typeof(Fields.StringField);
-                case "TZTIMESTAMP": return typeof(Fields.StringField);
-                case "XMLDATA": return typeof(Fields.StringField);
-                case "LANGUAGE": return typeof(Fields.StringField);
-                case "XID": return typeof(Fields.StringField);
-                case "XIDREF": return typeof(Fields.StringField);
-
-                case "TIME": return typeof(Fields.DateTimeField);
-                case "DATE": return typeof(Fields.StringField);
-                default: throw new DictionaryParseException("invalid type: " + type);
-            }
+            case "TIME": return typeof(Fields.DateTimeField);
+            case "DATE": return typeof(Fields.StringField);
+            default: throw new DictionaryParseException("invalid type: " + type);
         }
     }
 }

--- a/QuickFIXn/DataDictionary/DDField.cs
+++ b/QuickFIXn/DataDictionary/DDField.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 
 namespace QuickFix.DataDictionary
@@ -12,11 +13,11 @@ namespace QuickFix.DataDictionary
         /// <param name="name"></param>
         /// <param name="enums">dictionary of enum=>description values</param>
         /// <param name="fixFldType"></param>
-        public DDField(int tag, String name, Dictionary<String, String> enums, String fixFldType)
+        public DDField(int tag, String name, IReadOnlyDictionary<String, String> enums, String fixFldType)
         {
             this.Tag = tag;
             this.Name = name;
-            this.EnumDict = enums;
+            this.EnumDict = enums.ToFrozenDictionary();
             this.FixFldType = fixFldType;
             this.FieldType = FieldTypeFromFix(this.FixFldType, out bool isMVFWE);
             this.IsMultipleValueFieldWithEnums = isMVFWE;
@@ -24,7 +25,9 @@ namespace QuickFix.DataDictionary
 
         public int Tag { get; private set; }
         public String Name { get; private set; }
-        public Dictionary<String, String> EnumDict { get; private set; }
+
+        public IReadOnlyDictionary<String, String> EnumDict { get; }
+
         public String FixFldType { get; private set; }
         public Type FieldType { get; private set; }
 

--- a/QuickFIXn/DataDictionary/DataDictionary.cs
+++ b/QuickFIXn/DataDictionary/DataDictionary.cs
@@ -5,692 +5,691 @@ using System.Linq;
 using System.Xml;
 using QuickFix.Fields;
 
-namespace QuickFix.DataDictionary
+namespace QuickFix.DataDictionary;
+
+/// <summary>
+/// Provide the message metadata for various versions of FIX
+/// </summary>
+public class DataDictionary
 {
-    /// <summary>
-    /// Provide the message metadata for various versions of FIX
-    /// </summary>
-    public class DataDictionary
+    public string? MajorVersion { get; private set; }
+    public string? MinorVersion { get; private set; }
+    public string? Version { get; private set; }
+
+    public readonly Dictionary<string, DDMap> Messages = new();
+    public readonly Dictionary<string, DDField> FieldsByName = new();
+
+    // TODO: Audit these Dict usages for unprotected [] lookups.
+    public readonly Dictionary<int, DDField> FieldsByTag = new();
+    private readonly Dictionary<string, XmlNode> _componentsByName = new();
+
+    public bool CheckFieldsOutOfOrder { get; set; }
+    public bool CheckFieldsHaveValues { get; set; }
+    public bool CheckUserDefinedFields { get; set; }
+    public bool AllowUnknownEnumValues { get; set; }
+    public bool AllowUnknownMessageFields { get; set; }
+
+    public DDMap Header = new();
+    public DDMap Trailer = new();
+
+    public DataDictionary()
     {
-        public string? MajorVersion { get; private set; }
-        public string? MinorVersion { get; private set; }
-        public string? Version { get; private set; }
+        CheckFieldsHaveValues = true;
+        CheckFieldsOutOfOrder = true;
+        CheckUserDefinedFields = true;
+        AllowUnknownEnumValues = false;
+        AllowUnknownMessageFields = false;
+    }
 
-        public readonly Dictionary<string, DDMap> Messages = new();
-        public readonly Dictionary<string, DDField> FieldsByName = new();
+    /// <summary>
+    /// Initialize a data dictionary from a file path
+    /// </summary>
+    /// <param name="path"></param>
+    public DataDictionary(string path)
+        : this()
+    {
+        Load(path);
+    }
 
-        // TODO: Audit these Dict usages for unprotected [] lookups.
-        public readonly Dictionary<int, DDField> FieldsByTag = new();
-        private readonly Dictionary<string, XmlNode> _componentsByName = new();
+    /// <summary>
+    /// Initialize a data dictionary from a stream
+    /// </summary>
+    /// <param name="stream"></param>
+    public DataDictionary(Stream stream)
+        : this()
+    {
+        Load(stream);
+    }
 
-        public bool CheckFieldsOutOfOrder { get; set; }
-        public bool CheckFieldsHaveValues { get; set; }
-        public bool CheckUserDefinedFields { get; set; }
-        public bool AllowUnknownEnumValues { get; set; }
-        public bool AllowUnknownMessageFields { get; set; }
+    /// <summary>
+    /// Copy a data dictionary
+    /// </summary>
+    /// <param name="src">the source dictionary that will be copied into this dictionary</param>
+    public DataDictionary(DataDictionary src)
+        : this()
+    {
+        Messages = src.Messages;
+        FieldsByName = src.FieldsByName;
+        FieldsByTag = src.FieldsByTag;
+        MajorVersion = src.MajorVersion;
+        MinorVersion = src.MinorVersion;
+        Version = src.Version;
+        CheckFieldsHaveValues = src.CheckFieldsHaveValues;
+        CheckFieldsOutOfOrder = src.CheckFieldsOutOfOrder;
+        CheckUserDefinedFields = src.CheckUserDefinedFields;
+        Header = src.Header;
+        Trailer = src.Trailer;
+    }
 
-        public DDMap Header = new();
-        public DDMap Trailer = new();
-
-        public DataDictionary()
-        {
-            CheckFieldsHaveValues = true;
-            CheckFieldsOutOfOrder = true;
-            CheckUserDefinedFields = true;
-            AllowUnknownEnumValues = false;
-            AllowUnknownMessageFields = false;
+    public static void Validate(Message message, DataDictionary? transportDataDict, DataDictionary appDataDict, string beginString, string msgType)
+    {
+        if (transportDataDict?.Version is not null && !transportDataDict.Version.Equals(beginString)) {
+            throw new UnsupportedVersion(beginString);
         }
 
-        /// <summary>
-        /// Initialize a data dictionary from a file path
-        /// </summary>
-        /// <param name="path"></param>
-        public DataDictionary(string path)
-            : this()
-        {
-            Load(path);
+        // TODO: this check is not well-designed. The ex is only triggered if Message.FromString sets an invalid state.
+        // (no other Message function can set this state!)
+        // Furthermore, this is the only time we throw a TagOutOfOrder exception.
+        // It's not clear to me that this logic is useful.
+        if(transportDataDict?.CheckFieldsOutOfOrder == true || appDataDict.CheckFieldsOutOfOrder) {
+            if (!message.HasValidStructure(out var field))
+                throw new TagOutOfOrder(field);
         }
 
-        /// <summary>
-        /// Initialize a data dictionary from a stream
-        /// </summary>
-        /// <param name="stream"></param>
-        public DataDictionary(Stream stream)
-            : this()
+        if(appDataDict.Version is not null)
         {
-            Load(stream);
+            appDataDict.CheckMsgType(msgType);
+            appDataDict.CheckHasRequired(message, msgType);
         }
 
-        /// <summary>
-        /// Copy a data dictionary
-        /// </summary>
-        /// <param name="src">the source dictionary that will be copied into this dictionary</param>
-        public DataDictionary(DataDictionary src)
-            : this()
+        if (transportDataDict is not null)
         {
-            Messages = src.Messages;
-            FieldsByName = src.FieldsByName;
-            FieldsByTag = src.FieldsByTag;
-            MajorVersion = src.MajorVersion;
-            MinorVersion = src.MinorVersion;
-            Version = src.Version;
-            CheckFieldsHaveValues = src.CheckFieldsHaveValues;
-            CheckFieldsOutOfOrder = src.CheckFieldsOutOfOrder;
-            CheckUserDefinedFields = src.CheckUserDefinedFields;
-            Header = src.Header;
-            Trailer = src.Trailer;
+            transportDataDict.Iterate(message.Header, msgType);
+            transportDataDict.Iterate(message.Trailer, msgType);
         }
 
-        public static void Validate(Message message, DataDictionary? transportDataDict, DataDictionary appDataDict, string beginString, string msgType)
+        appDataDict.Iterate(message, msgType);
+    }
+
+    public static void CheckHasNoRepeatedTags(FieldMap map)
+    {
+        if (map.RepeatedTags.Count > 0)
+            throw new RepeatedTag(map.RepeatedTags[0].Tag);
+    }
+
+    public DDMap? GetMapForMessage(string msgType) => Messages.TryGetValue(msgType, out var message) ? message : null;
+
+    /// <summary>
+    /// If DD defines this message type, returns with no side effect; else throws InvalidMessageType.
+    /// </summary>
+    /// <param name="msgType"></param>
+    /// <exception cref="InvalidMessageType"></exception>
+    public void CheckMsgType(string msgType)
+    {
+        if (Messages.ContainsKey(msgType))
+            return;
+        if (FieldsByTag[35].EnumDict.ContainsKey(msgType))
+            return;
+        throw new InvalidMessageType();
+
+    }
+
+    public void CheckHasRequired(Message message, string msgType)
+    {
+        foreach (int field in Header.ReqFields)
         {
-            if (transportDataDict?.Version is not null && !transportDataDict.Version.Equals(beginString)) {
-                throw new UnsupportedVersion(beginString);
-            }
+            if (!message.Header.IsSetField(field))
+                throw new RequiredTagMissing(field);
+        }
 
-            // TODO: this check is not well-designed. The ex is only triggered if Message.FromString sets an invalid state.
-            // (no other Message function can set this state!)
-            // Furthermore, this is the only time we throw a TagOutOfOrder exception.
-            // It's not clear to me that this logic is useful.
-            if(transportDataDict?.CheckFieldsOutOfOrder == true || appDataDict.CheckFieldsOutOfOrder) {
-                if (!message.HasValidStructure(out var field))
-                    throw new TagOutOfOrder(field);
-            }
+        foreach (int field in Trailer.ReqFields)
+        {
+            if (!message.Trailer.IsSetField(field))
+                throw new RequiredTagMissing(field);
+        }
 
-            if(appDataDict.Version is not null)
+        if (Messages.TryGetValue(msgType, out DDMap? ddmap))
+        {
+            foreach (int field in ddmap.ReqFields)
             {
-                appDataDict.CheckMsgType(msgType);
-                appDataDict.CheckHasRequired(message, msgType);
-            }
-
-            if (transportDataDict is not null)
-            {
-                transportDataDict.Iterate(message.Header, msgType);
-                transportDataDict.Iterate(message.Trailer, msgType);
-            }
-
-            appDataDict.Iterate(message, msgType);
-        }
-
-        public static void CheckHasNoRepeatedTags(FieldMap map)
-        {
-            if (map.RepeatedTags.Count > 0)
-                throw new RepeatedTag(map.RepeatedTags[0].Tag);
-        }
-
-        public DDMap? GetMapForMessage(string msgType) => Messages.TryGetValue(msgType, out var message) ? message : null;
-
-        /// <summary>
-        /// If DD defines this message type, returns with no side effect; else throws InvalidMessageType.
-        /// </summary>
-        /// <param name="msgType"></param>
-        /// <exception cref="InvalidMessageType"></exception>
-        public void CheckMsgType(string msgType)
-        {
-            if (Messages.ContainsKey(msgType))
-                return;
-            if (FieldsByTag[35].EnumDict.ContainsKey(msgType))
-                return;
-            throw new InvalidMessageType();
-
-        }
-
-        public void CheckHasRequired(Message message, string msgType)
-        {
-            foreach (int field in Header.ReqFields)
-            {
-                if (!message.Header.IsSetField(field))
+                if (!message.IsSetField(field))
                     throw new RequiredTagMissing(field);
             }
-
-            foreach (int field in Trailer.ReqFields)
-            {
-                if (!message.Trailer.IsSetField(field))
-                    throw new RequiredTagMissing(field);
-            }
-
-            if (Messages.TryGetValue(msgType, out DDMap? ddmap))
-            {
-                foreach (int field in ddmap.ReqFields)
-                {
-                    if (!message.IsSetField(field))
-                        throw new RequiredTagMissing(field);
-                }
-            }
-
-            /* FIXME TODO group stuff
-            foreach (DDGroup grp in _messages[msgType].Groups.Values)
-              if (_messages[msgType].ReqFields.Contains(grp.Field))
-                ReqFieldsSetInGroups(grp, fields);
-            */
         }
 
-        public void Iterate(FieldMap map, string msgType)
+        /* FIXME TODO group stuff
+        foreach (DDGroup grp in _messages[msgType].Groups.Values)
+          if (_messages[msgType].ReqFields.Contains(grp.Field))
+            ReqFieldsSetInGroups(grp, fields);
+        */
+    }
+
+    public void Iterate(FieldMap map, string msgType)
+    {
+        CheckHasNoRepeatedTags(map);
+
+        // check non-group fields
+        int lastField = 0;
+        foreach (KeyValuePair<int, IField> kvp in map)
         {
-            CheckHasNoRepeatedTags(map);
+            IField field = kvp.Value;
+            if (lastField != 0 && field.Tag == lastField)
+                throw new RepeatedTag(lastField);
+            CheckHasValue(field);
 
-            // check non-group fields
-            int lastField = 0;
-            foreach (KeyValuePair<int, IField> kvp in map)
+            if (!string.IsNullOrEmpty(this.Version))
             {
-                IField field = kvp.Value;
-                if (lastField != 0 && field.Tag == lastField)
-                    throw new RepeatedTag(lastField);
-                CheckHasValue(field);
+                CheckValidFormat(field);
 
-                if (!string.IsNullOrEmpty(this.Version))
+                if (ShouldCheckTag(field))
                 {
-                    CheckValidFormat(field);
-
-                    if (ShouldCheckTag(field))
+                    CheckValidTagNumber(field.Tag);
+                    CheckValue(field);
+                    if (!Message.IsHeaderField(field.Tag, this) && !Message.IsTrailerField(field.Tag, this))
                     {
-                        CheckValidTagNumber(field.Tag);
-                        CheckValue(field);
-                        if (!Message.IsHeaderField(field.Tag, this) && !Message.IsTrailerField(field.Tag, this))
-                        {
-                            CheckIsInMessage(field, msgType);
-                            CheckGroupCount(field, map, msgType);
-                        }
-                    }
-                }
-                lastField = field.Tag;
-            }
-
-            // check contents of each group
-            List<int> groupTagList = map.GetGroupTags();
-            if (groupTagList.Count > 0) {
-                if (!Messages.TryGetValue(msgType, out DDMap? msgDdMap))
-                {
-                    // This shouldn't be possible
-                    throw new MessageParseError(
-                        $"Cannot locate msgType='{msgType}' message groups in DataDictionary (Please report this error)");
-                }
-
-                foreach (int groupTag in groupTagList)
-                {
-                    for (int i = 1; i <= map.GroupCount(groupTag); i++)
-                    {
-                        Group g = map.GetGroup(i, groupTag);
-                        DDGrp ddg = msgDdMap.GetGroup(groupTag);
-                        IterateGroup(g, ddg, msgType);
+                        CheckIsInMessage(field, msgType);
+                        CheckGroupCount(field, map, msgType);
                     }
                 }
             }
+            lastField = field.Tag;
         }
 
-        public void IterateGroup(Group group, DDGrp ddgroup, string msgType)
-        {
-            CheckHasNoRepeatedTags(group);
-
-            int lastField = 0;
-            foreach (KeyValuePair<int, IField> kvp in group)
+        // check contents of each group
+        List<int> groupTagList = map.GetGroupTags();
+        if (groupTagList.Count > 0) {
+            if (!Messages.TryGetValue(msgType, out DDMap? msgDdMap))
             {
-                IField field = kvp.Value;
-                if (lastField != 0 && field.Tag == lastField)
-                    throw new RepeatedTag(lastField);
-                CheckHasValue(field);
-
-                if (!string.IsNullOrEmpty(this.Version))
-                {
-                    CheckValidFormat(field);
-
-                    if (ShouldCheckTag(field))
-                    {
-                        CheckValidTagNumber(field.Tag);
-                        CheckValue(field);
-
-                        CheckIsInGroup(field, ddgroup, msgType);
-                        CheckGroupCount(field, group, msgType);
-                    }
-                }
-                lastField = field.Tag;
+                // This shouldn't be possible
+                throw new MessageParseError(
+                    $"Cannot locate msgType='{msgType}' message groups in DataDictionary (Please report this error)");
             }
 
-            // check contents of each nested group
-            foreach (int groupTag in group.GetGroupTags())
+            foreach (int groupTag in groupTagList)
             {
-                for (int i = 1; i <= group.GroupCount(groupTag); i++)
+                for (int i = 1; i <= map.GroupCount(groupTag); i++)
                 {
-                    Group g = group.GetGroup(i, groupTag);
-                    DDGrp ddg = ddgroup.GetGroup(groupTag);
+                    Group g = map.GetGroup(i, groupTag);
+                    DDGrp ddg = msgDdMap.GetGroup(groupTag);
                     IterateGroup(g, ddg, msgType);
                 }
             }
         }
+    }
 
-        /// <summary>
-        /// Check that the field has a value (i.e. that there's something after the equal sign);
-        /// does nothing if configuration has "ValidateFieldsHaveValues=N".
-        /// </summary>
-        /// <param name="field"></param>
-        public void CheckHasValue(IField field)
-        {
-            if (this.CheckFieldsHaveValues && (field.ToString().Length < 1))
-                throw new NoTagValue(field.Tag);
-        }
+    public void IterateGroup(Group group, DDGrp ddgroup, string msgType)
+    {
+        CheckHasNoRepeatedTags(group);
 
-        /// <summary>
-        /// Check that the field contents match the DataDictionary-defined type
-        /// </summary>
-        /// <param name="field"></param>
-        public void CheckValidFormat(IField field)
+        int lastField = 0;
+        foreach (KeyValuePair<int, IField> kvp in group)
         {
-            try
+            IField field = kvp.Value;
+            if (lastField != 0 && field.Tag == lastField)
+                throw new RepeatedTag(lastField);
+            CheckHasValue(field);
+
+            if (!string.IsNullOrEmpty(this.Version))
             {
-                Type type;
-                if (!TryGetFieldType(field.Tag, out type))
-                    return;
-                if (type == typeof(StringField))
-                    return;
+                CheckValidFormat(field);
 
-                if (false == CheckFieldsHaveValues && field.ToString().Length < 1)
+                if (ShouldCheckTag(field))
                 {
-                    // If ValidateFieldsHaveValues=N, don't check empty non-string fields
-                    // because engine should not decide how to convert empty to e.g. float or datetime.
-                    // (User code may see IncorrectDataFormat exceptions
-                    //  when attempting to extract fields in not-string formats.)
-                    return;
+                    CheckValidTagNumber(field.Tag);
+                    CheckValue(field);
+
+                    CheckIsInGroup(field, ddgroup, msgType);
+                    CheckGroupCount(field, group, msgType);
                 }
-
-                if (type == typeof(CharField))
-                    Fields.Converters.CharConverter.Convert(field.ToString());
-                else if (type == typeof(IntField))
-                    Fields.Converters.IntConverter.Convert(field.ToString());
-                else if (type == typeof(DecimalField))
-                    Fields.Converters.DecimalConverter.Convert(field.ToString());
-                else if (type == typeof(BooleanField))
-                    Fields.Converters.BoolConverter.Convert(field.ToString());
-
-                else if (type == typeof(DateTimeField))
-                    Fields.Converters.DateTimeConverter.ParseToDateTime(field.ToString());
-                else if (type == typeof(DateOnlyField))
-                    Fields.Converters.DateTimeConverter.ParseToDateOnly(field.ToString());
-                else if (type == typeof(TimeOnlyField))
-                    Fields.Converters.DateTimeConverter.ParseToTimeOnly(field.ToString());
             }
-            catch (FieldConvertError e)
-            {
-                throw new IncorrectDataFormat(field.Tag, e);
-            }
+            lastField = field.Tag;
         }
 
-        public bool TryGetFieldType(int tag, out Type result)
+        // check contents of each nested group
+        foreach (int groupTag in group.GetGroupTags())
         {
-            if (FieldsByTag.TryGetValue(tag, out DDField? value))
+            for (int i = 1; i <= group.GroupCount(groupTag); i++)
             {
-                result = value.FieldType;
-                return true;
+                Group g = group.GetGroup(i, groupTag);
+                DDGrp ddg = ddgroup.GetGroup(groupTag);
+                IterateGroup(g, ddg, msgType);
             }
-            result = typeof(object); // doesn't matter
-            return false;
         }
+    }
 
-        /// <summary>
-        /// Check that this tag is defined in the DataDictionary
-        /// </summary>
-        /// <param name="tag"></param>
-        public void CheckValidTagNumber(int tag)
+    /// <summary>
+    /// Check that the field has a value (i.e. that there's something after the equal sign);
+    /// does nothing if configuration has "ValidateFieldsHaveValues=N".
+    /// </summary>
+    /// <param name="field"></param>
+    public void CheckHasValue(IField field)
+    {
+        if (this.CheckFieldsHaveValues && (field.ToString().Length < 1))
+            throw new NoTagValue(field.Tag);
+    }
+
+    /// <summary>
+    /// Check that the field contents match the DataDictionary-defined type
+    /// </summary>
+    /// <param name="field"></param>
+    public void CheckValidFormat(IField field)
+    {
+        try
         {
-            if (AllowUnknownMessageFields)
+            Type type;
+            if (!TryGetFieldType(field.Tag, out type))
                 return;
-            if (!FieldsByTag.ContainsKey(tag))
-                throw new InvalidTagNumber(tag);
-        }
-
-        /// <summary>
-        /// If field is an enum or multiple value field, make sure the value(s) is/are valid.
-        /// (If field is unknown, ignore it.  It's not this function's job to test that.)
-        /// </summary>
-        /// <param name="field"></param>
-        public void CheckValue(IField field)
-        {
-            if (AllowUnknownEnumValues)
+            if (type == typeof(StringField))
                 return;
-            if (FieldsByTag.TryGetValue(field.Tag, out var fld))
-            {
-                if (fld.HasEnums())
-                {
-                    if (fld.IsMultipleValueFieldWithEnums) {
-                        string[] splitted = field.ToString().Split(' ');
 
-                        if (splitted.Any(value => !fld.EnumDict.ContainsKey(value))) {
-                            throw new IncorrectTagValue(field.Tag);
-                        }
-                    }
-                    else if (!fld.EnumDict.ContainsKey(field.ToString()))
+            if (false == CheckFieldsHaveValues && field.ToString().Length < 1)
+            {
+                // If ValidateFieldsHaveValues=N, don't check empty non-string fields
+                // because engine should not decide how to convert empty to e.g. float or datetime.
+                // (User code may see IncorrectDataFormat exceptions
+                //  when attempting to extract fields in not-string formats.)
+                return;
+            }
+
+            if (type == typeof(CharField))
+                Fields.Converters.CharConverter.Convert(field.ToString());
+            else if (type == typeof(IntField))
+                Fields.Converters.IntConverter.Convert(field.ToString());
+            else if (type == typeof(DecimalField))
+                Fields.Converters.DecimalConverter.Convert(field.ToString());
+            else if (type == typeof(BooleanField))
+                Fields.Converters.BoolConverter.Convert(field.ToString());
+
+            else if (type == typeof(DateTimeField))
+                Fields.Converters.DateTimeConverter.ParseToDateTime(field.ToString());
+            else if (type == typeof(DateOnlyField))
+                Fields.Converters.DateTimeConverter.ParseToDateOnly(field.ToString());
+            else if (type == typeof(TimeOnlyField))
+                Fields.Converters.DateTimeConverter.ParseToTimeOnly(field.ToString());
+        }
+        catch (FieldConvertError e)
+        {
+            throw new IncorrectDataFormat(field.Tag, e);
+        }
+    }
+
+    public bool TryGetFieldType(int tag, out Type result)
+    {
+        if (FieldsByTag.TryGetValue(tag, out DDField? value))
+        {
+            result = value.FieldType;
+            return true;
+        }
+        result = typeof(object); // doesn't matter
+        return false;
+    }
+
+    /// <summary>
+    /// Check that this tag is defined in the DataDictionary
+    /// </summary>
+    /// <param name="tag"></param>
+    public void CheckValidTagNumber(int tag)
+    {
+        if (AllowUnknownMessageFields)
+            return;
+        if (!FieldsByTag.ContainsKey(tag))
+            throw new InvalidTagNumber(tag);
+    }
+
+    /// <summary>
+    /// If field is an enum or multiple value field, make sure the value(s) is/are valid.
+    /// (If field is unknown, ignore it.  It's not this function's job to test that.)
+    /// </summary>
+    /// <param name="field"></param>
+    public void CheckValue(IField field)
+    {
+        if (AllowUnknownEnumValues)
+            return;
+        if (FieldsByTag.TryGetValue(field.Tag, out var fld))
+        {
+            if (fld.HasEnums())
+            {
+                if (fld.IsMultipleValueFieldWithEnums) {
+                    string[] splitted = field.ToString().Split(' ');
+
+                    if (splitted.Any(value => !fld.EnumDict.ContainsKey(value))) {
                         throw new IncorrectTagValue(field.Tag);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Check that <paramref name="field"/> is supposed to be in the message type indicated by <paramref name="msgType"/>.
-        /// </summary>
-        /// <param name="field"></param>
-        /// <param name="msgType"></param>
-        public void CheckIsInMessage(IField field, string msgType)
-        {
-            if (AllowUnknownMessageFields)
-                return;
-            if (Messages.TryGetValue(msgType, out DDMap? dd))
-                if (dd.Fields.ContainsKey(field.Tag))
-                    return;
-            throw new TagNotDefinedForMessage(field.Tag, msgType);
-        }
-
-        /// <summary>
-        /// Check that <paramref name="field"/> is supposed to be in the group defined in <paramref name="ddgrp"/>
-        /// </summary>
-        /// <param name="field"></param>
-        /// <param name="ddgrp"></param>
-        /// <param name="msgType">Message type that contains the group (included in exceptions thrown on failure)</param>
-        public static void CheckIsInGroup(IField field, DDGrp ddgrp, string msgType)
-        {
-            if (ddgrp.IsField(field.Tag))
-                return;
-            throw new TagNotDefinedForMessage(field.Tag, msgType);
-        }
-
-        /// <summary>
-        /// If <paramref name="field"/> is a group-counter for <paramref name="msgType"/>, check that it is accurate, else do nothing.
-        /// </summary>
-        /// <param name="field">a group's counter field</param>
-        /// <param name="map">the FieldMap that contains the group being checked</param>
-        /// <param name="msgType">msg type of message that is/contains <paramref name="map"/></param>
-        public void CheckGroupCount(IField field, FieldMap map, string msgType)
-        {
-            if (IsGroup(msgType, field.Tag))
-            {
-                if (map.GetInt(field.Tag) != map.GroupCount(field.Tag))
-                {
-                    throw new RepeatingGroupCountMismatch(field.Tag);
-                }
-            }
-        }
-
-        public bool IsGroup(string msgType, int tag)
-        {
-            return Messages.TryGetValue(msgType, out DDMap? dd) && dd.IsGroup(tag);
-        }
-
-        /// <summary>
-        /// Determine if this is a field that should be checked for validity according to config
-        /// </summary>
-        /// <param name="field"></param>
-        /// <returns></returns>
-        public bool ShouldCheckTag(IField field)
-        {
-            return this.CheckUserDefinedFields || field.Tag < Fields.Limits.USER_MIN;
-        }
-
-        public bool IsHeaderField(int tag)
-        {
-            return Header.IsField(tag);
-        }
-
-        public bool IsTrailerField(int tag)
-        {
-            return Trailer.IsField(tag);
-        }
-
-        public void Load(string path)
-        {
-            var stream = new FileStream(path, FileMode.Open, FileAccess.Read);
-            Load(stream);
-        }
-
-        public void Load(Stream stream)
-        {
-            XmlReaderSettings readerSettings = new()
-            {
-                IgnoreComments = true
-            };
-
-            using (XmlReader reader = XmlReader.Create(stream, readerSettings)) {
-                XmlDocument rootDoc = new();
-                rootDoc.Load(reader);
-                SetVersionInfo(rootDoc);
-                ParseFields(rootDoc);
-                CacheComponents(rootDoc);
-                ParseMessages(rootDoc);
-                ParseHeader(rootDoc);
-                ParseTrailer(rootDoc);
-            }
-        }
-
-        public bool FieldHasValue(int tag, string val)
-        {
-            return FieldsByTag[tag].EnumDict.ContainsKey(val);
-        }
-
-        private void SetVersionInfo(XmlDocument doc)
-        {
-            XmlNode? majorVerNode = doc.SelectSingleNode("/fix/@major");
-            XmlNode? minorVerNode = doc.SelectSingleNode("/fix/@minor");
-
-            if (majorVerNode is null || minorVerNode is null) {
-                throw new DictionaryParseException("Failed to find attributes 'major' and 'minor' in <fix> tag");
-            }
-
-            MajorVersion = majorVerNode.Value;
-            MinorVersion = minorVerNode.Value;
-            XmlNode? node = doc.SelectSingleNode("/fix/@type");
-
-            string typeAtt = node?.Value ?? "FIX"; // att is omitted in non-FIXT DDs
-
-            if (!typeAtt.Equals("FIX") && !typeAtt.Equals("FIXT"))
-                throw new DictionaryParseException("<fix> 'type' attribute must be FIX or FIXT (assumes FIX if not present)");
-            Version = $"{typeAtt}.{MajorVersion}.{MinorVersion}";
-        }
-
-        private void ParseFields(XmlDocument doc)
-        {
-            XmlNodeList? nodeList = doc.SelectNodes("//fields/field");
-            if (nodeList is null)
-                throw new DictionaryParseException("No <fields> tag in dictionary");
-            foreach (XmlNode fldEl in nodeList)
-            {
-                DDField fld = NewField(fldEl);
-                FieldsByTag[fld.Tag] = fld;
-                FieldsByName[fld.Name] = fld;
-            }
-        }
-
-        private void CacheComponents(XmlDocument doc)
-        {
-            XmlNodeList? nodeList = doc.SelectNodes("//components/component");
-            if(nodeList is null)
-                throw new DictionaryParseException("No <components> tag in dictionary");
-            foreach (XmlNode compEl in nodeList)
-            {
-                XmlAttribute? nameAtt = compEl.Attributes?["name"];
-                if (nameAtt != null)
-                    _componentsByName[nameAtt.Value] = compEl;
-            }
-        }
-
-        private DDField NewField(XmlNode fldEl)
-        {
-            XmlAttribute? tagAtt = fldEl.Attributes?["number"];
-            XmlAttribute? nameAtt = fldEl.Attributes?["name"];
-            XmlAttribute? typeAtt = fldEl.Attributes?["type"];
-
-            if (tagAtt is null)
-                throw new DictionaryParseException("A <field> is missing its 'number' attribute");
-            string tagstr = tagAtt.Value;
-
-            if(nameAtt is null)
-                throw new DictionaryParseException($"<field number='{tagstr}'> is missing its 'name' attribute");
-            if(typeAtt is null)
-                throw new DictionaryParseException($"<field number='{tagstr}'> is missing its 'type' attribute");
-
-            string name = nameAtt.Value;
-            string fldType = typeAtt.Value;
-
-            int tag = QuickFix.Fields.Converters.IntConverter.Convert(tagstr);
-            Dictionary<string, string> enums = new Dictionary<string, string>();
-            if (fldEl.HasChildNodes)
-            {
-                XmlNodeList? enumNodeList = fldEl.SelectNodes(".//value");
-                if (enumNodeList is not null)
-                {
-                    foreach (XmlNode enumEl in enumNodeList)
-                    {
-                        string description = string.Empty;
-                        if (enumEl.Attributes?["description"] is not null)
-                            description = enumEl.Attributes["description"]!.Value;
-
-                        XmlAttribute? enumAtt = enumEl.Attributes?["enum"];
-                        if (enumAtt is null)
-                            throw new DictionaryParseException(
-                                $"Field {tagstr} has an <value> that is missing its 'enum' attribute");
-                        enums[enumAtt.Value] = description;
                     }
                 }
+                else if (!fld.EnumDict.ContainsKey(field.ToString()))
+                    throw new IncorrectTagValue(field.Tag);
             }
-            return new DDField(tag, name, enums, fldType);
         }
+    }
 
-        private void ParseMessages(XmlDocument doc)
+    /// <summary>
+    /// Check that <paramref name="field"/> is supposed to be in the message type indicated by <paramref name="msgType"/>.
+    /// </summary>
+    /// <param name="field"></param>
+    /// <param name="msgType"></param>
+    public void CheckIsInMessage(IField field, string msgType)
+    {
+        if (AllowUnknownMessageFields)
+            return;
+        if (Messages.TryGetValue(msgType, out DDMap? dd))
+            if (dd.Fields.ContainsKey(field.Tag))
+                return;
+        throw new TagNotDefinedForMessage(field.Tag, msgType);
+    }
+
+    /// <summary>
+    /// Check that <paramref name="field"/> is supposed to be in the group defined in <paramref name="ddgrp"/>
+    /// </summary>
+    /// <param name="field"></param>
+    /// <param name="ddgrp"></param>
+    /// <param name="msgType">Message type that contains the group (included in exceptions thrown on failure)</param>
+    public static void CheckIsInGroup(IField field, DDGrp ddgrp, string msgType)
+    {
+        if (ddgrp.IsField(field.Tag))
+            return;
+        throw new TagNotDefinedForMessage(field.Tag, msgType);
+    }
+
+    /// <summary>
+    /// If <paramref name="field"/> is a group-counter for <paramref name="msgType"/>, check that it is accurate, else do nothing.
+    /// </summary>
+    /// <param name="field">a group's counter field</param>
+    /// <param name="map">the FieldMap that contains the group being checked</param>
+    /// <param name="msgType">msg type of message that is/contains <paramref name="map"/></param>
+    public void CheckGroupCount(IField field, FieldMap map, string msgType)
+    {
+        if (IsGroup(msgType, field.Tag))
         {
-            XmlNodeList? nodeList = doc.SelectNodes("//messages/message");
-            if (nodeList is null)
-                throw new DictionaryParseException("No <messages> tag in dictionary");
-            foreach (XmlNode msgEl in nodeList)
+            if (map.GetInt(field.Tag) != map.GroupCount(field.Tag))
             {
-                DDMap msg = new DDMap();
-                ParseMsgNode(msgEl, msg);
-                string? msgtype = msgEl.Attributes?["msgtype"]?.Value;
-                if (msgtype is null)
-                    throw new DictionaryParseException("A <message> is missing its 'msgtype' attribute");
-                Messages.Add(msgtype, msg);
+                throw new RepeatingGroupCountMismatch(field.Tag);
             }
         }
+    }
 
-        private void ParseHeader(XmlDocument doc)
+    public bool IsGroup(string msgType, int tag)
+    {
+        return Messages.TryGetValue(msgType, out DDMap? dd) && dd.IsGroup(tag);
+    }
+
+    /// <summary>
+    /// Determine if this is a field that should be checked for validity according to config
+    /// </summary>
+    /// <param name="field"></param>
+    /// <returns></returns>
+    public bool ShouldCheckTag(IField field)
+    {
+        return this.CheckUserDefinedFields || field.Tag < Fields.Limits.USER_MIN;
+    }
+
+    public bool IsHeaderField(int tag)
+    {
+        return Header.IsField(tag);
+    }
+
+    public bool IsTrailerField(int tag)
+    {
+        return Trailer.IsField(tag);
+    }
+
+    public void Load(string path)
+    {
+        var stream = new FileStream(path, FileMode.Open, FileAccess.Read);
+        Load(stream);
+    }
+
+    public void Load(Stream stream)
+    {
+        XmlReaderSettings readerSettings = new()
         {
-            XmlNode? node = doc.SelectSingleNode("//header");
-            if (node is null)
-                throw new DictionaryParseException("No <header> tag in the dictionary");
-            ParseMsgNode(node, Header);
+            IgnoreComments = true
+        };
+
+        using (XmlReader reader = XmlReader.Create(stream, readerSettings)) {
+            XmlDocument rootDoc = new();
+            rootDoc.Load(reader);
+            SetVersionInfo(rootDoc);
+            ParseFields(rootDoc);
+            CacheComponents(rootDoc);
+            ParseMessages(rootDoc);
+            ParseHeader(rootDoc);
+            ParseTrailer(rootDoc);
+        }
+    }
+
+    public bool FieldHasValue(int tag, string val)
+    {
+        return FieldsByTag[tag].EnumDict.ContainsKey(val);
+    }
+
+    private void SetVersionInfo(XmlDocument doc)
+    {
+        XmlNode? majorVerNode = doc.SelectSingleNode("/fix/@major");
+        XmlNode? minorVerNode = doc.SelectSingleNode("/fix/@minor");
+
+        if (majorVerNode is null || minorVerNode is null) {
+            throw new DictionaryParseException("Failed to find attributes 'major' and 'minor' in <fix> tag");
         }
 
-        private void ParseTrailer(XmlDocument doc)
-        {
-            XmlNode? node = doc.SelectSingleNode("//trailer");
-            if (node is null)
-                throw new DictionaryParseException("No <trailer> tag in the dictionary");
-            ParseMsgNode(node, Trailer);
-        }
+        MajorVersion = majorVerNode.Value;
+        MinorVersion = minorVerNode.Value;
+        XmlNode? node = doc.SelectSingleNode("/fix/@type");
 
-        /// <summary>
-        /// Checks that node has 'name' attribute, and is not a stray text node.
-        /// Throws a DictionaryParseException if a field or component node is malformed.
-        /// </summary>
-        /// <param name="childNode"></param>
-        /// <param name="parentNode"></param>
-        internal static string VerifyChildNodeAndReturnNameAtt(XmlNode childNode, XmlNode parentNode)
+        string typeAtt = node?.Value ?? "FIX"; // att is omitted in non-FIXT DDs
+
+        if (!typeAtt.Equals("FIX") && !typeAtt.Equals("FIXT"))
+            throw new DictionaryParseException("<fix> 'type' attribute must be FIX or FIXT (assumes FIX if not present)");
+        Version = $"{typeAtt}.{MajorVersion}.{MinorVersion}";
+    }
+
+    private void ParseFields(XmlDocument doc)
+    {
+        XmlNodeList? nodeList = doc.SelectNodes("//fields/field");
+        if (nodeList is null)
+            throw new DictionaryParseException("No <fields> tag in dictionary");
+        foreach (XmlNode fldEl in nodeList)
         {
-            if (childNode.Attributes == null)
+            DDField fld = NewField(fldEl);
+            FieldsByTag[fld.Tag] = fld;
+            FieldsByName[fld.Name] = fld;
+        }
+    }
+
+    private void CacheComponents(XmlDocument doc)
+    {
+        XmlNodeList? nodeList = doc.SelectNodes("//components/component");
+        if(nodeList is null)
+            throw new DictionaryParseException("No <components> tag in dictionary");
+        foreach (XmlNode compEl in nodeList)
+        {
+            XmlAttribute? nameAtt = compEl.Attributes?["name"];
+            if (nameAtt != null)
+                _componentsByName[nameAtt.Value] = compEl;
+        }
+    }
+
+    private DDField NewField(XmlNode fldEl)
+    {
+        XmlAttribute? tagAtt = fldEl.Attributes?["number"];
+        XmlAttribute? nameAtt = fldEl.Attributes?["name"];
+        XmlAttribute? typeAtt = fldEl.Attributes?["type"];
+
+        if (tagAtt is null)
+            throw new DictionaryParseException("A <field> is missing its 'number' attribute");
+        string tagstr = tagAtt.Value;
+
+        if(nameAtt is null)
+            throw new DictionaryParseException($"<field number='{tagstr}'> is missing its 'name' attribute");
+        if(typeAtt is null)
+            throw new DictionaryParseException($"<field number='{tagstr}'> is missing its 'type' attribute");
+
+        string name = nameAtt.Value;
+        string fldType = typeAtt.Value;
+
+        int tag = QuickFix.Fields.Converters.IntConverter.Convert(tagstr);
+        Dictionary<string, string> enums = new Dictionary<string, string>();
+        if (fldEl.HasChildNodes)
+        {
+            XmlNodeList? enumNodeList = fldEl.SelectNodes(".//value");
+            if (enumNodeList is not null)
             {
-                throw new DictionaryParseException($"Malformed data dictionary: Found text-only node containing '{childNode.InnerText.Trim()}'");
+                foreach (XmlNode enumEl in enumNodeList)
+                {
+                    string description = string.Empty;
+                    if (enumEl.Attributes?["description"] is not null)
+                        description = enumEl.Attributes["description"]!.Value;
+
+                    XmlAttribute? enumAtt = enumEl.Attributes?["enum"];
+                    if (enumAtt is null)
+                        throw new DictionaryParseException(
+                            $"Field {tagstr} has an <value> that is missing its 'enum' attribute");
+                    enums[enumAtt.Value] = description;
+                }
             }
+        }
+        return new DDField(tag, name, enums, fldType);
+    }
 
-            string? nameatt = childNode.Attributes["name"]?.Value;
+    private void ParseMessages(XmlDocument doc)
+    {
+        XmlNodeList? nodeList = doc.SelectNodes("//messages/message");
+        if (nodeList is null)
+            throw new DictionaryParseException("No <messages> tag in dictionary");
+        foreach (XmlNode msgEl in nodeList)
+        {
+            DDMap msg = new DDMap();
+            ParseMsgNode(msgEl, msg);
+            string? msgtype = msgEl.Attributes?["msgtype"]?.Value;
+            if (msgtype is null)
+                throw new DictionaryParseException("A <message> is missing its 'msgtype' attribute");
+            Messages.Add(msgtype, msg);
+        }
+    }
 
-            if (nameatt is null)
-            {
-                string messageTypeName = parentNode.Attributes?["name"]?.Value ?? parentNode.Name;
-                throw new DictionaryParseException($"Malformed data dictionary: Found '{childNode.Name}' node without 'name' within parent '{parentNode.Name}/{messageTypeName}'");
-            }
+    private void ParseHeader(XmlDocument doc)
+    {
+        XmlNode? node = doc.SelectSingleNode("//header");
+        if (node is null)
+            throw new DictionaryParseException("No <header> tag in the dictionary");
+        ParseMsgNode(node, Header);
+    }
 
-            return nameatt;
+    private void ParseTrailer(XmlDocument doc)
+    {
+        XmlNode? node = doc.SelectSingleNode("//trailer");
+        if (node is null)
+            throw new DictionaryParseException("No <trailer> tag in the dictionary");
+        ParseMsgNode(node, Trailer);
+    }
+
+    /// <summary>
+    /// Checks that node has 'name' attribute, and is not a stray text node.
+    /// Throws a DictionaryParseException if a field or component node is malformed.
+    /// </summary>
+    /// <param name="childNode"></param>
+    /// <param name="parentNode"></param>
+    internal static string VerifyChildNodeAndReturnNameAtt(XmlNode childNode, XmlNode parentNode)
+    {
+        if (childNode.Attributes == null)
+        {
+            throw new DictionaryParseException($"Malformed data dictionary: Found text-only node containing '{childNode.InnerText.Trim()}'");
         }
 
-        /// <summary>
-        /// Parse a message node (message, group, or component).  Its data is added to parameter `ddmap`.
-        /// </summary>
-        /// <param name="node">a message, group, or component node</param>
-        /// <param name="ddmap">the still-being-constructed DDMap for this node</param>
-        /// <param name="componentRequired">
-        /// If non-null, parsing is inside a component that is required (true) or not (false).
-        /// If null, parser is not inside a component.
-        /// </param>
-        private void ParseMsgNode(XmlNode node, DDMap ddmap, bool? componentRequired = null)
+        string? nameatt = childNode.Attributes["name"]?.Value;
+
+        if (nameatt is null)
         {
-            /* 
-            // This code is great for debugging DD parsing issues.
-            string s = "+ " + node.Name;  // node.Name is probably "message"
-            if (node.Attributes["name"] != null)
-                s += " | " + node.Attributes["name"].Value;
+            string messageTypeName = parentNode.Attributes?["name"]?.Value ?? parentNode.Name;
+            throw new DictionaryParseException($"Malformed data dictionary: Found '{childNode.Name}' node without 'name' within parent '{parentNode.Name}/{messageTypeName}'");
+        }
+
+        return nameatt;
+    }
+
+    /// <summary>
+    /// Parse a message node (message, group, or component).  Its data is added to parameter `ddmap`.
+    /// </summary>
+    /// <param name="node">a message, group, or component node</param>
+    /// <param name="ddmap">the still-being-constructed DDMap for this node</param>
+    /// <param name="componentRequired">
+    /// If non-null, parsing is inside a component that is required (true) or not (false).
+    /// If null, parser is not inside a component.
+    /// </param>
+    private void ParseMsgNode(XmlNode node, DDMap ddmap, bool? componentRequired = null)
+    {
+        /*
+        // This code is great for debugging DD parsing issues.
+        string s = "+ " + node.Name;  // node.Name is probably "message"
+        if (node.Attributes["name"] != null)
+            s += " | " + node.Attributes["name"].Value;
+        Console.WriteLine(s);
+        */
+
+        string? messageTypeName = node.Name switch
+        {
+            "header" => "header",
+            "trailer" => "trailer",
+            _ => node.Attributes?["name"]?.Value
+        };
+
+        if (messageTypeName is null)
+            throw new DictionaryParseException($"Found <{node.Name}> that is missing its 'name' attribute");
+
+        if (!node.HasChildNodes) { return; }
+        foreach (XmlNode childNode in node.ChildNodes)
+        {
+            /*
+            // Continuation of code that's great for debugging DD parsing issues.
+            s = "    + " + childNode.Name;  // childNode.Name is probably "field"
+            if (childNode.Attributes["name"] != null)
+                s += " | " + childNode.Attributes["name"].Value;
             Console.WriteLine(s);
             */
 
-            string? messageTypeName = node.Name switch
+            string nameAttribute = VerifyChildNodeAndReturnNameAtt(childNode, node);
+
+            switch (childNode.Name)
             {
-                "header" => "header",
-                "trailer" => "trailer",
-                _ => node.Attributes?["name"]?.Value
-            };
+                case "field":
+                case "group":
+                    if (FieldsByName.TryGetValue(nameAttribute, out DDField? fld) == false)
+                    {
+                        throw new DictionaryParseException(
+                            $"Field '{nameAttribute}' is not defined in <fields> section.");
+                    }
 
-            if (messageTypeName is null)
-                throw new DictionaryParseException($"Found <{node.Name}> that is missing its 'name' attribute");
+                    // If this child is in non-required component (componentRequired=false),
+                    //   then ignore the "required" attribute
+                    bool required = childNode.Attributes?["required"]?.Value == "Y" && componentRequired.GetValueOrDefault(true);
 
-            if (!node.HasChildNodes) { return; }
-            foreach (XmlNode childNode in node.ChildNodes)
-            {
-                /*
-                // Continuation of code that's great for debugging DD parsing issues.
-                s = "    + " + childNode.Name;  // childNode.Name is probably "field"
-                if (childNode.Attributes["name"] != null)
-                    s += " | " + childNode.Attributes["name"].Value;
-                Console.WriteLine(s);
-                */
+                    if (required)
+                        ddmap.ReqFields.Add(fld.Tag);
 
-                string nameAttribute = VerifyChildNodeAndReturnNameAtt(childNode, node);
+                    if (ddmap.IsField(fld.Tag) == false)
+                        ddmap.Fields.Add(fld.Tag, fld);
 
-                switch (childNode.Name)
-                {
-                    case "field":
-                    case "group":
-                        if (FieldsByName.TryGetValue(nameAttribute, out DDField? fld) == false)
-                        {
-                            throw new DictionaryParseException(
-                                $"Field '{nameAttribute}' is not defined in <fields> section.");
-                        }
+                    // if this is in a group whose delim is unset, then this must be the delim (i.e. first field)
+                    if (ddmap is DDGrp ddGroup && ddGroup.Delim == 0)
+                        ddGroup.Delim = fld.Tag;
 
-                        // If this child is in non-required component (componentRequired=false),
-                        //   then ignore the "required" attribute
-                        bool required = childNode.Attributes?["required"]?.Value == "Y" && componentRequired.GetValueOrDefault(true);
-
+                    if (childNode.Name == "group")
+                    {
+                        DDGrp grp = new() { NumFld = fld.Tag };
                         if (required)
-                            ddmap.ReqFields.Add(fld.Tag);
+                            grp.Required = true;
 
-                        if (ddmap.IsField(fld.Tag) == false)
-                            ddmap.Fields.Add(fld.Tag, fld);
+                        ParseMsgNode(childNode, grp);
+                        ddmap.Groups.Add(fld.Tag, grp);
+                    }
+                    break;
 
-                        // if this is in a group whose delim is unset, then this must be the delim (i.e. first field)
-                        if (ddmap is DDGrp ddGroup && ddGroup.Delim == 0)
-                            ddGroup.Delim = fld.Tag;
+                case "component":
+                    XmlNode compNode = _componentsByName[nameAttribute];
+                    ParseMsgNode(compNode, ddmap, childNode.Attributes?["required"]?.Value == "Y");
+                    break;
 
-                        if (childNode.Name == "group")
-                        {
-                            DDGrp grp = new() { NumFld = fld.Tag };
-                            if (required)
-                                grp.Required = true;
-
-                            ParseMsgNode(childNode, grp);
-                            ddmap.Groups.Add(fld.Tag, grp);
-                        }
-                        break;
-
-                    case "component":
-                        XmlNode compNode = _componentsByName[nameAttribute];
-                        ParseMsgNode(compNode, ddmap, childNode.Attributes?["required"]?.Value == "Y");
-                        break;
-
-                    default:
-                        throw new DictionaryParseException($"Malformed data dictionary: child node type should be one of {{field,group,component}} but is '{childNode.Name}' within parent '{node.Name}/{messageTypeName}'");
-                }
+                default:
+                    throw new DictionaryParseException($"Malformed data dictionary: child node type should be one of {{field,group,component}} but is '{childNode.Name}' within parent '{node.Name}/{messageTypeName}'");
             }
         }
     }

--- a/QuickFIXn/DataDictionary/DataDictionary.cs
+++ b/QuickFIXn/DataDictionary/DataDictionary.cs
@@ -117,11 +117,7 @@ namespace QuickFix.DataDictionary
                 throw new RepeatedTag(map.RepeatedTags[0].Tag);
         }
 
-        public DDMap? GetMapForMessage(string msgType) {
-            return Messages.ContainsKey(msgType)
-                ? Messages[msgType]
-                : null;
-        }
+        public DDMap? GetMapForMessage(string msgType) => Messages.TryGetValue(msgType, out var message) ? message : null;
 
         /// <summary>
         /// If DD defines this message type, returns with no side effect; else throws InvalidMessageType.
@@ -413,7 +409,7 @@ namespace QuickFix.DataDictionary
 
         public bool IsGroup(string msgType, int tag)
         {
-            return Messages.ContainsKey(msgType) && Messages[msgType].IsGroup(tag);
+            return Messages.TryGetValue(msgType, out DDMap? dd) && dd.IsGroup(tag);
         }
 
         /// <summary>

--- a/QuickFIXn/DataDictionaryProvider.cs
+++ b/QuickFIXn/DataDictionaryProvider.cs
@@ -35,12 +35,12 @@ namespace QuickFix
 
         public DataDictionary.DataDictionary GetSessionDataDictionary(string beginString)
         {
-            return _transportDataDictionaries.GetValueOrDefault(beginString, _emptyDataDictionary);
+            return _transportDataDictionaries.TryGetValue(beginString, out var value) ? value : _emptyDataDictionary;
         }
 
         public DataDictionary.DataDictionary GetApplicationDataDictionary(string applVerId)
         {
-            return _applicationDataDictionaries.GetValueOrDefault(applVerId, _emptyDataDictionary);
+            return _applicationDataDictionaries.TryGetValue(applVerId, out var value) ? value : _emptyDataDictionary;
         }
     }
 }

--- a/QuickFIXn/DataDictionaryProvider.cs
+++ b/QuickFIXn/DataDictionaryProvider.cs
@@ -1,46 +1,45 @@
 ﻿using System.Collections.Generic;
 
-namespace QuickFix
+namespace QuickFix;
+
+public class DataDictionaryProvider
 {
-    public class DataDictionaryProvider
+    private readonly Dictionary<string, DataDictionary.DataDictionary> _transportDataDictionaries;
+    private readonly Dictionary<string, DataDictionary.DataDictionary> _applicationDataDictionaries;
+    private readonly DataDictionary.DataDictionary _emptyDataDictionary;
+
+    public DataDictionaryProvider()
     {
-        private readonly Dictionary<string, DataDictionary.DataDictionary> _transportDataDictionaries;
-        private readonly Dictionary<string, DataDictionary.DataDictionary> _applicationDataDictionaries;
-        private readonly DataDictionary.DataDictionary _emptyDataDictionary;
+        _transportDataDictionaries = new Dictionary<string, DataDictionary.DataDictionary>();
+        _applicationDataDictionaries = new Dictionary<string, DataDictionary.DataDictionary>();
+        _emptyDataDictionary = new DataDictionary.DataDictionary();
+    }
 
-        public DataDictionaryProvider()
-        {
-            _transportDataDictionaries = new Dictionary<string, DataDictionary.DataDictionary>();
-            _applicationDataDictionaries = new Dictionary<string, DataDictionary.DataDictionary>();
-            _emptyDataDictionary = new DataDictionary.DataDictionary();
-        }
+    /// TODO need to make deeper copy?
+    public DataDictionaryProvider(DataDictionaryProvider src)
+    {
+        _transportDataDictionaries = new Dictionary<string, DataDictionary.DataDictionary>(src._transportDataDictionaries);
+        _applicationDataDictionaries = new Dictionary<string, DataDictionary.DataDictionary>(src._applicationDataDictionaries);
+        _emptyDataDictionary = new DataDictionary.DataDictionary(src._emptyDataDictionary);
+    }
 
-        /// TODO need to make deeper copy?
-        public DataDictionaryProvider(DataDictionaryProvider src)
-        {
-            _transportDataDictionaries = new Dictionary<string, DataDictionary.DataDictionary>(src._transportDataDictionaries);
-            _applicationDataDictionaries = new Dictionary<string, DataDictionary.DataDictionary>(src._applicationDataDictionaries);
-            _emptyDataDictionary = new DataDictionary.DataDictionary(src._emptyDataDictionary);
-        }
+    public void AddTransportDataDictionary(string beginString, DataDictionary.DataDictionary dataDictionary)
+    {
+        _transportDataDictionaries[beginString] = dataDictionary;
+    }
 
-        public void AddTransportDataDictionary(string beginString, DataDictionary.DataDictionary dataDictionary)
-        {
-            _transportDataDictionaries[beginString] = dataDictionary;
-        }
+    public void AddApplicationDataDictionary(string applVerId, DataDictionary.DataDictionary dataDictionary)
+    {
+        _applicationDataDictionaries[applVerId] = dataDictionary;
+    }
 
-        public void AddApplicationDataDictionary(string applVerId, DataDictionary.DataDictionary dataDictionary)
-        {
-            _applicationDataDictionaries[applVerId] = dataDictionary;
-        }
+    public DataDictionary.DataDictionary GetSessionDataDictionary(string beginString)
+    {
+        return _transportDataDictionaries.TryGetValue(beginString, out var value) ? value : _emptyDataDictionary;
+    }
 
-        public DataDictionary.DataDictionary GetSessionDataDictionary(string beginString)
-        {
-            return _transportDataDictionaries.TryGetValue(beginString, out var value) ? value : _emptyDataDictionary;
-        }
-
-        public DataDictionary.DataDictionary GetApplicationDataDictionary(string applVerId)
-        {
-            return _applicationDataDictionaries.TryGetValue(applVerId, out var value) ? value : _emptyDataDictionary;
-        }
+    public DataDictionary.DataDictionary GetApplicationDataDictionary(string applVerId)
+    {
+        return _applicationDataDictionaries.TryGetValue(applVerId, out var value) ? value : _emptyDataDictionary;
     }
 }

--- a/QuickFIXn/Message/FieldMap.cs
+++ b/QuickFIXn/Message/FieldMap.cs
@@ -260,14 +260,14 @@ namespace QuickFix
             // copy, in case user code reuses input object
             Group group = grp.Clone();
 
-            if (!_groups.TryGetValue(group.CounterField, out var groupList))
+            if (_groups.TryGetValue(group.CounterField, out var groupList))
             {
-                groupList = new List<Group> { group };
-                _groups.Add(group.CounterField, groupList);
+                groupList.Add(group);
             }
             else
             {
-                groupList.Add(group);
+                groupList = new List<Group> { group };
+                _groups.Add(group.CounterField, groupList);
             }
 
             if (autoIncCounter)
@@ -290,7 +290,7 @@ namespace QuickFix
         /// <exception cref="FieldNotFoundException" />
         public Group GetGroup(int num, int counterTag)
         {
-            if (!_groups.TryGetValue(counterTag, out var groupList) || num <= 0 || groupList.Count < num)
+            if (!_groups.TryGetValue(counterTag, out List<Group>? groupList) || num <= 0 || groupList.Count < num)
                 throw new FieldNotFoundException(counterTag);
 
             return groupList[num - 1];
@@ -339,7 +339,7 @@ namespace QuickFix
                     return ((ULongField)fld).Value;
                 return ULongConverter.Convert(fld.ToString());
             }
-            catch (System.Collections.Generic.KeyNotFoundException)
+            catch (KeyNotFoundException)
             {
                 throw new FieldNotFoundException(tag);
             }

--- a/QuickFIXn/Message/FieldMap.cs
+++ b/QuickFIXn/Message/FieldMap.cs
@@ -5,685 +5,684 @@ using System.Text;
 using QuickFix.Fields;
 using QuickFix.Fields.Converters;
 
-namespace QuickFix
-{
+namespace QuickFix;
+
+/// <summary>
+/// Field container used by messages, groups, and composites
+/// </summary>
+public class FieldMap : IEnumerable<KeyValuePair<int, IField>> {
+    private SortedDictionary<int, IField> _fields = new();
+
+    /// FIXME sorted dict is a hack to get quasi-correct field order
+    private Dictionary<int, List<Group>> _groups = new();
+
     /// <summary>
-    /// Field container used by messages, groups, and composites
+    /// order of field tags as an integer array
     /// </summary>
-    public class FieldMap : IEnumerable<KeyValuePair<int, IField>> {
-        private SortedDictionary<int, IField> _fields = new();
+    public int[] FieldOrder { get; private set; } = Array.Empty<int>();
 
-        /// FIXME sorted dict is a hack to get quasi-correct field order
-        private Dictionary<int, List<Group>> _groups = new();
+    /// <summary>
+    /// Used for validation.  Only set during Message parsing.
+    /// </summary>
+    public List<IField> RepeatedTags { get; private set; } = new();
 
-        /// <summary>
-        /// order of field tags as an integer array
-        /// </summary>
-        public int[] FieldOrder { get; private set; } = Array.Empty<int>();
+    /// <summary>
+    /// Default constructor
+    /// </summary>
+    public FieldMap()
+    {
+    }
 
-        /// <summary>
-        /// Used for validation.  Only set during Message parsing.
-        /// </summary>
-        public List<IField> RepeatedTags { get; private set; } = new();
+    /// <summary>
+    /// Constructor with field order
+    /// </summary>
+    /// <param name="fieldOrd"></param>
+    public FieldMap(int[] fieldOrd)
+        : this()
+    {
+        FieldOrder = fieldOrd;
+    }
 
-        /// <summary>
-        /// Default constructor
-        /// </summary>
-        public FieldMap()
-        {
-        }
+    /// <summary>
+    /// FIXME this should probably make a deeper copy
+    /// </summary>
+    /// <param name="src">The QuickFix.FieldMap to copy</param>
+    /// <returns>A copy of the given QuickFix.FieldMap</returns>
+    public FieldMap(FieldMap src)
+    {
+        CopyStateFrom(src);
+    }
 
-        /// <summary>
-        /// Constructor with field order
-        /// </summary>
-        /// <param name="fieldOrd"></param>
-        public FieldMap(int[] fieldOrd)
-            : this()
-        {
-            FieldOrder = fieldOrd;
-        }
+    public void CopyStateFrom(FieldMap src)
+    {
+        FieldOrder = src.FieldOrder;
 
-        /// <summary>
-        /// FIXME this should probably make a deeper copy
-        /// </summary>
-        /// <param name="src">The QuickFix.FieldMap to copy</param>
-        /// <returns>A copy of the given QuickFix.FieldMap</returns>
-        public FieldMap(FieldMap src)
-        {
-            CopyStateFrom(src);
-        }
+        _fields = new SortedDictionary<int, IField>(src._fields);
 
-        public void CopyStateFrom(FieldMap src)
-        {
-            FieldOrder = src.FieldOrder;
+        _groups = new Dictionary<int, List<Group>>();
+        foreach (KeyValuePair<int, List<Group>> g in src._groups)
+            _groups.Add(g.Key, new List<Group>(g.Value));
 
-            _fields = new SortedDictionary<int, IField>(src._fields);
+        RepeatedTags = new List<IField>(src.RepeatedTags);
+    }
 
-            _groups = new Dictionary<int, List<Group>>();
-            foreach (KeyValuePair<int, List<Group>> g in src._groups)
-                _groups.Add(g.Key, new List<Group>(g.Value));
+    /// <summary>
+    /// Remove a field from the fieldmap
+    /// </summary>
+    /// <param name="field"></param>
+    /// <returns>true if field was removed, false otherwise</returns>
+    public bool RemoveField(int field)
+    {
+        return _fields.Remove(field);
+    }
 
-            RepeatedTags = new List<IField>(src.RepeatedTags);
-        }
+    /// <summary>
+    /// set field in the fieldmap
+    /// will overwrite field if it exists
+    /// </summary>
+    public void SetField(IField field)
+    {
+        _fields[field.Tag] = field;
+    }
 
-        /// <summary>
-        /// Remove a field from the fieldmap
-        /// </summary>
-        /// <param name="field"></param>
-        /// <returns>true if field was removed, false otherwise</returns>
-        public bool RemoveField(int field)
-        {
-            return _fields.Remove(field);
-        }
-
-        /// <summary>
-        /// set field in the fieldmap
-        /// will overwrite field if it exists
-        /// </summary>
-        public void SetField(IField field)
+    /// <summary>
+    /// set many fields at the same time
+    /// </summary>
+    public void SetFields(IEnumerable<IField> fields)
+    {
+        foreach (var field in fields)
         {
             _fields[field.Tag] = field;
         }
+    }
 
-        /// <summary>
-        /// set many fields at the same time
-        /// </summary>
-        public void SetFields(IEnumerable<IField> fields)
+    /// <summary>
+    /// Set field, with optional override check
+    /// </summary>
+    /// <param name="field"></param>
+    /// <param name="overwrite">will overwrite existing field if set to true</param>
+    /// <returns>false if overwrite=true and is denied</returns>
+    public bool SetField(IField field, bool overwrite)
+    {
+        if (_fields.ContainsKey(field.Tag) && !overwrite)
+            return false;
+
+        SetField(field);
+        return true;
+    }
+
+    /// <summary>
+    /// Gets a boolean field; saves its value into the parameter object, which is also the return value.
+    /// </summary>
+    /// <param name="field">this field's tag is used to extract the value from the message; that value is saved back into this object</param>
+    /// <exception cref="FieldNotFoundException">thrown if <paramref name="field"/> isn't found</exception>
+    /// <returns><paramref name="field"/></returns>
+    public BooleanField GetField(BooleanField field)
+    {
+        field.Value = GetBoolean(field.Tag);
+        return field;
+    }
+
+    /// <summary>
+    /// Gets a string field; saves its value into the parameter object, which is also the return value.
+    /// </summary>
+    /// <param name="field">this field's tag is used to extract the value from the message; that value is saved back into this object</param>
+    /// <exception cref="FieldNotFoundException">thrown if <paramref name="field"/> isn't found</exception>
+    /// <returns><paramref name="field"/></returns>
+    public StringField GetField(StringField field)
+    {
+        field.Value = GetString(field.Tag);
+        return field;
+    }
+
+    /// <summary>
+    /// Gets a char field; saves its value into the parameter object, which is also the return value.
+    /// </summary>
+    /// <param name="field">this field's tag is used to extract the value from the message; that value is saved back into this object</param>
+    /// <exception cref="FieldNotFoundException">thrown if <paramref name="field"/> isn't found</exception>
+    /// <returns><paramref name="field"/></returns>
+    public CharField GetField(CharField field)
+    {
+        field.Value = GetChar(field.Tag);
+        return field;
+    }
+
+    /// <summary>
+    /// Gets a int field; saves its value into the parameter object, which is also the return value.
+    /// </summary>
+    /// <param name="field">this field's tag is used to extract the value from the message; that value is saved back into this object</param>
+    /// <exception cref="FieldNotFoundException">thrown if <paramref name="field"/> isn't found</exception>
+    /// <returns><paramref name="field"/></returns>
+    public IntField GetField(IntField field)
+    {
+        field.Value = GetInt(field.Tag);
+        return field;
+    }
+
+    /// <summary>
+    /// Gets a ulong field; saves its value into the parameter object, which is also the return value.
+    /// </summary>
+    /// <param name="field">this field's tag is used to extract the value from the message; that value is saved back into this object</param>
+    /// <exception cref="FieldNotFoundException">thrown if <paramref name="field"/> isn't found</exception>
+    /// <returns><paramref name="field"/></returns>
+    public ULongField GetField(ULongField field)
+    {
+        field.Value = GetULong(field.Tag);
+        return field;
+    }
+
+    /// <summary>
+    /// Gets a decimal field; saves its value into the parameter object, which is also the return value.
+    /// </summary>
+    /// <param name="field">this field's tag is used to extract the value from the message; that value is saved back into this object</param>
+    /// <exception cref="FieldNotFoundException">thrown if <paramref name="field"/> isn't found</exception>
+    /// <returns><paramref name="field"/></returns>
+    public DecimalField GetField(DecimalField field)
+    {
+        field.Value = GetDecimal(field.Tag);
+        return field;
+    }
+
+    /// <summary>
+    /// Gets a datetime field; saves its value into the parameter object, which is also the return value.
+    /// </summary>
+    /// <param name="field">this field's tag is used to extract the value from the message; that value is saved back into this object</param>
+    /// <exception cref="FieldNotFoundException">thrown if <paramref name="field"/> isn't found</exception>
+    /// <returns><paramref name="field"/></returns>
+    public DateTimeField GetField(DateTimeField field)
+    {
+        field.Value = GetDateTime(field.Tag);
+        return field;
+    }
+
+    /// <summary>
+    /// Gets a date only field; saves its value into the parameter object, which is also the return value.
+    /// </summary>
+    /// <param name="field">this field's tag is used to extract the value from the message; that value is saved back into this object</param>
+    /// <exception cref="FieldNotFoundException">thrown if <paramref name="field"/> isn't found</exception>
+    /// <returns><paramref name="field"/></returns>
+    public DateOnlyField GetField(DateOnlyField field)
+    {
+        field.Value = GetDateOnly(field.Tag);
+        return field;
+    }
+
+    /// <summary>
+    /// Gets a time only field; saves its value into the parameter object, which is also the return value.
+    /// </summary>
+    /// <param name="field">this field's tag is used to extract the value from the message; that value is saved back into this object</param>
+    /// <exception cref="FieldNotFoundException">thrown if <paramref name="field"/> isn't found</exception>
+    /// <returns><paramref name="field"/></returns>
+    public TimeOnlyField GetField(TimeOnlyField field)
+    {
+        field.Value = GetTimeOnly(field.Tag);
+        return field;
+    }
+
+    /// <summary>
+    /// Check to see if field is set
+    /// </summary>
+    /// <param name="field">Field Object</param>
+    /// <returns>true if set</returns>
+    public bool IsSetField(IField field)
+    {
+        return IsSetField(field.Tag);
+    }
+
+    /// <summary>
+    /// Check to see if field is set
+    /// </summary>
+    /// <param name="tag">Tag Number</param>
+    /// <returns>true if set</returns>
+    public bool IsSetField(int tag)
+    {
+        return _fields.ContainsKey(tag);
+    }
+
+    /// <summary>
+    /// Add a group to message; the group counter is automatically incremented.
+    /// </summary>
+    /// <param name="grp">group to add</param>
+    public void AddGroup(Group grp)
+    {
+        AddGroup(grp, true);
+    }
+
+    /// <summary>
+    /// Add a group to message; optionally auto-increment the counter.
+    /// When parsing from a string (e.g. Message::FromString()), we want to leave the counter alone
+    /// so we can detect when the counterparty has set it wrong.
+    /// </summary>
+    /// <param name="grp">group to add</param>
+    /// <param name="autoIncCounter">if true, auto-increment the counter, else leave it as-is</param>
+    internal void AddGroup(Group grp, bool autoIncCounter)
+    {
+        // copy, in case user code reuses input object
+        Group group = grp.Clone();
+
+        if (_groups.TryGetValue(group.CounterField, out var groupList))
         {
-            foreach (var field in fields)
+            groupList.Add(group);
+        }
+        else
+        {
+            groupList = new List<Group> { group };
+            _groups.Add(group.CounterField, groupList);
+        }
+
+        if (autoIncCounter)
+        {
+            // increment group size
+            int groupSize = groupList.Count;
+            int countTag = group.CounterField;
+            IntField count = new IntField(countTag, groupSize);
+            this.SetField(count, true);
+        }
+    }
+
+    /// <summary>
+    /// Gets an instance of a group.  Note: use GetGroup(int,Group) if you want
+    /// your group as the proper subtype (e.g. NoPartyIDsGroup instead of the generic Group)
+    /// </summary>
+    /// <param name="num">index of desired group (starting at 1)</param>
+    /// <param name="counterTag">counter tag of repeating group</param>
+    /// <returns>retrieved group object</returns>
+    /// <exception cref="FieldNotFoundException" />
+    public Group GetGroup(int num, int counterTag)
+    {
+        if (!_groups.TryGetValue(counterTag, out List<Group>? groupList) || num <= 0 || groupList.Count < num)
+            throw new FieldNotFoundException(counterTag);
+
+        return groupList[num - 1];
+    }
+
+    /// <summary>
+    /// Extracts a repeating-group item into <paramref name="group"/>
+    /// </summary>
+    /// <param name="num">index of desired group item (index starts at 1, not 0)</param>
+    /// <param name="group">group to populate (<c>group.Field</c> is used by this function to extract the group)</param>
+    public void GetGroup(int num, Group group)
+    {
+        int tag = group.CounterField;
+        group.CopyStateFrom(this.GetGroup(num, tag));
+    }
+
+    /// <summary>
+    /// Gets the integer value of a field
+    /// </summary>
+    /// <param name="tag">the FIX tag</param>
+    /// <returns>the integer field value</returns>
+    /// <exception cref="FieldNotFoundException" />
+    public int GetInt(int tag)
+    {
+        if (!_fields.TryGetValue(tag, out IField? fld))
+            throw new FieldNotFoundException(tag);
+
+        if (fld is FieldBase<int> intField)
+            return intField.Value;
+
+        return IntConverter.Convert(fld.ToString());
+    }
+
+    /// <summary>
+    /// Gets the ulong value of a field
+    /// </summary>
+    /// <param name="tag">the FIX tag</param>
+    /// <returns>the ulong field value</returns>
+    /// <exception cref="FieldNotFoundException" />
+    public ulong GetULong(int tag)
+    {
+        try
+        {
+            IField fld = _fields[tag];
+            if (fld.GetType() == typeof(ULongField))
+                return ((ULongField)fld).Value;
+            return ULongConverter.Convert(fld.ToString());
+        }
+        catch (KeyNotFoundException)
+        {
+            throw new FieldNotFoundException(tag);
+        }
+    }
+
+    /// <summary>
+    /// Gets the DateTime value of a field
+    /// </summary>
+    /// <param name="tag">the FIX tag</param>
+    /// <returns>the DateTime value</returns>
+    /// <exception cref="FieldNotFoundException" />
+    public DateTime GetDateTime(int tag)
+    {
+        if (!_fields.TryGetValue(tag, out IField? fld))
+            throw new FieldNotFoundException(tag);
+
+        return fld switch
+        {
+            DateOnlyField dateOnlyField => dateOnlyField.Value.Date,
+            TimeOnlyField timeOnlyField => new DateTime(1980, 01, 01).Add(timeOnlyField.Value.TimeOfDay),
+            FieldBase<DateTime> dateTimeField => dateTimeField.Value,
+            _ => DateTimeConverter.ParseToDateTime(fld.ToString())
+        };
+    }
+
+    /// <summary>
+    /// Gets the DateOnly value of a field
+    /// </summary>
+    /// <param name="tag">the FIX tag</param>
+    /// <returns>the DateTime value</returns>
+    /// <exception cref="FieldNotFoundException" />
+    public DateTime GetDateOnly(int tag)
+    {
+        if (!_fields.TryGetValue(tag, out IField? fld))
+            throw new FieldNotFoundException(tag);
+
+        if (fld is FieldBase<DateTime> dateTimeField)
+            return dateTimeField.Value.Date;
+
+        return DateTimeConverter.ParseToDateOnly(fld.ToString());
+    }
+
+    /// <summary>
+    /// Gets the TimeOnly value of a field
+    /// </summary>
+    /// <param name="tag">the FIX tag</param>
+    /// <returns>the DateTime value</returns>
+    /// <exception cref="FieldNotFoundException" />
+    public DateTime GetTimeOnly(int tag)
+    {
+        if (!_fields.TryGetValue(tag, out IField? fld))
+            throw new FieldNotFoundException(tag);
+
+        if (fld is FieldBase<DateTime> dateTimeField)
+            return new DateTime(1980, 01, 01).Add(dateTimeField.Value.TimeOfDay);
+
+        return DateTimeConverter.ParseToTimeOnly(fld.ToString());
+    }
+
+    /// <summary>
+    /// Gets the boolean value of a field
+    /// </summary>
+    /// <param name="tag">the FIX tag</param>
+    /// <returns>the bool value</returns>
+    /// <exception cref="FieldNotFoundException" />
+    public bool GetBoolean(int tag)
+    {
+        if (!_fields.TryGetValue(tag, out IField? fld))
+            throw new FieldNotFoundException(tag);
+
+        if (fld is FieldBase<bool> boolField)
+            return boolField.Value;
+
+        return BoolConverter.Convert(fld.ToString());
+    }
+
+    /// <summary>
+    /// Gets the string value of a field
+    /// </summary>
+    /// <param name="tag">the FIX tag</param>
+    /// <returns>the string value</returns>
+    /// <exception cref="FieldNotFoundException" />
+    public string GetString(int tag)
+    {
+        if (!_fields.TryGetValue(tag, out IField? fld))
+            throw new FieldNotFoundException(tag);
+
+        return fld.ToString();
+    }
+
+    /// <summary>
+    /// Gets the char value of a field
+    /// </summary>
+    /// <param name="tag">the FIX tag</param>
+    /// <returns>the char value</returns>
+    /// <exception cref="FieldNotFoundException" />
+    public char GetChar(int tag)
+    {
+        if (!_fields.TryGetValue(tag, out IField? fld))
+            throw new FieldNotFoundException(tag);
+
+        if (fld is FieldBase<char> charField)
+            return charField.Value;
+
+        return CharConverter.Convert(fld.ToString());
+    }
+
+    /// <summary>
+    /// Gets the decimal value of a field
+    /// </summary>
+    /// <param name="tag">the FIX tag</param>
+    /// <returns>the decimal value</returns>
+    /// <exception cref="FieldNotFoundException" />
+    public decimal GetDecimal(int tag)
+    {
+        if (!_fields.TryGetValue(tag, out IField? fld))
+            throw new FieldNotFoundException(tag);
+
+        if (fld is FieldBase<decimal> decimalField)
+            return decimalField.Value;
+
+        return DecimalConverter.Convert(fld.ToString());
+    }
+
+    /// <summary>
+    /// Removes specific group instance
+    /// </summary>
+    /// <param name="num">num of group (starting at 1)</param>
+    /// <param name="field">tag of group</param>
+    /// <exception cref="FieldNotFoundException" />
+    public void RemoveGroup(int num, int field)
+    {
+        if (!_groups.TryGetValue(field, out List<Group>? groupList) || num <= 0 || groupList.Count < num)
+            throw new FieldNotFoundException(field);
+
+        if (groupList.Count.Equals(1))
+            _groups.Remove(field);
+        else
+            groupList.RemoveAt(num - 1);
+    }
+
+    /// <summary>
+    /// Replaces specific group instance
+    /// </summary>
+    /// <param name="num">num of group (starting at 1)</param>
+    /// <param name="field">tag of group</param>
+    /// <param name="group">the group to replace it with</param>
+    /// <returns>Group object</returns>
+    /// <exception cref="FieldNotFoundException" />
+    public Group ReplaceGroup(int num, int field, Group group)
+    {
+        if (!_groups.TryGetValue(field, out List<Group>? groupList) || num <= 0 || groupList.Count < num)
+            throw new FieldNotFoundException(field);
+
+        return groupList[num - 1] = group;
+    }
+
+    /// <summary>
+    /// Removes fields and groups in message
+    /// </summary>
+    public virtual void Clear()
+    {
+        _fields.Clear();
+        _groups.Clear();
+    }
+
+    /// <summary>
+    /// Checks emptiness of message
+    /// </summary>
+    /// <returns>true if no fields or groups have been set</returns>
+    public bool IsEmpty()
+    {
+        return (_fields.Count == 0) && (_groups.Count == 0);
+    }
+
+    public int CalculateTotal()
+    {
+        int total = 0;
+        foreach (IField field in _fields.Values)
+        {
+            if (field.Tag != Fields.Tags.CheckSum)
+                total += field.GetTotal();
+        }
+
+        foreach (IField field in this.RepeatedTags)
+        {
+            if (field.Tag != Fields.Tags.CheckSum)
+                total += field.GetTotal();
+        }
+
+        foreach (List<Group> groupList in _groups.Values)
+        {
+            foreach (Group group in groupList)
+                total += group.CalculateTotal();
+        }
+        return total;
+    }
+
+    public int CalculateLength()
+    {
+        int total = 0;
+        foreach (IField field in _fields.Values)
+        {
+            if (field.Tag != Tags.BeginString
+                && field.Tag != Tags.BodyLength
+                && field.Tag != Tags.CheckSum)
             {
-                _fields[field.Tag] = field;
+                total += field.GetLength();
             }
         }
 
-        /// <summary>
-        /// Set field, with optional override check
-        /// </summary>
-        /// <param name="field"></param>
-        /// <param name="overwrite">will overwrite existing field if set to true</param>
-        /// <returns>false if overwrite=true and is denied</returns>
-        public bool SetField(IField field, bool overwrite)
+        foreach (IField field in this.RepeatedTags)
         {
-            if (_fields.ContainsKey(field.Tag) && !overwrite)
-                return false;
-            
-            SetField(field);
-            return true;
-        }
-
-        /// <summary>
-        /// Gets a boolean field; saves its value into the parameter object, which is also the return value.
-        /// </summary>
-        /// <param name="field">this field's tag is used to extract the value from the message; that value is saved back into this object</param>
-        /// <exception cref="FieldNotFoundException">thrown if <paramref name="field"/> isn't found</exception>
-        /// <returns><paramref name="field"/></returns>
-        public BooleanField GetField(BooleanField field)
-        {
-            field.Value = GetBoolean(field.Tag);
-            return field;
-        }
-
-        /// <summary>
-        /// Gets a string field; saves its value into the parameter object, which is also the return value.
-        /// </summary>
-        /// <param name="field">this field's tag is used to extract the value from the message; that value is saved back into this object</param>
-        /// <exception cref="FieldNotFoundException">thrown if <paramref name="field"/> isn't found</exception>
-        /// <returns><paramref name="field"/></returns>
-        public StringField GetField(StringField field)
-        {
-            field.Value = GetString(field.Tag);
-            return field;
-        }
-
-        /// <summary>
-        /// Gets a char field; saves its value into the parameter object, which is also the return value.
-        /// </summary>
-        /// <param name="field">this field's tag is used to extract the value from the message; that value is saved back into this object</param>
-        /// <exception cref="FieldNotFoundException">thrown if <paramref name="field"/> isn't found</exception>
-        /// <returns><paramref name="field"/></returns>
-        public CharField GetField(CharField field)
-        {
-            field.Value = GetChar(field.Tag);
-            return field;
-        }
-
-        /// <summary>
-        /// Gets a int field; saves its value into the parameter object, which is also the return value.
-        /// </summary>
-        /// <param name="field">this field's tag is used to extract the value from the message; that value is saved back into this object</param>
-        /// <exception cref="FieldNotFoundException">thrown if <paramref name="field"/> isn't found</exception>
-        /// <returns><paramref name="field"/></returns>
-        public IntField GetField(IntField field)
-        {
-            field.Value = GetInt(field.Tag);
-            return field;
-        }
-
-        /// <summary>
-        /// Gets a ulong field; saves its value into the parameter object, which is also the return value.
-        /// </summary>
-        /// <param name="field">this field's tag is used to extract the value from the message; that value is saved back into this object</param>
-        /// <exception cref="FieldNotFoundException">thrown if <paramref name="field"/> isn't found</exception>
-        /// <returns><paramref name="field"/></returns>
-        public ULongField GetField(ULongField field)
-        {
-            field.Value = GetULong(field.Tag);
-            return field;
-        }
-
-        /// <summary>
-        /// Gets a decimal field; saves its value into the parameter object, which is also the return value.
-        /// </summary>
-        /// <param name="field">this field's tag is used to extract the value from the message; that value is saved back into this object</param>
-        /// <exception cref="FieldNotFoundException">thrown if <paramref name="field"/> isn't found</exception>
-        /// <returns><paramref name="field"/></returns>
-        public DecimalField GetField(DecimalField field)
-        {
-            field.Value = GetDecimal(field.Tag);
-            return field;
-        }
-
-        /// <summary>
-        /// Gets a datetime field; saves its value into the parameter object, which is also the return value.
-        /// </summary>
-        /// <param name="field">this field's tag is used to extract the value from the message; that value is saved back into this object</param>
-        /// <exception cref="FieldNotFoundException">thrown if <paramref name="field"/> isn't found</exception>
-        /// <returns><paramref name="field"/></returns>
-        public DateTimeField GetField(DateTimeField field)
-        {
-            field.Value = GetDateTime(field.Tag);
-            return field;
-        }
-
-        /// <summary>
-        /// Gets a date only field; saves its value into the parameter object, which is also the return value.
-        /// </summary>
-        /// <param name="field">this field's tag is used to extract the value from the message; that value is saved back into this object</param>
-        /// <exception cref="FieldNotFoundException">thrown if <paramref name="field"/> isn't found</exception>
-        /// <returns><paramref name="field"/></returns>
-        public DateOnlyField GetField(DateOnlyField field)
-        {
-            field.Value = GetDateOnly(field.Tag);
-            return field;
-        }
-
-        /// <summary>
-        /// Gets a time only field; saves its value into the parameter object, which is also the return value.
-        /// </summary>
-        /// <param name="field">this field's tag is used to extract the value from the message; that value is saved back into this object</param>
-        /// <exception cref="FieldNotFoundException">thrown if <paramref name="field"/> isn't found</exception>
-        /// <returns><paramref name="field"/></returns>
-        public TimeOnlyField GetField(TimeOnlyField field)
-        {
-            field.Value = GetTimeOnly(field.Tag);
-            return field;
-        }
-
-        /// <summary>
-        /// Check to see if field is set
-        /// </summary>
-        /// <param name="field">Field Object</param>
-        /// <returns>true if set</returns>
-        public bool IsSetField(IField field)
-        {
-            return IsSetField(field.Tag);
-        }
-
-        /// <summary>
-        /// Check to see if field is set
-        /// </summary>
-        /// <param name="tag">Tag Number</param>
-        /// <returns>true if set</returns>
-        public bool IsSetField(int tag)
-        {
-            return _fields.ContainsKey(tag);
-        }
-
-        /// <summary>
-        /// Add a group to message; the group counter is automatically incremented.
-        /// </summary>
-        /// <param name="grp">group to add</param>
-        public void AddGroup(Group grp)
-        {
-            AddGroup(grp, true);
-        }
-
-        /// <summary>
-        /// Add a group to message; optionally auto-increment the counter.
-        /// When parsing from a string (e.g. Message::FromString()), we want to leave the counter alone
-        /// so we can detect when the counterparty has set it wrong.
-        /// </summary>
-        /// <param name="grp">group to add</param>
-        /// <param name="autoIncCounter">if true, auto-increment the counter, else leave it as-is</param>
-        internal void AddGroup(Group grp, bool autoIncCounter)
-        {
-            // copy, in case user code reuses input object
-            Group group = grp.Clone();
-
-            if (_groups.TryGetValue(group.CounterField, out var groupList))
+            if (field.Tag != Tags.BeginString
+                && field.Tag != Tags.BodyLength
+                && field.Tag != Tags.CheckSum)
             {
-                groupList.Add(group);
-            }
-            else
-            {
-                groupList = new List<Group> { group };
-                _groups.Add(group.CounterField, groupList);
-            }
-
-            if (autoIncCounter)
-            {
-                // increment group size
-                int groupSize = groupList.Count;
-                int countTag = group.CounterField;
-                IntField count = new IntField(countTag, groupSize);
-                this.SetField(count, true);
+                total += field.GetLength();
             }
         }
 
-        /// <summary>
-        /// Gets an instance of a group.  Note: use GetGroup(int,Group) if you want
-        /// your group as the proper subtype (e.g. NoPartyIDsGroup instead of the generic Group)
-        /// </summary>
-        /// <param name="num">index of desired group (starting at 1)</param>
-        /// <param name="counterTag">counter tag of repeating group</param>
-        /// <returns>retrieved group object</returns>
-        /// <exception cref="FieldNotFoundException" />
-        public Group GetGroup(int num, int counterTag)
+        foreach (List<Group> groupList in _groups.Values)
         {
-            if (!_groups.TryGetValue(counterTag, out List<Group>? groupList) || num <= 0 || groupList.Count < num)
-                throw new FieldNotFoundException(counterTag);
-
-            return groupList[num - 1];
+            foreach (Group group in groupList)
+                total += group.CalculateLength();
         }
 
-        /// <summary>
-        /// Extracts a repeating-group item into <paramref name="group"/>
-        /// </summary>
-        /// <param name="num">index of desired group item (index starts at 1, not 0)</param>
-        /// <param name="group">group to populate (<c>group.Field</c> is used by this function to extract the group)</param>
-        public void GetGroup(int num, Group group)
+        return total;
+    }
+
+    /// <summary>
+    /// Creates a FIX (ish) string representation of this FieldMap (does not change the object state)
+    /// </summary>
+    /// <returns></returns>
+    public virtual string CalculateString()
+    {
+        return CalculateString(new StringBuilder(), FieldOrder);
+    }
+
+    /// <summary>
+    /// Creates a FIX (ish) string representation of this FieldMap (does not change the object state)
+    /// </summary>
+    /// <param name="sb"></param>
+    /// <param name="preFields"></param>
+    /// <returns></returns>
+    public virtual string CalculateString(StringBuilder sb, int[] preFields)
+    {
+        HashSet<int> groupCounterTags = new(_groups.Keys);
+
+        foreach (int preField in preFields)
         {
-            int tag = group.CounterField;
-            group.CopyStateFrom(this.GetGroup(num, tag));
-        }
-
-        /// <summary>
-        /// Gets the integer value of a field
-        /// </summary>
-        /// <param name="tag">the FIX tag</param>
-        /// <returns>the integer field value</returns>
-        /// <exception cref="FieldNotFoundException" />
-        public int GetInt(int tag)
-        {
-            if (!_fields.TryGetValue(tag, out IField? fld))
-                throw new FieldNotFoundException(tag);
-
-            if (fld is FieldBase<int> intField)
-                return intField.Value;
-
-            return IntConverter.Convert(fld.ToString());
-        }
-
-        /// <summary>
-        /// Gets the ulong value of a field
-        /// </summary>
-        /// <param name="tag">the FIX tag</param>
-        /// <returns>the ulong field value</returns>
-        /// <exception cref="FieldNotFoundException" />
-        public ulong GetULong(int tag)
-        {
-            try
+            if (IsSetField(preField))
             {
-                IField fld = _fields[tag];
-                if (fld.GetType() == typeof(ULongField))
-                    return ((ULongField)fld).Value;
-                return ULongConverter.Convert(fld.ToString());
-            }
-            catch (KeyNotFoundException)
-            {
-                throw new FieldNotFoundException(tag);
-            }
-        }
- 
-        /// <summary>
-        /// Gets the DateTime value of a field
-        /// </summary>
-        /// <param name="tag">the FIX tag</param>
-        /// <returns>the DateTime value</returns>
-        /// <exception cref="FieldNotFoundException" />
-        public DateTime GetDateTime(int tag)
-        {
-            if (!_fields.TryGetValue(tag, out IField? fld))
-                throw new FieldNotFoundException(tag);
-
-            return fld switch
-            {
-                DateOnlyField dateOnlyField => dateOnlyField.Value.Date,
-                TimeOnlyField timeOnlyField => new DateTime(1980, 01, 01).Add(timeOnlyField.Value.TimeOfDay),
-                FieldBase<DateTime> dateTimeField => dateTimeField.Value,
-                _ => DateTimeConverter.ParseToDateTime(fld.ToString())
-            };
-        }
-
-        /// <summary>
-        /// Gets the DateOnly value of a field
-        /// </summary>
-        /// <param name="tag">the FIX tag</param>
-        /// <returns>the DateTime value</returns>
-        /// <exception cref="FieldNotFoundException" />
-        public DateTime GetDateOnly(int tag)
-        {
-            if (!_fields.TryGetValue(tag, out IField? fld))
-                throw new FieldNotFoundException(tag);
-
-            if (fld is FieldBase<DateTime> dateTimeField)
-                return dateTimeField.Value.Date;
-
-            return DateTimeConverter.ParseToDateOnly(fld.ToString());
-        }
-
-        /// <summary>
-        /// Gets the TimeOnly value of a field
-        /// </summary>
-        /// <param name="tag">the FIX tag</param>
-        /// <returns>the DateTime value</returns>
-        /// <exception cref="FieldNotFoundException" />
-        public DateTime GetTimeOnly(int tag)
-        {
-            if (!_fields.TryGetValue(tag, out IField? fld))
-                throw new FieldNotFoundException(tag);
-
-            if (fld is FieldBase<DateTime> dateTimeField)
-                return new DateTime(1980, 01, 01).Add(dateTimeField.Value.TimeOfDay);
-
-            return DateTimeConverter.ParseToTimeOnly(fld.ToString());
-        }
-
-        /// <summary>
-        /// Gets the boolean value of a field
-        /// </summary>
-        /// <param name="tag">the FIX tag</param>
-        /// <returns>the bool value</returns>
-        /// <exception cref="FieldNotFoundException" />
-        public bool GetBoolean(int tag)
-        {
-            if (!_fields.TryGetValue(tag, out IField? fld))
-                throw new FieldNotFoundException(tag);
-
-            if (fld is FieldBase<bool> boolField)
-                return boolField.Value;
-
-            return BoolConverter.Convert(fld.ToString());
-        }
-
-        /// <summary>
-        /// Gets the string value of a field
-        /// </summary>
-        /// <param name="tag">the FIX tag</param>
-        /// <returns>the string value</returns>
-        /// <exception cref="FieldNotFoundException" />
-        public string GetString(int tag)
-        {
-            if (!_fields.TryGetValue(tag, out IField? fld))
-                throw new FieldNotFoundException(tag);
-
-            return fld.ToString();
-        }
-
-        /// <summary>
-        /// Gets the char value of a field
-        /// </summary>
-        /// <param name="tag">the FIX tag</param>
-        /// <returns>the char value</returns>
-        /// <exception cref="FieldNotFoundException" />
-        public char GetChar(int tag)
-        {
-            if (!_fields.TryGetValue(tag, out IField? fld))
-                throw new FieldNotFoundException(tag);
-
-            if (fld is FieldBase<char> charField)
-                return charField.Value;
-
-            return CharConverter.Convert(fld.ToString());
-        }
-
-        /// <summary>
-        /// Gets the decimal value of a field
-        /// </summary>
-        /// <param name="tag">the FIX tag</param>
-        /// <returns>the decimal value</returns>
-        /// <exception cref="FieldNotFoundException" />
-        public decimal GetDecimal(int tag)
-        {
-            if (!_fields.TryGetValue(tag, out IField? fld))
-                throw new FieldNotFoundException(tag);
-
-            if (fld is FieldBase<decimal> decimalField)
-                return decimalField.Value;
-
-            return DecimalConverter.Convert(fld.ToString());
-        }
-
-        /// <summary>
-        /// Removes specific group instance
-        /// </summary>
-        /// <param name="num">num of group (starting at 1)</param>
-        /// <param name="field">tag of group</param>
-        /// <exception cref="FieldNotFoundException" />
-        public void RemoveGroup(int num, int field)
-        {
-            if (!_groups.TryGetValue(field, out List<Group>? groupList) || num <= 0 || groupList.Count < num)
-                throw new FieldNotFoundException(field);
-
-            if (groupList.Count.Equals(1))
-                _groups.Remove(field);
-            else
-                groupList.RemoveAt(num - 1);
-        }
-
-        /// <summary>
-        /// Replaces specific group instance
-        /// </summary>
-        /// <param name="num">num of group (starting at 1)</param>
-        /// <param name="field">tag of group</param>
-        /// <param name="group">the group to replace it with</param>
-        /// <returns>Group object</returns>
-        /// <exception cref="FieldNotFoundException" />
-        public Group ReplaceGroup(int num, int field, Group group)
-        {
-            if (!_groups.TryGetValue(field, out List<Group>? groupList) || num <= 0 || groupList.Count < num)
-                throw new FieldNotFoundException(field);
-
-            return groupList[num - 1] = group;
-        }
-
-        /// <summary>
-        /// Removes fields and groups in message
-        /// </summary>
-        public virtual void Clear()
-        {
-            _fields.Clear();
-            _groups.Clear();
-        }
-
-        /// <summary>
-        /// Checks emptiness of message
-        /// </summary>
-        /// <returns>true if no fields or groups have been set</returns>
-        public bool IsEmpty()
-        {
-            return (_fields.Count == 0) && (_groups.Count == 0);
-        }
-
-        public int CalculateTotal()
-        {
-            int total = 0;
-            foreach (IField field in _fields.Values)
-            {
-                if (field.Tag != Fields.Tags.CheckSum)
-                    total += field.GetTotal();
-            }
-
-            foreach (IField field in this.RepeatedTags)
-            {
-                if (field.Tag != Fields.Tags.CheckSum)
-                    total += field.GetTotal();
-            }
-
-            foreach (List<Group> groupList in _groups.Values)
-            {
-                foreach (Group group in groupList)
-                    total += group.CalculateTotal();
-            }
-            return total;
-        }
-
-        public int CalculateLength()
-        {
-            int total = 0;
-            foreach (IField field in _fields.Values)
-            {
-                if (field.Tag != Tags.BeginString
-                    && field.Tag != Tags.BodyLength
-                    && field.Tag != Tags.CheckSum)
+                sb.Append(preField + "=" + GetString(preField)).Append(Message.SOH);
+                if (groupCounterTags.Contains(preField))
                 {
-                    total += field.GetLength();
-                }
-            }
-
-            foreach (IField field in this.RepeatedTags)
-            {
-                if (field.Tag != Tags.BeginString
-                    && field.Tag != Tags.BodyLength
-                    && field.Tag != Tags.CheckSum)
-                {
-                    total += field.GetLength();
-                }
-            }
-
-            foreach (List<Group> groupList in _groups.Values)
-            {
-                foreach (Group group in groupList)
-                    total += group.CalculateLength();
-            }
-    
-            return total;
-        }
-
-        /// <summary>
-        /// Creates a FIX (ish) string representation of this FieldMap (does not change the object state)
-        /// </summary>
-        /// <returns></returns>
-        public virtual string CalculateString()
-        {
-            return CalculateString(new StringBuilder(), FieldOrder);
-        }
-
-        /// <summary>
-        /// Creates a FIX (ish) string representation of this FieldMap (does not change the object state)
-        /// </summary>
-        /// <param name="sb"></param>
-        /// <param name="preFields"></param>
-        /// <returns></returns>
-        public virtual string CalculateString(StringBuilder sb, int[] preFields)
-        {
-            HashSet<int> groupCounterTags = new(_groups.Keys);
-            
-            foreach (int preField in preFields)
-            {
-                if (IsSetField(preField))
-                {
-                    sb.Append(preField + "=" + GetString(preField)).Append(Message.SOH);
-                    if (groupCounterTags.Contains(preField))
-                    {
-                        List<Group> glist = _groups[preField];
-                        foreach (Group g in glist)
-                            sb.Append(g.CalculateString());
-                    }
-                }
-            }
-
-            foreach (IField field in _fields.Values)
-            {
-                if (groupCounterTags.Contains(field.Tag))
-                    continue;
-                if (preFields.Contains(field.Tag))
-                    continue; //already did this one
-                sb.Append($"{field.Tag}={field.ToString()}");
-                sb.Append(Message.SOH);
-            }
-
-            foreach(int counterTag in _groups.Keys)
-            {
-                if (preFields.Contains(counterTag))
-                    continue; //already did this one
-
-                List<Group> groupList = _groups[counterTag];
-                if (groupList.Count == 0)
-                    continue; //probably unnecessary, but it doesn't hurt to check
-
-                sb.Append(_fields[counterTag].ToStringField());
-                sb.Append(Message.SOH);
-
-                foreach (Group group in groupList)
-                    sb.Append(group.CalculateString());
-            }
-
-            return sb.ToString();
-        }
-
-        /// <summary>
-        /// Get count of items in the repeating group
-        /// </summary>
-        /// <param name="fieldNo">the counter tag of the group</param>
-        /// <returns></returns>
-        public int GroupCount(int fieldNo) {
-            return _groups.TryGetValue(fieldNo, out var group) ? group.Count : 0;
-        }
-
-        /// <summary>
-        /// Return a List containing the counter tag for each group in this message.
-        /// (The returned List is a static copy.)
-        /// </summary>
-        /// <returns></returns>
-        public List<int> GetGroupTags()
-        {
-            return new List<int>(_groups.Keys);
-        }
-
-        /// <summary>
-        /// Read groups via IEnumerable.
-        /// </summary>
-        /// <typeparam name="TGroup">The group class type retrieved by groupCountTag</typeparam>
-        /// <param name="groupCountTag">The FIX group tag</param>
-        /// <returns>retrieved enumerable groups</returns>
-        /// <exception cref="InvalidCastException">If groupCountTag retreives a group that can't be cast to TGroup</exception>
-        public IEnumerable<TGroup> ReadGroups<TGroup>(int groupCountTag) where TGroup : Group
-        {
-            if (IsSetField(groupCountTag) && GetGroupTags().Contains(groupCountTag))
-            {
-                int grpCount = GetInt(groupCountTag);
-
-                for (int grpIndex = 1; grpIndex <= grpCount; grpIndex += 1)
-                {
-                    Group group = GetGroup(grpIndex, groupCountTag);
-                    if(group is not TGroup tgroup)
-                        throw new InvalidCastException($"Can't cast {group.GetType()} to {typeof(TGroup)}");
-                    yield return tgroup;
+                    List<Group> glist = _groups[preField];
+                    foreach (Group g in glist)
+                        sb.Append(g.CalculateString());
                 }
             }
         }
 
-        // IEnumerable<KeyValuePair<int,IField>> Member
-        public IEnumerator<KeyValuePair<int, IField>> GetEnumerator()
+        foreach (IField field in _fields.Values)
         {
-            return _fields.GetEnumerator();
+            if (groupCounterTags.Contains(field.Tag))
+                continue;
+            if (preFields.Contains(field.Tag))
+                continue; //already did this one
+            sb.Append($"{field.Tag}={field.ToString()}");
+            sb.Append(Message.SOH);
         }
 
-        // IEnumerable Member
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        foreach(int counterTag in _groups.Keys)
         {
-            return _fields.GetEnumerator();
+            if (preFields.Contains(counterTag))
+                continue; //already did this one
+
+            List<Group> groupList = _groups[counterTag];
+            if (groupList.Count == 0)
+                continue; //probably unnecessary, but it doesn't hurt to check
+
+            sb.Append(_fields[counterTag].ToStringField());
+            sb.Append(Message.SOH);
+
+            foreach (Group group in groupList)
+                sb.Append(group.CalculateString());
         }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Get count of items in the repeating group
+    /// </summary>
+    /// <param name="fieldNo">the counter tag of the group</param>
+    /// <returns></returns>
+    public int GroupCount(int fieldNo) {
+        return _groups.TryGetValue(fieldNo, out var group) ? group.Count : 0;
+    }
+
+    /// <summary>
+    /// Return a List containing the counter tag for each group in this message.
+    /// (The returned List is a static copy.)
+    /// </summary>
+    /// <returns></returns>
+    public List<int> GetGroupTags()
+    {
+        return new List<int>(_groups.Keys);
+    }
+
+    /// <summary>
+    /// Read groups via IEnumerable.
+    /// </summary>
+    /// <typeparam name="TGroup">The group class type retrieved by groupCountTag</typeparam>
+    /// <param name="groupCountTag">The FIX group tag</param>
+    /// <returns>retrieved enumerable groups</returns>
+    /// <exception cref="InvalidCastException">If groupCountTag retreives a group that can't be cast to TGroup</exception>
+    public IEnumerable<TGroup> ReadGroups<TGroup>(int groupCountTag) where TGroup : Group
+    {
+        if (IsSetField(groupCountTag) && GetGroupTags().Contains(groupCountTag))
+        {
+            int grpCount = GetInt(groupCountTag);
+
+            for (int grpIndex = 1; grpIndex <= grpCount; grpIndex += 1)
+            {
+                Group group = GetGroup(grpIndex, groupCountTag);
+                if(group is not TGroup tgroup)
+                    throw new InvalidCastException($"Can't cast {group.GetType()} to {typeof(TGroup)}");
+                yield return tgroup;
+            }
+        }
+    }
+
+    // IEnumerable<KeyValuePair<int,IField>> Member
+    public IEnumerator<KeyValuePair<int, IField>> GetEnumerator()
+    {
+        return _fields.GetEnumerator();
+    }
+
+    // IEnumerable Member
+    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+    {
+        return _fields.GetEnumerator();
     }
 }

--- a/QuickFIXn/Message/Message.cs
+++ b/QuickFIXn/Message/Message.cs
@@ -6,1009 +6,1008 @@ using System.Collections.Generic;
 using QuickFix.DataDictionary;
 using DD = QuickFix.DataDictionary.DataDictionary;
 
-namespace QuickFix
+namespace QuickFix;
+
+/// <summary>
+/// Represents a FIX message
+/// </summary>
+public class Message : FieldMap
 {
+    public const char SOH = '\u0001';
+
     /// <summary>
-    /// Represents a FIX message
+    /// If message is invalid, then this is set to the tag that caused it
     /// </summary>
-    public class Message : FieldMap
+    private int _invalidField = 0;
+
+    private bool _isValid = false;
+
+    public Header Header { get; }
+    public Trailer Trailer { get; }
+
+    public Message()
     {
-        public const char SOH = '\u0001';
+        Header = new Header();
+        Trailer = new Trailer();
+        _isValid = true;
+    }
 
-        /// <summary>
-        /// If message is invalid, then this is set to the tag that caused it
-        /// </summary>
-        private int _invalidField = 0;
+    public Message(
+        string msgStr,
+        bool validate = true)
+        : this(msgStr, null, null, validate)
+    { }
 
-        private bool _isValid = false;
+    /// <summary>
+    /// </summary>
+    /// <param name="msgstr"></param>
+    /// <param name="transportDict">(if FIX4, transportDict and appDict should be the same)</param>
+    /// <param name="appDict">(if FIX4, transportDict and appDict should be the same)</param>
+    /// <param name="validate"></param>
+    public Message(string msgstr, DD? transportDict, DD? appDict, bool validate)
+        : this()
+    {
+        PopulateHeaderFromMessageString(msgstr);
+        if (IsAdmin())
+            FromString(msgstr, validate, transportDict, transportDict, null, false);
+        else
+            FromString(msgstr, validate, transportDict, appDict, null, false);
+    }
 
-        public Header Header { get; }
-        public Trailer Trailer { get; }
+    public Message(Message src)
+        : base(src)
+    {
+        Header = new Header(src.Header);
+        Trailer = new Trailer(src.Trailer);
+        _isValid = src._isValid;
+        _invalidField = src._invalidField;
+    }
 
-        public Message()
-        {
-            Header = new Header();
-            Trailer = new Trailer();
-            _isValid = true;
-        }
+    #region Static Methods
 
-        public Message(
-            string msgStr,
-            bool validate = true)
-            : this(msgStr, null, null, validate)
-        { }
+    public static bool IsAdminMsgType(string msgType)
+    {
+        return msgType.Length == 1 && "0A12345n".Contains(msgType[0]);
+    }
 
-        /// <summary>
-        /// </summary>
-        /// <param name="msgstr"></param>
-        /// <param name="transportDict">(if FIX4, transportDict and appDict should be the same)</param>
-        /// <param name="appDict">(if FIX4, transportDict and appDict should be the same)</param>
-        /// <param name="validate"></param>
-        public Message(string msgstr, DD? transportDict, DD? appDict, bool validate)
-            : this()
-        {
-            PopulateHeaderFromMessageString(msgstr);
-            if (IsAdmin())
-                FromString(msgstr, validate, transportDict, transportDict, null, false);
-            else
-                FromString(msgstr, validate, transportDict, appDict, null, false);
-        }
+    /// <summary>
+    /// Parse the message type (tag 35) from a FIX string
+    /// </summary>
+    /// <param name="fixstring">the FIX string to parse</param>
+    /// <returns>the message type as a MsgType object</returns>
+    /// <exception cref="MessageParseError">if 35 tag is missing or malformed</exception>
+    public static MsgType IdentifyType(string fixstring)
+    {
+        return new MsgType(GetMsgType(fixstring));
+    }
 
-        public Message(Message src)
-            : base(src)
-        {
-            Header = new Header(src.Header);
-            Trailer = new Trailer(src.Trailer);
-            _isValid = src._isValid;
-            _invalidField = src._invalidField;
-        }
+    public static int ExtractFieldTag(string msgstr, int pos)
+    {
+        int tagend = msgstr.IndexOf('=', pos);
+        int tag = Convert.ToInt32(msgstr.Substring(pos, tagend - pos));
+        return tag;
+    }
 
-        #region Static Methods
-
-        public static bool IsAdminMsgType(string msgType)
-        {
-            return msgType.Length == 1 && "0A12345n".Contains(msgType[0]);
-        }
-
-        /// <summary>
-        /// Parse the message type (tag 35) from a FIX string
-        /// </summary>
-        /// <param name="fixstring">the FIX string to parse</param>
-        /// <returns>the message type as a MsgType object</returns>
-        /// <exception cref="MessageParseError">if 35 tag is missing or malformed</exception>
-        public static MsgType IdentifyType(string fixstring)
-        {
-            return new MsgType(GetMsgType(fixstring));
-        }
-
-        public static int ExtractFieldTag(string msgstr, int pos)
+    public static StringField ExtractDataField(string msgstr, int dataLength, ref int pos)
+    {
+        try
         {
             int tagend = msgstr.IndexOf('=', pos);
             int tag = Convert.ToInt32(msgstr.Substring(pos, tagend - pos));
-            return tag;
+            pos = tagend + 1;
+            StringField field = new StringField(tag, msgstr.Substring(pos, dataLength));
+
+            pos += dataLength + 1;
+            return field;
         }
-
-        public static StringField ExtractDataField(string msgstr, int dataLength, ref int pos)
+        catch (ArgumentOutOfRangeException e)
         {
-            try
-            {
-                int tagend = msgstr.IndexOf('=', pos);
-                int tag = Convert.ToInt32(msgstr.Substring(pos, tagend - pos));
-                pos = tagend + 1;
-                StringField field = new StringField(tag, msgstr.Substring(pos, dataLength));
-
-                pos += dataLength + 1;
-                return field;
-            }
-            catch (ArgumentOutOfRangeException e)
-            {
-                throw new MessageParseError($"Error at position ({pos}) while parsing msg ({msgstr})", e);
-            }
-            catch (OverflowException e)
-            {
-                throw new MessageParseError($"Error at position ({pos}) while parsing msg ({msgstr})", e);
-            }
-            catch (FormatException e)
-            {
-                throw new MessageParseError($"Error at position ({pos}) while parsing msg ({msgstr})", e);
-            }
+            throw new MessageParseError($"Error at position ({pos}) while parsing msg ({msgstr})", e);
         }
-
-        public static StringField ExtractField(string msgstr, ref int pos)
+        catch (OverflowException e)
         {
-            try
-            {
-                int tagend = msgstr.IndexOf('=', pos);
-                int tag = Convert.ToInt32(msgstr.Substring(pos, tagend - pos));
-                pos = tagend + 1;
-                int fieldvalend = msgstr.IndexOf((char)1, pos);
-                StringField field =  new StringField(tag, msgstr.Substring(pos, fieldvalend - pos));
-
-                pos = fieldvalend + 1;
-                return field;
-            }
-            catch (ArgumentOutOfRangeException e)
-            {
-                throw new MessageParseError("Error at position (" + pos + ") while parsing msg (" + msgstr + ")", e);
-            }
-            catch (OverflowException e)
-            {
-                throw new MessageParseError("Error at position (" + pos + ") while parsing msg (" + msgstr + ")", e);
-            }
-            catch (FormatException e)
-            {
-                throw new MessageParseError("Error at position (" + pos + ") while parsing msg (" + msgstr + ")", e);
-            }
+            throw new MessageParseError($"Error at position ({pos}) while parsing msg ({msgstr})", e);
         }
-
-        public static string ExtractBeginString(string msgstr)
+        catch (FormatException e)
         {
-            int i = 0;
-            return ExtractField(msgstr, ref i).Value;
+            throw new MessageParseError($"Error at position ({pos}) while parsing msg ({msgstr})", e);
         }
+    }
 
-        public static bool IsHeaderField(int tag)
+    public static StringField ExtractField(string msgstr, ref int pos)
+    {
+        try
         {
-            switch (tag)
-            {
-                case Tags.BeginString:
-                case Tags.BodyLength:
-                case Tags.MsgType:
-                case Tags.SenderCompID:
-                case Tags.TargetCompID:
-                case Tags.OnBehalfOfCompID:
-                case Tags.DeliverToCompID:
-                case Tags.SecureDataLen:
-                case Tags.MsgSeqNum:
-                case Tags.SenderSubID:
-                case Tags.SenderLocationID:
-                case Tags.TargetSubID:
-                case Tags.TargetLocationID:
-                case Tags.OnBehalfOfSubID:
-                case Tags.OnBehalfOfLocationID:
-                case Tags.DeliverToSubID:
-                case Tags.DeliverToLocationID:
-                case Tags.PossDupFlag:
-                case Tags.PossResend:
-                case Tags.SendingTime:
-                case Tags.OrigSendingTime:
-                case Tags.XmlDataLen:
-                case Tags.XmlData:
-                case Tags.MessageEncoding:
-                case Tags.LastMsgSeqNumProcessed:
-                    // case Tags.OnBehalfOfSendingTime: TODO 
-                    return true;
-                default:
-                    return false;
-            }
+            int tagend = msgstr.IndexOf('=', pos);
+            int tag = Convert.ToInt32(msgstr.Substring(pos, tagend - pos));
+            pos = tagend + 1;
+            int fieldvalend = msgstr.IndexOf((char)1, pos);
+            StringField field =  new StringField(tag, msgstr.Substring(pos, fieldvalend - pos));
+
+            pos = fieldvalend + 1;
+            return field;
         }
-        public static bool IsHeaderField(int tag, DD? dd)
+        catch (ArgumentOutOfRangeException e)
         {
-            if (IsHeaderField(tag))
+            throw new MessageParseError("Error at position (" + pos + ") while parsing msg (" + msgstr + ")", e);
+        }
+        catch (OverflowException e)
+        {
+            throw new MessageParseError("Error at position (" + pos + ") while parsing msg (" + msgstr + ")", e);
+        }
+        catch (FormatException e)
+        {
+            throw new MessageParseError("Error at position (" + pos + ") while parsing msg (" + msgstr + ")", e);
+        }
+    }
+
+    public static string ExtractBeginString(string msgstr)
+    {
+        int i = 0;
+        return ExtractField(msgstr, ref i).Value;
+    }
+
+    public static bool IsHeaderField(int tag)
+    {
+        switch (tag)
+        {
+            case Tags.BeginString:
+            case Tags.BodyLength:
+            case Tags.MsgType:
+            case Tags.SenderCompID:
+            case Tags.TargetCompID:
+            case Tags.OnBehalfOfCompID:
+            case Tags.DeliverToCompID:
+            case Tags.SecureDataLen:
+            case Tags.MsgSeqNum:
+            case Tags.SenderSubID:
+            case Tags.SenderLocationID:
+            case Tags.TargetSubID:
+            case Tags.TargetLocationID:
+            case Tags.OnBehalfOfSubID:
+            case Tags.OnBehalfOfLocationID:
+            case Tags.DeliverToSubID:
+            case Tags.DeliverToLocationID:
+            case Tags.PossDupFlag:
+            case Tags.PossResend:
+            case Tags.SendingTime:
+            case Tags.OrigSendingTime:
+            case Tags.XmlDataLen:
+            case Tags.XmlData:
+            case Tags.MessageEncoding:
+            case Tags.LastMsgSeqNumProcessed:
+                // case Tags.OnBehalfOfSendingTime: TODO
                 return true;
-            if (dd is not null)
-                return dd.IsHeaderField(tag);
-            return false;
+            default:
+                return false;
         }
+    }
+    public static bool IsHeaderField(int tag, DD? dd)
+    {
+        if (IsHeaderField(tag))
+            return true;
+        if (dd is not null)
+            return dd.IsHeaderField(tag);
+        return false;
+    }
 
-        public static bool IsTrailerField(int tag)
+    public static bool IsTrailerField(int tag)
+    {
+        switch (tag)
         {
-            switch (tag)
-            {
-                case Tags.SignatureLength:
-                case Tags.Signature:
-                case Tags.CheckSum:
-                    return true;
-                default:
-                    return false;
-            }
-        }
-
-        public static bool IsTrailerField(int tag, DD? dd)
-        {
-            if (IsTrailerField(tag))
+            case Tags.SignatureLength:
+            case Tags.Signature:
+            case Tags.CheckSum:
                 return true;
-            if (dd is not null)
-                return dd.IsTrailerField(tag);
-            return false;
+            default:
+                return false;
         }
+    }
 
-        private static string GetFieldOrDefault(FieldMap fields, int tag, string defaultValue)
+    public static bool IsTrailerField(int tag, DD? dd)
+    {
+        if (IsTrailerField(tag))
+            return true;
+        if (dd is not null)
+            return dd.IsTrailerField(tag);
+        return false;
+    }
+
+    private static string GetFieldOrDefault(FieldMap fields, int tag, string defaultValue)
+    {
+        if (!fields.IsSetField(tag))
+            return defaultValue;
+
+        try
         {
-            if (!fields.IsSetField(tag))
-                return defaultValue;
+            return fields.GetString(tag);
+        }
+        catch (FieldNotFoundException)
+        {
+            return defaultValue;
+        }
+    }
 
-            try
+    private static SessionID GetReverseSessionId(Message msg)
+    {
+        return new SessionID(
+            GetFieldOrDefault(msg.Header, Tags.BeginString, SessionID.NOT_SET),
+            GetFieldOrDefault(msg.Header, Tags.TargetCompID, SessionID.NOT_SET),
+            GetFieldOrDefault(msg.Header, Tags.TargetSubID, SessionID.NOT_SET),
+            GetFieldOrDefault(msg.Header, Tags.TargetLocationID, SessionID.NOT_SET),
+            GetFieldOrDefault(msg.Header, Tags.SenderCompID, SessionID.NOT_SET),
+            GetFieldOrDefault(msg.Header, Tags.SenderSubID, SessionID.NOT_SET),
+            GetFieldOrDefault(msg.Header, Tags.SenderLocationID, SessionID.NOT_SET)
+        );
+    }
+
+    public static SessionID GetReverseSessionId(string msg)
+    {
+        Message m = new Message(msg);
+        return GetReverseSessionId(m);
+    }
+
+    /// <summary>
+    /// Parse the message type (tag 35) from a FIX string
+    /// </summary>
+    /// <param name="fixstring">the FIX string to parse</param>
+    /// <returns>message type</returns>
+    /// <exception cref="MessageParseError">if 35 tag is missing or malformed</exception>
+    public static string GetMsgType(string fixstring)
+    {
+        // Note: This is faster than regex.  See stats from https://github.com/connamara/quickfixn/pull/910
+        ReadOnlySpan<char> chars = fixstring.AsSpan();
+        int l = 0;
+        int r = 1;
+
+        if (chars.Length > 0 && chars[0] == SOH) l = 1;
+        while (r < chars.Length)
+        {
+            if (chars[r] == SOH)
             {
-                return fields.GetString(tag);
-            }
-            catch (FieldNotFoundException)
-            {
-                return defaultValue;
-            }
-        }
-
-        private static SessionID GetReverseSessionId(Message msg)
-        {
-            return new SessionID(
-                GetFieldOrDefault(msg.Header, Tags.BeginString, SessionID.NOT_SET),
-                GetFieldOrDefault(msg.Header, Tags.TargetCompID, SessionID.NOT_SET),
-                GetFieldOrDefault(msg.Header, Tags.TargetSubID, SessionID.NOT_SET),
-                GetFieldOrDefault(msg.Header, Tags.TargetLocationID, SessionID.NOT_SET),
-                GetFieldOrDefault(msg.Header, Tags.SenderCompID, SessionID.NOT_SET),
-                GetFieldOrDefault(msg.Header, Tags.SenderSubID, SessionID.NOT_SET),
-                GetFieldOrDefault(msg.Header, Tags.SenderLocationID, SessionID.NOT_SET)
-            );
-        }
-
-        public static SessionID GetReverseSessionId(string msg)
-        {
-            Message m = new Message(msg);
-            return GetReverseSessionId(m);
-        }
-
-        /// <summary>
-        /// Parse the message type (tag 35) from a FIX string
-        /// </summary>
-        /// <param name="fixstring">the FIX string to parse</param>
-        /// <returns>message type</returns>
-        /// <exception cref="MessageParseError">if 35 tag is missing or malformed</exception>
-        public static string GetMsgType(string fixstring)
-        {
-            // Note: This is faster than regex.  See stats from https://github.com/connamara/quickfixn/pull/910
-            ReadOnlySpan<char> chars = fixstring.AsSpan();
-            int l = 0;
-            int r = 1;
-
-            if (chars.Length > 0 && chars[0] == SOH) l = 1;
-            while (r < chars.Length)
-            {
-                if (chars[r] == SOH)
+                if (r - l >= 4 &&
+                    chars[l] == '3' &&
+                    chars[l + 1] == '5' &&
+                    chars[l + 2] == '=')
                 {
-                    if (r - l >= 4 &&
-                        chars[l] == '3' &&
-                        chars[l + 1] == '5' &&
-                        chars[l + 2] == '=')
-                    {
-                        return new string(chars[(l + 3)..r]);
-                    }
-
-                    l = r + 1;
+                    return new string(chars[(l + 3)..r]);
                 }
 
-                r++;
+                l = r + 1;
             }
 
-            throw new MessageParseError("Missing or malformed tag 35 in msg: " + fixstring);
+            r++;
         }
 
-        public static ApplVerID GetApplVerID(string beginString)
+        throw new MessageParseError("Missing or malformed tag 35 in msg: " + fixstring);
+    }
+
+    public static ApplVerID GetApplVerID(string beginString)
+    {
+        switch (beginString)
         {
-            switch (beginString)
+            case FixValues.BeginString.FIX40:
+                return new ApplVerID(ApplVerID.FIX40);
+            case FixValues.BeginString.FIX41:
+                return new ApplVerID(ApplVerID.FIX41);
+            case FixValues.BeginString.FIX42:
+                return new ApplVerID(ApplVerID.FIX42);
+            case FixValues.BeginString.FIX43:
+                return new ApplVerID(ApplVerID.FIX43);
+            case FixValues.BeginString.FIX44:
+                return new ApplVerID(ApplVerID.FIX44);
+            case FixValues.BeginString.FIX50:
+                return new ApplVerID(ApplVerID.FIX50);
+            case FixValues.BeginString.FIX50SP1:
+                return new ApplVerID(ApplVerID.FIX50SP1);
+            case FixValues.BeginString.FIX50SP2:
+                return new ApplVerID(ApplVerID.FIX50SP2);
+            default:
+                throw new ArgumentException($"ApplVerID for {beginString} not supported");
+        }
+    }
+
+    #endregion
+
+    public override void Clear()
+    {
+        _invalidField = 0;
+        Header.Clear();
+        base.Clear();
+        Trailer.Clear();
+    }
+
+    private void PopulateHeaderFromMessageString(string msgstr)
+    {
+        Clear();
+
+        int pos = 0;
+        int count = 0;
+        while(pos < msgstr.Length)
+        {
+            StringField f = ExtractField(msgstr, ref pos);
+
+            if (count < 3 && Header.HEADER_FIELD_ORDER[count++] != f.Tag)
+                return;
+
+            if(IsHeaderField(f.Tag))
+                Header.SetField(f, false);
+            else
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Creates a Message from a FIX string
+    /// </summary>
+    /// <param name="msgstr"></param>
+    /// <param name="validate"></param>
+    /// <param name="transportDict">(if FIX4, transportDict and appDict should be the same)</param>
+    /// <param name="appDict">(if FIX4, transportDict and appDict will be the same)</param>
+    /// <param name="msgFactory">If null, any groups will be constructed as generic Group objects</param>
+    /// <param name="ignoreBody">(default false) if true, ignores all non-header non-trailer fields.
+    ///   Intended for callers that only need rejection-related information from the header.
+    ///   </param>
+    public void FromString(
+        string msgstr,
+        bool validate,
+        DD? transportDict,
+        DD? appDict,
+        IMessageFactory? msgFactory = null,
+        bool ignoreBody = false)
+    {
+        Clear();
+
+        bool expectingHeader = true;
+        bool expectingBody = true;
+        int count = 0;
+        int pos = 0;
+        IFieldMapSpec? msgMap = null;
+
+        while (pos < msgstr.Length)
+        {
+            StringField? f = null;
+
+            int fieldTag = ExtractFieldTag(msgstr, pos);
+            if (fieldTag == Tags.XmlData)
             {
-                case FixValues.BeginString.FIX40:
-                    return new ApplVerID(ApplVerID.FIX40);
-                case FixValues.BeginString.FIX41:
-                    return new ApplVerID(ApplVerID.FIX41);
-                case FixValues.BeginString.FIX42:
-                    return new ApplVerID(ApplVerID.FIX42);
-                case FixValues.BeginString.FIX43:
-                    return new ApplVerID(ApplVerID.FIX43);
-                case FixValues.BeginString.FIX44:
-                    return new ApplVerID(ApplVerID.FIX44);
-                case FixValues.BeginString.FIX50:
-                    return new ApplVerID(ApplVerID.FIX50);
-                case FixValues.BeginString.FIX50SP1:
-                    return new ApplVerID(ApplVerID.FIX50SP1);
-                case FixValues.BeginString.FIX50SP2:
-                    return new ApplVerID(ApplVerID.FIX50SP2);
-                default:
-                    throw new ArgumentException($"ApplVerID for {beginString} not supported");
+                if (IsHeaderField(Tags.XmlDataLen))
+                    f = ExtractDataField(msgstr, Header.GetInt(Tags.XmlDataLen), ref pos);
+                else if (IsSetField(Tags.XmlDataLen))
+                    f = ExtractDataField(msgstr, GetInt(Tags.XmlDataLen), ref pos);
             }
-        }
 
-        #endregion
+            f ??= ExtractField(msgstr, ref pos);
 
-        public override void Clear()
-        {
-            _invalidField = 0;
-            Header.Clear();
-            base.Clear();
-            Trailer.Clear();
-        }
+            if (validate && (count < 3) && (Header.HEADER_FIELD_ORDER[count++] != f.Tag))
+                throw new InvalidMessage("Header fields out of order");
 
-        private void PopulateHeaderFromMessageString(string msgstr)
-        {
-            Clear();
-
-            int pos = 0;
-            int count = 0;
-            while(pos < msgstr.Length)
+            if (IsHeaderField(f.Tag, transportDict))
             {
-                StringField f = ExtractField(msgstr, ref pos);
+                if (!expectingHeader)
+                {
+                    if (0 == _invalidField)
+                        _invalidField = f.Tag;
+                    _isValid = false;
+                }
 
-                if (count < 3 && Header.HEADER_FIELD_ORDER[count++] != f.Tag)
-                    return;
-                
-                if(IsHeaderField(f.Tag))
-                    Header.SetField(f, false);
-                else
-                    break;
+                if (Tags.MsgType.Equals(f.Tag))
+                {
+                    string msgType = f.Value;
+                    if (appDict is not null)
+                    {
+                        msgMap = appDict.GetMapForMessage(msgType);
+                    }
+                }
+
+                if (!Header.SetField(f, false))
+                    Header.RepeatedTags.Add(f);
+
+                if (transportDict is not null && transportDict.Header.IsGroup(f.Tag))
+                {
+                    pos = SetGroup(f, msgstr, pos, Header, transportDict.Header.GetGroupSpec(f.Tag), msgFactory);
+                }
+            }
+            else if (IsTrailerField(f.Tag, transportDict))
+            {
+                expectingHeader = false;
+                expectingBody = false;
+                if (!Trailer.SetField(f, false))
+                    Trailer.RepeatedTags.Add(f);
+
+                if (transportDict is not null && transportDict.Trailer.IsGroup(f.Tag))
+                {
+                    pos = SetGroup(f, msgstr, pos, Trailer, transportDict.Trailer.GetGroup(f.Tag), msgFactory);
+                }
+            }
+            else if (ignoreBody==false)
+            {
+                if (!expectingBody)
+                {
+                    if (0 == _invalidField)
+                        _invalidField = f.Tag;
+                    _isValid = false;
+                }
+
+                expectingHeader = false;
+                if (!SetField(f, false))
+                {
+                    RepeatedTags.Add(f);
+                }
+
+                if(msgMap is not null && msgMap.IsGroup(f.Tag))
+                {
+                    pos = SetGroup(f, msgstr, pos, this, msgMap.GetGroupSpec(f.Tag), msgFactory);
+                }
             }
         }
 
-        /// <summary>
-        /// Creates a Message from a FIX string
-        /// </summary>
-        /// <param name="msgstr"></param>
-        /// <param name="validate"></param>
-        /// <param name="transportDict">(if FIX4, transportDict and appDict should be the same)</param>
-        /// <param name="appDict">(if FIX4, transportDict and appDict will be the same)</param>
-        /// <param name="msgFactory">If null, any groups will be constructed as generic Group objects</param>
-        /// <param name="ignoreBody">(default false) if true, ignores all non-header non-trailer fields.
-        ///   Intended for callers that only need rejection-related information from the header.
-        ///   </param>
-        public void FromString(
-            string msgstr,
-            bool validate,
-            DD? transportDict,
-            DD? appDict,
-            IMessageFactory? msgFactory = null,
-            bool ignoreBody = false)
+        if (validate)
         {
-            Clear();
+            Validate();
+        }
+    }
 
-            bool expectingHeader = true;
-            bool expectingBody = true;
-            int count = 0;
-            int pos = 0;
-            IFieldMapSpec? msgMap = null;
+    /// <summary>
+    /// Creates a Message from FIX JSON Encoding.
+    /// See: https://github.com/FIXTradingCommunity/fix-json-encoding-spec
+    /// </summary>
+    /// <param name="json"></param>
+    /// <param name="validate"></param>
+    /// <param name="transportDict"></param>
+    /// <param name="appDict"></param>
+    /// <param name="msgFactory">If null, any groups will be constructed as generic Group objects</param>
+    public void FromJson(string json, bool validate,
+        DD transportDict,
+        DD appDict,
+        IMessageFactory? msgFactory)
+    {
+        Clear();
 
-            while (pos < msgstr.Length)
-            {
-                StringField? f = null;
+        using (JsonDocument document = JsonDocument.Parse(json)) {
+            string? beginString = document.RootElement.GetProperty("Header").GetProperty("BeginString").GetString();
+            string? msgType     = document.RootElement.GetProperty("Header").GetProperty("MsgType").GetString();
 
-                int fieldTag = ExtractFieldTag(msgstr, pos);
-                if (fieldTag == Tags.XmlData)
-                {
-                    if (IsHeaderField(Tags.XmlDataLen))
-                        f = ExtractDataField(msgstr, Header.GetInt(Tags.XmlDataLen), ref pos);
-                    else if (IsSetField(Tags.XmlDataLen))
-                        f = ExtractDataField(msgstr, GetInt(Tags.XmlDataLen), ref pos);
-                }
-
-                f ??= ExtractField(msgstr, ref pos);
-
-                if (validate && (count < 3) && (Header.HEADER_FIELD_ORDER[count++] != f.Tag))
-                    throw new InvalidMessage("Header fields out of order");
-
-                if (IsHeaderField(f.Tag, transportDict))
-                {
-                    if (!expectingHeader)
-                    {
-                        if (0 == _invalidField)
-                            _invalidField = f.Tag;
-                        _isValid = false;
-                    }
-
-                    if (Tags.MsgType.Equals(f.Tag))
-                    {
-                        string msgType = f.Value;
-                        if (appDict is not null)
-                        {
-                            msgMap = appDict.GetMapForMessage(msgType);
-                        }
-                    }
-
-                    if (!Header.SetField(f, false))
-                        Header.RepeatedTags.Add(f);
-
-                    if (transportDict is not null && transportDict.Header.IsGroup(f.Tag))
-                    {
-                        pos = SetGroup(f, msgstr, pos, Header, transportDict.Header.GetGroupSpec(f.Tag), msgFactory);
-                    }
-                }
-                else if (IsTrailerField(f.Tag, transportDict))
-                {
-                    expectingHeader = false;
-                    expectingBody = false;
-                    if (!Trailer.SetField(f, false))
-                        Trailer.RepeatedTags.Add(f);
-
-                    if (transportDict is not null && transportDict.Trailer.IsGroup(f.Tag))
-                    {
-                        pos = SetGroup(f, msgstr, pos, Trailer, transportDict.Trailer.GetGroup(f.Tag), msgFactory);
-                    }
-                }
-                else if (ignoreBody==false)
-                {
-                    if (!expectingBody)
-                    {
-                        if (0 == _invalidField)
-                            _invalidField = f.Tag;
-                        _isValid = false;
-                    }
-
-                    expectingHeader = false;
-                    if (!SetField(f, false))
-                    {
-                        RepeatedTags.Add(f);
-                    }
-
-                    if(msgMap is not null && msgMap.IsGroup(f.Tag))
-                    {
-                        pos = SetGroup(f, msgstr, pos, this, msgMap.GetGroupSpec(f.Tag), msgFactory);
-                    }
-                }
+            if (beginString is null || msgType is null) {
+                throw new ArgumentException(
+                    $"JSON message has invalid/missing beginString ({beginString}) and/or msgType ({msgType})");
             }
 
-            if (validate)
+            IFieldMapSpec? msgMap = appDict.GetMapForMessage(msgType);
+            FromJson(document.RootElement.GetProperty("Header"),  beginString, msgType, msgMap, msgFactory, transportDict, Header);
+            FromJson(document.RootElement.GetProperty("Body"),    beginString, msgType, msgMap, msgFactory, appDict, this);
+            FromJson(document.RootElement.GetProperty("Trailer"), beginString, msgType, msgMap, msgFactory, transportDict, Trailer);
+        }
+
+        Header.SetField(new BodyLength(BodyLength()), true);
+        Trailer.SetField(new CheckSum(Fields.Converters.CheckSumConverter.Convert(CheckSum())), true);
+
+        if (validate)
+        {
+            Validate();
+        }
+    }
+
+    protected void FromJson(JsonElement jsonElement,
+        string beginString,
+        string msgType,
+        IFieldMapSpec? msgMap,
+        IMessageFactory? msgFactory,
+        DD dataDict,
+        FieldMap fieldMap)
+    {
+        foreach (JsonProperty field in jsonElement.EnumerateObject())
+        {
+            if (dataDict.FieldsByName.TryGetValue(field.Name, out DDField? ddField))
             {
-                Validate();
+                if (msgMap is not null && msgMap.IsGroup(ddField.Tag) && JsonValueKind.Array == field.Value.ValueKind)
+                {
+                    foreach (JsonElement jsonGrp in field.Value.EnumerateArray())
+                    {
+                        IGroupSpec grpSpec = msgMap.GetGroupSpec(ddField.Tag);
+
+                        Group grp = msgFactory?.Create(beginString, msgType, ddField.Tag)
+                            ?? new Group(ddField.Tag, grpSpec.Delim);
+                        FromJson(jsonGrp, beginString, msgType, grpSpec, msgFactory, dataDict, grp);
+                        fieldMap.AddGroup(grp);
+                    }
+                }
+
+                if (JsonValueKind.Array != field.Value.ValueKind)
+                {
+                    fieldMap.SetField(new StringField(ddField.Tag, field.Value.ToString()));
+                }
+            }
+            else
+            {
+                // this may be a custom tag given by number instead of name
+                if (int.TryParse(field.Name, out int customTagNumber))
+                {
+                    fieldMap.SetField(new StringField(customTagNumber, field.Value.ToString()));
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Constructs a group and stores it in this Message object
+    /// </summary>
+    /// <param name="grpNoFld">the group's counter field</param>
+    /// <param name="msgstr">full message string</param>
+    /// <param name="pos">starting character position of group</param>
+    /// <param name="fieldMap">full message as FieldMap</param>
+    /// <param name="groupSpec">group definition structure from dd</param>
+    /// <param name="msgFactory">if null, then this method will use the generic Group class constructor</param>
+    /// <returns></returns>
+    protected int SetGroup(
+        StringField grpNoFld, string msgstr, int pos, FieldMap fieldMap, IGroupSpec groupSpec,
+        IMessageFactory? msgFactory)
+    {
+        int grpEntryDelimiterTag = groupSpec.Delim;
+        int grpPos = pos;
+        Group? grp = null; // the group entry being constructed
+
+        while (pos < msgstr.Length)
+        {
+            grpPos = pos;
+            StringField f = ExtractField(msgstr, ref pos);
+            if (f.Tag == grpEntryDelimiterTag)
+            {
+                // This is the start of a group entry.
+
+                if (grp is not null)
+                {
+                    // We were already building an entry, so the delimiter means it's done.
+                    fieldMap.AddGroup(grp, false);
+                }
+
+                // Create a new group!
+                grp = msgFactory?.Create(ExtractBeginString(msgstr), GetMsgType(msgstr), grpNoFld.Tag)
+                    ?? new Group(grpNoFld.Tag, grpEntryDelimiterTag);
+            }
+            else if (!groupSpec.IsField(f.Tag))
+            {
+                // This field is not in the group, thus the repeating group is done.
+                if (grp is not null)
+                {
+                    fieldMap.AddGroup(grp, false);
+                }
+                return grpPos;
+            }
+            else if(groupSpec.IsField(f.Tag) && grp is not null && grp.IsSetField(f.Tag))
+            {
+                // Tag is appearing for the second time within a group element.
+                // Presumably the sender didn't set the delimiter (or their DD has a different delimiter).
+                throw new RepeatedTagWithoutGroupDelimiterTagException(grpNoFld.Tag, f.Tag);
+            }
+
+            if (grp is null)
+            {
+                // This means we got into the group's fields without finding a delimiter tag.
+                throw new GroupDelimiterTagException(grpNoFld.Tag, grpEntryDelimiterTag);
+            }
+
+            // f is just a field in our group entry.  Add it and iterate again.
+            grp.SetField(f);
+            if(groupSpec.IsGroup(f.Tag))
+            {
+                // f is a counter for a nested group.  Recurse!
+                pos = SetGroup(f, msgstr, pos, grp, groupSpec.GetGroupSpec(f.Tag), msgFactory);
+            }
+
+            // rare situation: if message ends on an in-group field (which means it lacks a checksum),
+            //   then this logic is needed here to actually write the group (because this loop won't run again)
+            if (pos == msgstr.Length) {
+                fieldMap.AddGroup(grp, false);
+                return pos;
             }
         }
 
-        /// <summary>
-        /// Creates a Message from FIX JSON Encoding.
-        /// See: https://github.com/FIXTradingCommunity/fix-json-encoding-spec
-        /// </summary>
-        /// <param name="json"></param>
-        /// <param name="validate"></param>
-        /// <param name="transportDict"></param>
-        /// <param name="appDict"></param>
-        /// <param name="msgFactory">If null, any groups will be constructed as generic Group objects</param>
-        public void FromJson(string json, bool validate,
-            DD transportDict,
-            DD appDict,
-            IMessageFactory? msgFactory)
+        return grpPos;
+    }
+
+    /// <summary>
+    /// Check if this message was deemed valid.
+    /// </summary>
+    /// <param name="problemField">If invalid, then this is set to the field that is the problem</param>
+    /// <returns></returns>
+    public bool HasValidStructure(out int problemField) {
+        problemField = _isValid ? 0 : _invalidField;
+        return _isValid;
+    }
+
+    public void Validate()
+    {
+        try
         {
-            Clear();
+            int receivedBodyLength = Header.GetInt(Tags.BodyLength);
+            if (BodyLength() != receivedBodyLength)
+                throw new InvalidMessage("Expected BodyLength=" + BodyLength() + ", Received BodyLength=" + receivedBodyLength + ", Message.SeqNum=" + Header.GetULong(Tags.MsgSeqNum));
 
-            using (JsonDocument document = JsonDocument.Parse(json)) {
-                string? beginString = document.RootElement.GetProperty("Header").GetProperty("BeginString").GetString();
-                string? msgType     = document.RootElement.GetProperty("Header").GetProperty("MsgType").GetString();
+            int receivedCheckSum = Trailer.GetInt(Tags.CheckSum);
+            if (CheckSum() != receivedCheckSum)
+                throw new InvalidMessage("Expected CheckSum=" + CheckSum() + ", Received CheckSum=" + receivedCheckSum + ", Message.SeqNum=" + Header.GetULong(Tags.MsgSeqNum));
+        }
+        catch (FieldNotFoundException e)
+        {
+            throw new InvalidMessage("BodyLength or CheckSum missing", e);
+        }
+        catch (FieldConvertError e)
+        {
+            throw new InvalidMessage("BodyLength or Checksum has wrong format", e);
+        }
+    }
 
-                if (beginString is null || msgType is null) {
-                    throw new ArgumentException(
-                        $"JSON message has invalid/missing beginString ({beginString}) and/or msgType ({msgType})");
+    public void ReverseRoute(Header header)
+    {
+        // required routing tags
+        Header.RemoveField(Tags.BeginString);
+        Header.RemoveField(Tags.SenderCompID);
+        Header.RemoveField(Tags.SenderSubID);
+        Header.RemoveField(Tags.SenderLocationID);
+        Header.RemoveField(Tags.TargetCompID);
+        Header.RemoveField(Tags.TargetSubID);
+        Header.RemoveField(Tags.TargetLocationID);
+
+        if (header.IsSetField(Tags.BeginString))
+        {
+            string beginString = header.GetString(Tags.BeginString);
+            if (beginString.Length > 0)
+                Header.SetField(new BeginString(beginString));
+
+            Header.RemoveField(Tags.OnBehalfOfLocationID);
+            Header.RemoveField(Tags.DeliverToLocationID);
+
+            if (string.CompareOrdinal(beginString, "FIX.4.1") >= 0)
+            {
+                if (header.IsSetField(Tags.OnBehalfOfLocationID))
+                {
+                    string onBehalfOfLocationId = header.GetString(Tags.OnBehalfOfLocationID);
+                    if (onBehalfOfLocationId.Length > 0)
+                        Header.SetField(new DeliverToLocationID(onBehalfOfLocationId));
                 }
 
-                IFieldMapSpec? msgMap = appDict.GetMapForMessage(msgType);
-                FromJson(document.RootElement.GetProperty("Header"),  beginString, msgType, msgMap, msgFactory, transportDict, Header);
-                FromJson(document.RootElement.GetProperty("Body"),    beginString, msgType, msgMap, msgFactory, appDict, this);
-                FromJson(document.RootElement.GetProperty("Trailer"), beginString, msgType, msgMap, msgFactory, transportDict, Trailer);
+                if (header.IsSetField(Tags.DeliverToLocationID))
+                {
+                    string deliverToLocationId = header.GetString(Tags.DeliverToLocationID);
+                    if (deliverToLocationId.Length > 0)
+                        Header.SetField(new OnBehalfOfLocationID(deliverToLocationId));
+                }
             }
+        }
 
+        if (header.IsSetField(Tags.SenderCompID))
+        {
+            SenderCompID senderCompId = new SenderCompID();
+            header.GetField(senderCompId);
+            if (senderCompId.Value.Length > 0)
+                Header.SetField(new TargetCompID(senderCompId.Value));
+        }
+
+        if (header.IsSetField(Tags.SenderSubID))
+        {
+            SenderSubID senderSubId = new SenderSubID();
+            header.GetField(senderSubId);
+            if (senderSubId.Value.Length > 0)
+                Header.SetField(new TargetSubID(senderSubId.Value));
+        }
+
+        if (header.IsSetField(Tags.SenderLocationID))
+        {
+            SenderLocationID senderLocationId = new SenderLocationID();
+            header.GetField(senderLocationId);
+            if (senderLocationId.Value.Length > 0)
+                Header.SetField(new TargetLocationID(senderLocationId.Value));
+        }
+
+        if (header.IsSetField(Tags.TargetCompID))
+        {
+            TargetCompID targetCompId = new TargetCompID();
+            header.GetField(targetCompId);
+            if (targetCompId.Value.Length > 0)
+                Header.SetField(new SenderCompID(targetCompId.Value));
+        }
+
+        if (header.IsSetField(Tags.TargetSubID))
+        {
+            TargetSubID targetSubId = new TargetSubID();
+            header.GetField(targetSubId);
+            if (targetSubId.Value.Length > 0)
+                Header.SetField(new SenderSubID(targetSubId.Value));
+        }
+
+        if (header.IsSetField(Tags.TargetLocationID))
+        {
+            TargetLocationID targetLocationId = new TargetLocationID();
+            header.GetField(targetLocationId);
+            if (targetLocationId.Value.Length > 0)
+                Header.SetField(new SenderLocationID(targetLocationId.Value));
+        }
+
+        // optional routing tags
+        Header.RemoveField(Tags.OnBehalfOfCompID);
+        Header.RemoveField(Tags.OnBehalfOfSubID);
+        Header.RemoveField(Tags.DeliverToCompID);
+        Header.RemoveField(Tags.DeliverToSubID);
+
+        if(header.IsSetField(Tags.OnBehalfOfCompID))
+        {
+            string onBehalfOfCompId = header.GetString(Tags.OnBehalfOfCompID);
+            if(onBehalfOfCompId.Length > 0)
+                Header.SetField(new DeliverToCompID(onBehalfOfCompId));
+        }
+
+        if(header.IsSetField(Tags.OnBehalfOfSubID))
+        {
+            string onBehalfOfSubId = header.GetString(  Tags.OnBehalfOfSubID);
+            if(onBehalfOfSubId.Length > 0)
+                Header.SetField(new DeliverToSubID(onBehalfOfSubId));
+        }
+
+        if(header.IsSetField(Tags.DeliverToCompID))
+        {
+            string deliverToCompId = header.GetString(Tags.DeliverToCompID);
+            if(deliverToCompId.Length > 0)
+                Header.SetField(new OnBehalfOfCompID(deliverToCompId));
+        }
+
+        if(header.IsSetField(Tags.DeliverToSubID))
+        {
+            string deliverToSubId = header.GetString(Tags.DeliverToSubID);
+            if(deliverToSubId.Length > 0)
+                Header.SetField(new OnBehalfOfSubID(deliverToSubId));
+        }
+    }
+
+    public int CheckSum()
+    {
+        return (
+            (Header.CalculateTotal()
+            + CalculateTotal()
+            + Trailer.CalculateTotal()) % 256);
+    }
+
+    public bool IsAdmin()
+    {
+        return Header.IsSetField(Tags.MsgType) && IsAdminMsgType(Header.GetString(Tags.MsgType));
+    }
+
+    public bool IsApp()
+    {
+        return Header.IsSetField(Tags.MsgType) && !IsAdminMsgType(Header.GetString(Tags.MsgType));
+    }
+
+    /// <summary>
+    /// FIXME less operator new
+    /// </summary>
+    /// <param name="sessionId"></param>
+    public void SetSessionID(SessionID sessionId)
+    {
+        Header.SetField(new BeginString(sessionId.BeginString));
+        Header.SetField(new SenderCompID(sessionId.SenderCompID));
+        if (SessionID.IsSet(sessionId.SenderSubID))
+            Header.SetField(new SenderSubID(sessionId.SenderSubID));
+        if (SessionID.IsSet(sessionId.SenderLocationID))
+            Header.SetField(new SenderLocationID(sessionId.SenderLocationID));
+        Header.SetField(new TargetCompID(sessionId.TargetCompID));
+        if (SessionID.IsSet(sessionId.TargetSubID))
+            Header.SetField(new TargetSubID(sessionId.TargetSubID));
+        if (SessionID.IsSet(sessionId.TargetLocationID))
+            Header.SetField(new TargetLocationID(sessionId.TargetLocationID));
+    }
+
+    public SessionID GetSessionID(Message m)
+    {
+        bool isSetSenderSubId = m.Header.IsSetField(Tags.SenderSubID);
+        bool isSetSenderLocationId = m.Header.IsSetField(Tags.SenderLocationID);
+        bool isSetTargetSubId = m.Header.IsSetField(Tags.TargetSubID);
+        bool isSetTargetLocationId = m.Header.IsSetField(Tags.TargetLocationID);
+
+        if (isSetSenderSubId && isSetSenderLocationId && isSetTargetSubId && isSetTargetLocationId)
+            return new SessionID(m.Header.GetString(Tags.BeginString),
+                m.Header.GetString(Tags.SenderCompID), m.Header.GetString(Tags.SenderSubID), m.Header.GetString(Tags.SenderLocationID),
+                m.Header.GetString(Tags.TargetCompID), m.Header.GetString(Tags.TargetSubID), m.Header.GetString(Tags.TargetLocationID));
+
+        if (isSetSenderSubId && isSetTargetSubId)
+            return new SessionID(m.Header.GetString(Tags.BeginString),
+                m.Header.GetString(Tags.SenderCompID), m.Header.GetString(Tags.SenderSubID),
+                m.Header.GetString(Tags.TargetCompID), m.Header.GetString(Tags.TargetSubID));
+
+        return new SessionID(
+            m.Header.GetString(Tags.BeginString),
+            m.Header.GetString(Tags.SenderCompID),
+            m.Header.GetString(Tags.TargetCompID));
+    }
+
+    private readonly Object _lockConstructString = new Object();
+    /// <summary>
+    /// Update BodyLength in Header, update CheckSum in Trailer, and return a FIX string.
+    /// (This function changes the object state!)
+    /// </summary>
+    /// <returns></returns>
+    public string ConstructString()
+    {
+        lock (_lockConstructString)
+        {
             Header.SetField(new BodyLength(BodyLength()), true);
             Trailer.SetField(new CheckSum(Fields.Converters.CheckSumConverter.Convert(CheckSum())), true);
 
-            if (validate)
-            {
-                Validate();
-            }
-        }
-
-        protected void FromJson(JsonElement jsonElement,
-            string beginString,
-            string msgType,
-            IFieldMapSpec? msgMap,
-            IMessageFactory? msgFactory,
-            DD dataDict,
-            FieldMap fieldMap)
-        {
-            foreach (JsonProperty field in jsonElement.EnumerateObject())
-            {
-                if (dataDict.FieldsByName.TryGetValue(field.Name, out DDField? ddField))
-                {
-                    if (msgMap is not null && msgMap.IsGroup(ddField.Tag) && JsonValueKind.Array == field.Value.ValueKind)
-                    {
-                        foreach (JsonElement jsonGrp in field.Value.EnumerateArray())
-                        {
-                            IGroupSpec grpSpec = msgMap.GetGroupSpec(ddField.Tag);
-
-                            Group grp = msgFactory?.Create(beginString, msgType, ddField.Tag)
-                                ?? new Group(ddField.Tag, grpSpec.Delim);
-                            FromJson(jsonGrp, beginString, msgType, grpSpec, msgFactory, dataDict, grp);
-                            fieldMap.AddGroup(grp);
-                        }
-                    }
-
-                    if (JsonValueKind.Array != field.Value.ValueKind)
-                    {
-                        fieldMap.SetField(new StringField(ddField.Tag, field.Value.ToString()));
-                    }
-                }
-                else
-                {
-                    // this may be a custom tag given by number instead of name
-                    if (int.TryParse(field.Name, out int customTagNumber))
-                    {
-                        fieldMap.SetField(new StringField(customTagNumber, field.Value.ToString()));
-                    }
-                }
-            }
-        }
-
-        /// <summary>
-        /// Constructs a group and stores it in this Message object
-        /// </summary>
-        /// <param name="grpNoFld">the group's counter field</param>
-        /// <param name="msgstr">full message string</param>
-        /// <param name="pos">starting character position of group</param>
-        /// <param name="fieldMap">full message as FieldMap</param>
-        /// <param name="groupSpec">group definition structure from dd</param>
-        /// <param name="msgFactory">if null, then this method will use the generic Group class constructor</param>
-        /// <returns></returns>
-        protected int SetGroup(
-            StringField grpNoFld, string msgstr, int pos, FieldMap fieldMap, IGroupSpec groupSpec,
-            IMessageFactory? msgFactory)
-        {
-            int grpEntryDelimiterTag = groupSpec.Delim;
-            int grpPos = pos;
-            Group? grp = null; // the group entry being constructed
-
-            while (pos < msgstr.Length)
-            {
-                grpPos = pos;
-                StringField f = ExtractField(msgstr, ref pos);
-                if (f.Tag == grpEntryDelimiterTag)
-                {
-                    // This is the start of a group entry.
-
-                    if (grp is not null)
-                    {
-                        // We were already building an entry, so the delimiter means it's done.
-                        fieldMap.AddGroup(grp, false);
-                    }
-
-                    // Create a new group!
-                    grp = msgFactory?.Create(ExtractBeginString(msgstr), GetMsgType(msgstr), grpNoFld.Tag)
-                        ?? new Group(grpNoFld.Tag, grpEntryDelimiterTag);
-                }
-                else if (!groupSpec.IsField(f.Tag))
-                {
-                    // This field is not in the group, thus the repeating group is done.
-                    if (grp is not null)
-                    {
-                        fieldMap.AddGroup(grp, false);
-                    }
-                    return grpPos;
-                }
-                else if(groupSpec.IsField(f.Tag) && grp is not null && grp.IsSetField(f.Tag))
-                {
-                    // Tag is appearing for the second time within a group element.
-                    // Presumably the sender didn't set the delimiter (or their DD has a different delimiter).
-                    throw new RepeatedTagWithoutGroupDelimiterTagException(grpNoFld.Tag, f.Tag);
-                }
-
-                if (grp is null)
-                {
-                    // This means we got into the group's fields without finding a delimiter tag.
-                    throw new GroupDelimiterTagException(grpNoFld.Tag, grpEntryDelimiterTag);
-                }
-
-                // f is just a field in our group entry.  Add it and iterate again.
-                grp.SetField(f);
-                if(groupSpec.IsGroup(f.Tag))
-                {
-                    // f is a counter for a nested group.  Recurse!
-                    pos = SetGroup(f, msgstr, pos, grp, groupSpec.GetGroupSpec(f.Tag), msgFactory);
-                }
-
-                // rare situation: if message ends on an in-group field (which means it lacks a checksum),
-                //   then this logic is needed here to actually write the group (because this loop won't run again)
-                if (pos == msgstr.Length) {
-                    fieldMap.AddGroup(grp, false);
-                    return pos;
-                }
-            }
-            
-            return grpPos;
-        }
-
-        /// <summary>
-        /// Check if this message was deemed valid.
-        /// </summary>
-        /// <param name="problemField">If invalid, then this is set to the field that is the problem</param>
-        /// <returns></returns>
-        public bool HasValidStructure(out int problemField) {
-            problemField = _isValid ? 0 : _invalidField;
-            return _isValid;
-        }
-
-        public void Validate()
-        {
-            try
-            {
-                int receivedBodyLength = Header.GetInt(Tags.BodyLength);
-                if (BodyLength() != receivedBodyLength)
-                    throw new InvalidMessage("Expected BodyLength=" + BodyLength() + ", Received BodyLength=" + receivedBodyLength + ", Message.SeqNum=" + Header.GetULong(Tags.MsgSeqNum));
-
-                int receivedCheckSum = Trailer.GetInt(Tags.CheckSum);
-                if (CheckSum() != receivedCheckSum)
-                    throw new InvalidMessage("Expected CheckSum=" + CheckSum() + ", Received CheckSum=" + receivedCheckSum + ", Message.SeqNum=" + Header.GetULong(Tags.MsgSeqNum));
-            }
-            catch (FieldNotFoundException e)
-            {
-                throw new InvalidMessage("BodyLength or CheckSum missing", e);
-            }
-            catch (FieldConvertError e)
-            {
-                throw new InvalidMessage("BodyLength or Checksum has wrong format", e);
-            }
-        }
-
-        public void ReverseRoute(Header header)
-        {
-            // required routing tags
-            Header.RemoveField(Tags.BeginString);
-            Header.RemoveField(Tags.SenderCompID);
-            Header.RemoveField(Tags.SenderSubID);
-            Header.RemoveField(Tags.SenderLocationID);
-            Header.RemoveField(Tags.TargetCompID);
-            Header.RemoveField(Tags.TargetSubID);
-            Header.RemoveField(Tags.TargetLocationID);
-
-            if (header.IsSetField(Tags.BeginString))
-            {
-                string beginString = header.GetString(Tags.BeginString);
-                if (beginString.Length > 0)
-                    Header.SetField(new BeginString(beginString));
-
-                Header.RemoveField(Tags.OnBehalfOfLocationID);
-                Header.RemoveField(Tags.DeliverToLocationID);
-
-                if (string.CompareOrdinal(beginString, "FIX.4.1") >= 0)
-                {
-                    if (header.IsSetField(Tags.OnBehalfOfLocationID))
-                    {
-                        string onBehalfOfLocationId = header.GetString(Tags.OnBehalfOfLocationID);
-                        if (onBehalfOfLocationId.Length > 0)
-                            Header.SetField(new DeliverToLocationID(onBehalfOfLocationId));
-                    }
-
-                    if (header.IsSetField(Tags.DeliverToLocationID))
-                    {
-                        string deliverToLocationId = header.GetString(Tags.DeliverToLocationID);
-                        if (deliverToLocationId.Length > 0)
-                            Header.SetField(new OnBehalfOfLocationID(deliverToLocationId));
-                    }
-                }
-            }
-
-            if (header.IsSetField(Tags.SenderCompID))
-            {
-                SenderCompID senderCompId = new SenderCompID();
-                header.GetField(senderCompId);
-                if (senderCompId.Value.Length > 0)
-                    Header.SetField(new TargetCompID(senderCompId.Value));
-            }
-
-            if (header.IsSetField(Tags.SenderSubID))
-            {
-                SenderSubID senderSubId = new SenderSubID();
-                header.GetField(senderSubId);
-                if (senderSubId.Value.Length > 0)
-                    Header.SetField(new TargetSubID(senderSubId.Value));
-            }
-
-            if (header.IsSetField(Tags.SenderLocationID))
-            {
-                SenderLocationID senderLocationId = new SenderLocationID();
-                header.GetField(senderLocationId);
-                if (senderLocationId.Value.Length > 0)
-                    Header.SetField(new TargetLocationID(senderLocationId.Value));
-            }
-
-            if (header.IsSetField(Tags.TargetCompID))
-            {
-                TargetCompID targetCompId = new TargetCompID();
-                header.GetField(targetCompId);
-                if (targetCompId.Value.Length > 0)
-                    Header.SetField(new SenderCompID(targetCompId.Value));
-            }
-
-            if (header.IsSetField(Tags.TargetSubID))
-            {
-                TargetSubID targetSubId = new TargetSubID();
-                header.GetField(targetSubId);
-                if (targetSubId.Value.Length > 0)
-                    Header.SetField(new SenderSubID(targetSubId.Value));
-            }
-
-            if (header.IsSetField(Tags.TargetLocationID))
-            {
-                TargetLocationID targetLocationId = new TargetLocationID();
-                header.GetField(targetLocationId);
-                if (targetLocationId.Value.Length > 0)
-                    Header.SetField(new SenderLocationID(targetLocationId.Value));
-            }
-
-            // optional routing tags
-            Header.RemoveField(Tags.OnBehalfOfCompID);
-            Header.RemoveField(Tags.OnBehalfOfSubID);
-            Header.RemoveField(Tags.DeliverToCompID);
-            Header.RemoveField(Tags.DeliverToSubID);
-
-            if(header.IsSetField(Tags.OnBehalfOfCompID))
-            {
-                string onBehalfOfCompId = header.GetString(Tags.OnBehalfOfCompID);
-                if(onBehalfOfCompId.Length > 0)
-                    Header.SetField(new DeliverToCompID(onBehalfOfCompId));
-            }
-
-            if(header.IsSetField(Tags.OnBehalfOfSubID))
-            {
-                string onBehalfOfSubId = header.GetString(  Tags.OnBehalfOfSubID);
-                if(onBehalfOfSubId.Length > 0)
-                    Header.SetField(new DeliverToSubID(onBehalfOfSubId));
-            }
-
-            if(header.IsSetField(Tags.DeliverToCompID))
-            {
-                string deliverToCompId = header.GetString(Tags.DeliverToCompID);
-                if(deliverToCompId.Length > 0)
-                    Header.SetField(new OnBehalfOfCompID(deliverToCompId));
-            }
-
-            if(header.IsSetField(Tags.DeliverToSubID))
-            {
-                string deliverToSubId = header.GetString(Tags.DeliverToSubID);
-                if(deliverToSubId.Length > 0)
-                    Header.SetField(new OnBehalfOfSubID(deliverToSubId));
-            }
-        }
-
-        public int CheckSum()
-        {
-            return (
-                (Header.CalculateTotal()
-                + CalculateTotal()
-                + Trailer.CalculateTotal()) % 256);
-        }
-
-        public bool IsAdmin()
-        {
-            return Header.IsSetField(Tags.MsgType) && IsAdminMsgType(Header.GetString(Tags.MsgType));
-        }
-
-        public bool IsApp()
-        {
-            return Header.IsSetField(Tags.MsgType) && !IsAdminMsgType(Header.GetString(Tags.MsgType));
-        }
-
-        /// <summary>
-        /// FIXME less operator new
-        /// </summary>
-        /// <param name="sessionId"></param>
-        public void SetSessionID(SessionID sessionId)
-        {
-            Header.SetField(new BeginString(sessionId.BeginString));
-            Header.SetField(new SenderCompID(sessionId.SenderCompID));
-            if (SessionID.IsSet(sessionId.SenderSubID))
-                Header.SetField(new SenderSubID(sessionId.SenderSubID));
-            if (SessionID.IsSet(sessionId.SenderLocationID))
-                Header.SetField(new SenderLocationID(sessionId.SenderLocationID));
-            Header.SetField(new TargetCompID(sessionId.TargetCompID));
-            if (SessionID.IsSet(sessionId.TargetSubID))
-                Header.SetField(new TargetSubID(sessionId.TargetSubID));
-            if (SessionID.IsSet(sessionId.TargetLocationID))
-                Header.SetField(new TargetLocationID(sessionId.TargetLocationID));
-        }
-
-        public SessionID GetSessionID(Message m)
-        {
-            bool isSetSenderSubId = m.Header.IsSetField(Tags.SenderSubID);
-            bool isSetSenderLocationId = m.Header.IsSetField(Tags.SenderLocationID);
-            bool isSetTargetSubId = m.Header.IsSetField(Tags.TargetSubID);
-            bool isSetTargetLocationId = m.Header.IsSetField(Tags.TargetLocationID);
-
-            if (isSetSenderSubId && isSetSenderLocationId && isSetTargetSubId && isSetTargetLocationId)
-                return new SessionID(m.Header.GetString(Tags.BeginString),
-                    m.Header.GetString(Tags.SenderCompID), m.Header.GetString(Tags.SenderSubID), m.Header.GetString(Tags.SenderLocationID),
-                    m.Header.GetString(Tags.TargetCompID), m.Header.GetString(Tags.TargetSubID), m.Header.GetString(Tags.TargetLocationID));
-
-            if (isSetSenderSubId && isSetTargetSubId)
-                return new SessionID(m.Header.GetString(Tags.BeginString),
-                    m.Header.GetString(Tags.SenderCompID), m.Header.GetString(Tags.SenderSubID),
-                    m.Header.GetString(Tags.TargetCompID), m.Header.GetString(Tags.TargetSubID));
-
-            return new SessionID(
-                m.Header.GetString(Tags.BeginString),
-                m.Header.GetString(Tags.SenderCompID),
-                m.Header.GetString(Tags.TargetCompID));
-        }
-
-        private readonly Object _lockConstructString = new Object();
-        /// <summary>
-        /// Update BodyLength in Header, update CheckSum in Trailer, and return a FIX string.
-        /// (This function changes the object state!)
-        /// </summary>
-        /// <returns></returns>
-        public string ConstructString()
-        {
-            lock (_lockConstructString)
-            {
-                Header.SetField(new BodyLength(BodyLength()), true);
-                Trailer.SetField(new CheckSum(Fields.Converters.CheckSumConverter.Convert(CheckSum())), true);
-
-                return Header.CalculateString() + CalculateString() + Trailer.CalculateString();
-            }
-        }
-
-        /// <summary>
-        /// Create a FIX-style string from the message.
-        /// This does NOT add/update BodyLength or CheckSum to the message header, or otherwise change the object state.
-        /// (Use <see cref="ConstructString"/> to compute and add/update BodyLength &amp; CheckSum.)
-        /// </summary>
-        /// <returns></returns>
-        public override string ToString() {
             return Header.CalculateString() + CalculateString() + Trailer.CalculateString();
         }
+    }
 
-        protected int BodyLength()
+    /// <summary>
+    /// Create a FIX-style string from the message.
+    /// This does NOT add/update BodyLength or CheckSum to the message header, or otherwise change the object state.
+    /// (Use <see cref="ConstructString"/> to compute and add/update BodyLength &amp; CheckSum.)
+    /// </summary>
+    /// <returns></returns>
+    public override string ToString() {
+        return Header.CalculateString() + CalculateString() + Trailer.CalculateString();
+    }
+
+    protected int BodyLength()
+    {
+        return Header.CalculateLength() + CalculateLength() + Trailer.CalculateLength();
+    }
+
+    private static string FieldMapToXml(DD? dd, FieldMap fields)
+    {
+        StringBuilder s = new StringBuilder();
+
+        // fields
+        foreach (var f in fields)
         {
-            return Header.CalculateLength() + CalculateLength() + Trailer.CalculateLength();
+           s.Append("<field ");
+           if (dd is not null && dd.FieldsByTag.TryGetValue(f.Key, out var value))
+           {
+               s.Append("name=\"" + value.Name + "\" ");
+           }
+           s.Append("number=\"" + f.Key + "\">");
+           s.Append("<![CDATA[" + f.Value + "]]>");
+           s.Append("</field>");
+        }
+        // now groups
+        List<int> groupTags = fields.GetGroupTags();
+        foreach (int groupTag in groupTags)
+        {
+            for (int counter = 1; counter <= fields.GroupCount(groupTag); counter++)
+            {
+                s.Append("<group>");
+                s.Append(FieldMapToXml(dd, fields.GetGroup(counter, groupTag)));
+                s.Append("</group>");
+            }
         }
 
-        private static string FieldMapToXml(DD? dd, FieldMap fields)
-        {
-            StringBuilder s = new StringBuilder();
+        return s.ToString();
+    }
 
-            // fields
-            foreach (var f in fields)
+
+    /// <summary>
+    /// ToJSON() helper method.
+    /// </summary>
+    /// <returns>an XML string</returns>
+    private static StringBuilder FieldMapToJson(StringBuilder sb, DD? dd, FieldMap fields, bool humanReadableValues, List<int>? tagsToMask, string maskText)
+    {
+        IList<int> numInGroupTagList = fields.GetGroupTags();
+        IList<IField> numInGroupFieldList = new List<IField>();
+
+        // Non-Group Fields
+        foreach (var (_, field) in fields)
+        {
+            if (QuickFix.Fields.CheckSum.TAG == field.Tag)
+                continue; // FIX JSON Encoding does not include CheckSum
+
+            if (numInGroupTagList.Contains(field.Tag))
             {
-               s.Append("<field ");
-               if (dd is not null && dd.FieldsByTag.TryGetValue(f.Key, out var value))
-               {
-                   s.Append("name=\"" + value.Name + "\" ");
-               }
-               s.Append("number=\"" + f.Key + "\">");
-               s.Append("<![CDATA[" + f.Value + "]]>");
-               s.Append("</field>");
-            }
-            // now groups
-            List<int> groupTags = fields.GetGroupTags();
-            foreach (int groupTag in groupTags)
-            {
-                for (int counter = 1; counter <= fields.GroupCount(groupTag); counter++)
-                {
-                    s.Append("<group>");
-                    s.Append(FieldMapToXml(dd, fields.GetGroup(counter, groupTag)));
-                    s.Append("</group>");
-                }
+                numInGroupFieldList.Add(field);
+                continue; // Groups will be handled below
             }
 
-            return s.ToString();
-        }
-
-
-        /// <summary>
-        /// ToJSON() helper method.
-        /// </summary>
-        /// <returns>an XML string</returns>
-        private static StringBuilder FieldMapToJson(StringBuilder sb, DD? dd, FieldMap fields, bool humanReadableValues, List<int>? tagsToMask, string maskText)
-        {
-            IList<int> numInGroupTagList = fields.GetGroupTags();
-            IList<IField> numInGroupFieldList = new List<IField>();
-
-            // Non-Group Fields
-            foreach (var (_, field) in fields)
+            if (dd is not null && dd.FieldsByTag.TryGetValue(field.Tag, out DDField? ddField))
             {
-                if (QuickFix.Fields.CheckSum.TAG == field.Tag)
-                    continue; // FIX JSON Encoding does not include CheckSum
-
-                if (numInGroupTagList.Contains(field.Tag))
+                sb.Append("\"" + ddField.Name + "\":");
+                if (tagsToMask != null && tagsToMask.Contains(field.Tag))
                 {
-                    numInGroupFieldList.Add(field);
-                    continue; // Groups will be handled below
+                    sb.Append("\"" + maskText + "\",");
                 }
-
-                if (dd is not null && dd.FieldsByTag.TryGetValue(field.Tag, out DDField? ddField))
+                else if (humanReadableValues)
                 {
-                    sb.Append("\"" + ddField.Name + "\":");
-                    if (tagsToMask != null && tagsToMask.Contains(field.Tag))
-                    {
-                        sb.Append("\"" + maskText + "\",");
-                    }
-                    else if (humanReadableValues)
-                    {
-                        if (dd.FieldsByTag[field.Tag].EnumDict.TryGetValue(field.ToString(), out var valueDescription))
-                            sb.Append("\"" + valueDescription + "\",");
-                        else
-                            sb.Append("\"" + field + "\",");
-                    }
+                    if (dd.FieldsByTag[field.Tag].EnumDict.TryGetValue(field.ToString(), out var valueDescription))
+                        sb.Append("\"" + valueDescription + "\",");
                     else
-                    {
                         sb.Append("\"" + field + "\",");
-                    }
                 }
                 else
                 {
-                    sb.Append("\"" + field.Tag + "\":");
                     sb.Append("\"" + field + "\",");
                 }
             }
-
-            // Group Fields
-            foreach(IField numInGroupField in numInGroupFieldList)
+            else
             {
-                // The name of the NumInGroup field is the key of the JSON list containing the Group items
-                if (dd is not null && dd.FieldsByTag.TryGetValue(numInGroupField.Tag, out DDField? field))
-                    sb.Append("\"" + field.Name + "\":[");
-                else
-                    sb.Append("\"" + numInGroupField.Tag + "\":[");
-
-                // Populate the JSON list with the Group items
-                for (int counter = 1; counter <= fields.GroupCount(numInGroupField.Tag); counter++)
-                {
-                    sb.Append('{');
-                    FieldMapToJson(sb, dd, fields.GetGroup(counter, numInGroupField.Tag), humanReadableValues, tagsToMask, maskText);
-                    sb.Append("},");
-                }
-
-                // Remove trailing comma
-                if (sb.Length > 0 && sb[^1] == ',')
-                    sb.Remove(sb.Length - 1, 1);
-
-                sb.Append("],");
+                sb.Append("\"" + field.Tag + "\":");
+                sb.Append("\"" + field + "\",");
             }
+        }
+
+        // Group Fields
+        foreach(IField numInGroupField in numInGroupFieldList)
+        {
+            // The name of the NumInGroup field is the key of the JSON list containing the Group items
+            if (dd is not null && dd.FieldsByTag.TryGetValue(numInGroupField.Tag, out DDField? field))
+                sb.Append("\"" + field.Name + "\":[");
+            else
+                sb.Append("\"" + numInGroupField.Tag + "\":[");
+
+            // Populate the JSON list with the Group items
+            for (int counter = 1; counter <= fields.GroupCount(numInGroupField.Tag); counter++)
+            {
+                sb.Append('{');
+                FieldMapToJson(sb, dd, fields.GetGroup(counter, numInGroupField.Tag), humanReadableValues, tagsToMask, maskText);
+                sb.Append("},");
+            }
+
             // Remove trailing comma
             if (sb.Length > 0 && sb[^1] == ',')
                 sb.Remove(sb.Length - 1, 1);
 
-            return sb;
+            sb.Append("],");
+        }
+        // Remove trailing comma
+        if (sb.Length > 0 && sb[^1] == ',')
+            sb.Remove(sb.Length - 1, 1);
+
+        return sb;
+    }
+
+    /// <summary>
+    /// Get a representation of the message as an XML string.
+    /// (NOTE: this is just an ad-hoc XML; it is NOT FIXML.)
+    /// </summary>
+    /// <param name="dataDictionary">if null, then field names cannot and will not be in the output</param>
+    /// <returns>an XML string</returns>
+    public string ToXML(DD? dataDictionary = null)
+    {
+        StringBuilder s = new StringBuilder();
+        s.Append("<message>");
+        s.Append("<header>");
+        s.Append(FieldMapToXml(dataDictionary, Header));
+        s.Append("</header>");
+        s.Append("<body>");
+        s.Append(FieldMapToXml(dataDictionary, this));
+        s.Append("</body>");
+        s.Append("<trailer>");
+        s.Append(FieldMapToXml(dataDictionary, Trailer));
+        s.Append("</trailer>");
+        s.Append("</message>");
+        return s.ToString();
+    }
+
+    /// <summary>
+    /// Get a representation of the message as a string in FIX JSON Encoding.
+    /// See: https://github.com/FIXTradingCommunity/fix-json-encoding-spec
+    ///
+    /// Per the FIX JSON Encoding spec, tags are converted to human-readable form, but values are not.
+    /// </summary>
+    /// <param name="dataDictionary">Needed if you want tag names emitted or humanReadableValues to work</param>
+    /// <param name="convertEnumsToDescriptions">
+    ///   True will cause enums to be converted to their description strings, but only if dataDictionary is provided.
+    ///   If true and dataDictionary is null, then throws an ArgumentNullException.
+    /// </param>
+    /// <param name="tagsToMask">Optional list containing field tags to mask from FIX JSON output</param>
+    /// <param name="maskText">Text to use in place of masked values. Defaults to '[HIDDEN]'</param>
+    /// <returns>a JSON string</returns>
+    public string ToJSON(DD? dataDictionary = null, bool convertEnumsToDescriptions = false, List<int>? tagsToMask = null, string maskText = "[HIDDEN]") {
+        if (convertEnumsToDescriptions && dataDictionary is null) {
+            throw new ArgumentNullException(
+                nameof(dataDictionary),
+                $"Must be non-null if '{nameof(convertEnumsToDescriptions)}' is true.");
         }
 
-        /// <summary>
-        /// Get a representation of the message as an XML string.
-        /// (NOTE: this is just an ad-hoc XML; it is NOT FIXML.)
-        /// </summary>
-        /// <param name="dataDictionary">if null, then field names cannot and will not be in the output</param>
-        /// <returns>an XML string</returns>
-        public string ToXML(DD? dataDictionary = null)
-        {
-            StringBuilder s = new StringBuilder();
-            s.Append("<message>");
-            s.Append("<header>");
-            s.Append(FieldMapToXml(dataDictionary, Header));
-            s.Append("</header>");
-            s.Append("<body>");
-            s.Append(FieldMapToXml(dataDictionary, this));
-            s.Append("</body>");
-            s.Append("<trailer>");
-            s.Append(FieldMapToXml(dataDictionary, Trailer));
-            s.Append("</trailer>");
-            s.Append("</message>");
-            return s.ToString();
-        }
-
-        /// <summary>
-        /// Get a representation of the message as a string in FIX JSON Encoding.
-        /// See: https://github.com/FIXTradingCommunity/fix-json-encoding-spec
-        ///
-        /// Per the FIX JSON Encoding spec, tags are converted to human-readable form, but values are not.
-        /// </summary>
-        /// <param name="dataDictionary">Needed if you want tag names emitted or humanReadableValues to work</param>
-        /// <param name="convertEnumsToDescriptions">
-        ///   True will cause enums to be converted to their description strings, but only if dataDictionary is provided.
-        ///   If true and dataDictionary is null, then throws an ArgumentNullException.
-        /// </param>
-        /// <param name="tagsToMask">Optional list containing field tags to mask from FIX JSON output</param>
-        /// <param name="maskText">Text to use in place of masked values. Defaults to '[HIDDEN]'</param>
-        /// <returns>a JSON string</returns>
-        public string ToJSON(DD? dataDictionary = null, bool convertEnumsToDescriptions = false, List<int>? tagsToMask = null, string maskText = "[HIDDEN]") {
-            if (convertEnumsToDescriptions && dataDictionary is null) {
-                throw new ArgumentNullException(
-                    nameof(dataDictionary),
-                    $"Must be non-null if '{nameof(convertEnumsToDescriptions)}' is true.");
-            }
-
-            StringBuilder sb = new StringBuilder().Append('{').Append("\"Header\":{");
-            FieldMapToJson(sb, dataDictionary, Header, convertEnumsToDescriptions, tagsToMask, maskText).Append("},\"Body\":{");
-            FieldMapToJson(sb, dataDictionary, this, convertEnumsToDescriptions, tagsToMask, maskText).Append("},\"Trailer\":{");
-            FieldMapToJson(sb, dataDictionary, Trailer, convertEnumsToDescriptions, tagsToMask, maskText).Append("}}");
-            return sb.ToString();
-        }
+        StringBuilder sb = new StringBuilder().Append('{').Append("\"Header\":{");
+        FieldMapToJson(sb, dataDictionary, Header, convertEnumsToDescriptions, tagsToMask, maskText).Append("},\"Body\":{");
+        FieldMapToJson(sb, dataDictionary, this, convertEnumsToDescriptions, tagsToMask, maskText).Append("},\"Trailer\":{");
+        FieldMapToJson(sb, dataDictionary, Trailer, convertEnumsToDescriptions, tagsToMask, maskText).Append("}}");
+        return sb.ToString();
     }
 }

--- a/QuickFIXn/Message/Message.cs
+++ b/QuickFIXn/Message/Message.cs
@@ -904,17 +904,17 @@ namespace QuickFix
                     continue; // Groups will be handled below
                 }
 
-                if (dd is not null && dd.FieldsByTag.ContainsKey(field.Tag))
+                if (dd is not null && dd.FieldsByTag.TryGetValue(field.Tag, out DDField? ddField))
                 {
-                    sb.Append("\"" + dd.FieldsByTag[field.Tag].Name + "\":");
-                    if (tagsToMask != null && tagsToMask.Contains(field.Tag)) {
+                    sb.Append("\"" + ddField.Name + "\":");
+                    if (tagsToMask != null && tagsToMask.Contains(field.Tag))
+                    {
                         sb.Append("\"" + maskText + "\",");
                     }
-                    else if (humanReadableValues) {
+                    else if (humanReadableValues)
+                    {
                         if (dd.FieldsByTag[field.Tag].EnumDict.TryGetValue(field.ToString(), out var valueDescription))
-                        {
                             sb.Append("\"" + valueDescription + "\",");
-                        }
                         else
                             sb.Append("\"" + field + "\",");
                     }

--- a/QuickFIXn/SessionState.cs
+++ b/QuickFIXn/SessionState.cs
@@ -295,10 +295,7 @@ namespace QuickFix
 
         public void Queue(SeqNumType msgSeqNum, Message msg)
         {
-            if (!MsgQueue.ContainsKey(msgSeqNum))
-            {
-                MsgQueue.Add(msgSeqNum, msg);
-            }
+            MsgQueue.TryAdd(msgSeqNum, msg);
         }
 
         public void ClearQueue()
@@ -308,25 +305,12 @@ namespace QuickFix
 
         public QuickFix.Message? Dequeue(SeqNumType num)
         {
-            if (MsgQueue.ContainsKey(num))
-            {
-                QuickFix.Message msg = MsgQueue[num];
-                MsgQueue.Remove(num);
-                return msg;
-            }
-            return null;
+            return MsgQueue.Remove(num, out Message? msg) ? msg : null;
         }
 
         public Message? Retrieve(SeqNumType msgSeqNum)
         {
-            if (MsgQueue.ContainsKey(msgSeqNum))
-            {
-                Message msg = MsgQueue[msgSeqNum];
-                MsgQueue.Remove(msgSeqNum);
-                return msg;
-            }
-
-            return null;
+            return MsgQueue.Remove(msgSeqNum, out Message? msg) ? msg : null;
         }
 
         /// <summary>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -47,6 +47,7 @@ What's New
 * #956 - fix: FileLog.Clear() broke in 1.13, now fixed again (hansw96/gbirchmeier)
 * #950 - added the ability to mask fields when converting a FIX message to FIX JSON (trevor-bush)
 * #765 - overhaul of DateTimeConverter (Rob-Hague/vyourtchenko/gbirchmeier)
+* #964 - Reduce unnecessary ContainsKey function calls to avoid multiple duplicate key lookups (VAllens)
 
 ### v1.13.1
 * backport #951 to 1.13

--- a/UnitTests/DDFieldTests.cs
+++ b/UnitTests/DDFieldTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using Microsoft.VisualBasic;
 using NUnit.Framework;
 using QuickFix.DataDictionary;
 
@@ -12,15 +11,17 @@ namespace UnitTests
         [Test]
         public void CtorEnum()
         {
-            Dictionary<String, String> enums = new Dictionary<string, string>();
-            enums["a"] = "AAA";
-            enums["b"] = "BBB";
+            Dictionary<string, string> enums = new()
+            {
+                ["a"] = "AAA",
+                ["b"] = "BBB"
+            };
 
-            DDField ddf = new DDField(5, "Foo", enums, "STRING");
+            DDField ddf = new(5, "Foo", enums, "STRING");
 
             Assert.That(5, Is.EqualTo(ddf.Tag));
             Assert.That("Foo", Is.EqualTo(ddf.Name));
-            //Assert.That(enums, Is.EqualTo(ddf.EnumDict));
+            Assert.That(enums, Is.EqualTo(ddf.EnumDict));
             Assert.That("STRING", Is.EqualTo(ddf.FixFldType));
             Assert.That(typeof(QuickFix.Fields.StringField), Is.EqualTo(ddf.FieldType));
 
@@ -31,7 +32,7 @@ namespace UnitTests
         [Test]
         public void CtorMultipleValueFieldWithEnums()
         {
-            DDField ddf = new DDField(111, "MultiX", new Dictionary<string, string>(), "MULTIPLEVALUESTRING");
+            DDField ddf = new(111, "MultiX", new Dictionary<string, string>(), "MULTIPLEVALUESTRING");
 
             Assert.That(111, Is.EqualTo(ddf.Tag));
             Assert.That("MultiX", Is.EqualTo(ddf.Name));

--- a/UnitTests/DDFieldTests.cs
+++ b/UnitTests/DDFieldTests.cs
@@ -20,7 +20,7 @@ namespace UnitTests
 
             Assert.That(5, Is.EqualTo(ddf.Tag));
             Assert.That("Foo", Is.EqualTo(ddf.Name));
-            Assert.That(enums, Is.EqualTo(ddf.EnumDict));
+            //Assert.That(enums, Is.EqualTo(ddf.EnumDict));
             Assert.That("STRING", Is.EqualTo(ddf.FixFldType));
             Assert.That(typeof(QuickFix.Fields.StringField), Is.EqualTo(ddf.FieldType));
 

--- a/UnitTests/DDFieldTests.cs
+++ b/UnitTests/DDFieldTests.cs
@@ -3,45 +3,44 @@ using System.Collections.Generic;
 using NUnit.Framework;
 using QuickFix.DataDictionary;
 
-namespace UnitTests
+namespace UnitTests;
+
+[TestFixture]
+public class DDFieldTests
 {
-    [TestFixture]
-    public class DDFieldTests
+    [Test]
+    public void CtorEnum()
     {
-        [Test]
-        public void CtorEnum()
+        Dictionary<string, string> enums = new()
         {
-            Dictionary<string, string> enums = new()
-            {
-                ["a"] = "AAA",
-                ["b"] = "BBB"
-            };
+            ["a"] = "AAA",
+            ["b"] = "BBB"
+        };
 
-            DDField ddf = new(5, "Foo", enums, "STRING");
+        DDField ddf = new(5, "Foo", enums, "STRING");
 
-            Assert.That(5, Is.EqualTo(ddf.Tag));
-            Assert.That("Foo", Is.EqualTo(ddf.Name));
-            Assert.That(enums, Is.EqualTo(ddf.EnumDict));
-            Assert.That("STRING", Is.EqualTo(ddf.FixFldType));
-            Assert.That(typeof(QuickFix.Fields.StringField), Is.EqualTo(ddf.FieldType));
+        Assert.That(5, Is.EqualTo(ddf.Tag));
+        Assert.That("Foo", Is.EqualTo(ddf.Name));
+        Assert.That(enums, Is.EqualTo(ddf.EnumDict));
+        Assert.That("STRING", Is.EqualTo(ddf.FixFldType));
+        Assert.That(typeof(QuickFix.Fields.StringField), Is.EqualTo(ddf.FieldType));
 
-            Assert.That(ddf.IsMultipleValueFieldWithEnums, Is.False);
-            Assert.That(ddf.HasEnums(), Is.True);
-        }
+        Assert.That(ddf.IsMultipleValueFieldWithEnums, Is.False);
+        Assert.That(ddf.HasEnums(), Is.True);
+    }
 
-        [Test]
-        public void CtorMultipleValueFieldWithEnums()
-        {
-            DDField ddf = new(111, "MultiX", new Dictionary<string, string>(), "MULTIPLEVALUESTRING");
+    [Test]
+    public void CtorMultipleValueFieldWithEnums()
+    {
+        DDField ddf = new(111, "MultiX", new Dictionary<string, string>(), "MULTIPLEVALUESTRING");
 
-            Assert.That(111, Is.EqualTo(ddf.Tag));
-            Assert.That("MultiX", Is.EqualTo(ddf.Name));
-            Assert.That(0, Is.EqualTo(ddf.EnumDict.Count));
-            Assert.That("MULTIPLEVALUESTRING", Is.EqualTo(ddf.FixFldType));
-            Assert.That(typeof(QuickFix.Fields.StringField), Is.EqualTo(ddf.FieldType));
+        Assert.That(111, Is.EqualTo(ddf.Tag));
+        Assert.That("MultiX", Is.EqualTo(ddf.Name));
+        Assert.That(0, Is.EqualTo(ddf.EnumDict.Count));
+        Assert.That("MULTIPLEVALUESTRING", Is.EqualTo(ddf.FixFldType));
+        Assert.That(typeof(QuickFix.Fields.StringField), Is.EqualTo(ddf.FieldType));
 
-            Assert.That(ddf.IsMultipleValueFieldWithEnums, Is.True);
-            Assert.That(ddf.HasEnums(), Is.False);
-        }
+        Assert.That(ddf.IsMultipleValueFieldWithEnums, Is.True);
+        Assert.That(ddf.HasEnums(), Is.False);
     }
 }

--- a/UnitTests/DataDictionaryTests.cs
+++ b/UnitTests/DataDictionaryTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Xml;
 using NUnit.Framework;
@@ -7,424 +6,423 @@ using QuickFix;
 using QuickFix.DataDictionary;
 using UnitTests.TestHelpers;
 
-namespace UnitTests
+namespace UnitTests;
+
+[TestFixture]
+public class DataDictionaryTests
 {
-    [TestFixture]
-    public class DataDictionaryTests
+    private readonly IMessageFactory _defaultMsgFactory = new DefaultMessageFactory();
+
+    [Test]
+    public void VersionTest()
     {
-        private readonly IMessageFactory _defaultMsgFactory = new DefaultMessageFactory();
+        DataDictionary dd44 = new();
+        dd44.LoadFIXSpec("FIX44");
+        Assert.That(dd44.MajorVersion, Is.EqualTo("4"));
+        Assert.That(dd44.MinorVersion, Is.EqualTo("4"));
+        Assert.That(dd44.Version, Is.EqualTo("FIX.4.4"));
+    }
 
-        [Test]
-        public void VersionTest()
+    [Test]
+    public void LoadFieldsTest()
+    {
+        DataDictionary dd = new();
+        dd.LoadFIXSpec("FIX44");
+        Assert.That(dd.FieldsByTag[1].Name, Is.EqualTo("Account"));
+        Assert.That(dd.FieldsByName["Account"].Tag, Is.EqualTo(1));
+        Assert.That(dd.FieldsByTag[1].EnumDict.Count, Is.EqualTo(0));
+        Assert.That(dd.FieldsByTag[QuickFix.Fields.Tags.StatusValue].EnumDict.Count, Is.EqualTo(4));
+    }
+
+	[Test]
+	public void LoadFieldsFromStreamTest()
+	{
+		DataDictionary dd = new();
+		Stream stream = new FileStream(Path.Combine(TestContext.CurrentContext.TestDirectory, "spec", "fix", "FIX44.xml"), FileMode.Open, FileAccess.Read);
+		dd.Load(stream);
+		Assert.That(dd.FieldsByTag[1].Name, Is.EqualTo("Account"));
+		Assert.That(dd.FieldsByName["Account"].Tag, Is.EqualTo(1));
+		Assert.That(dd.FieldsByTag[1].EnumDict.Count, Is.EqualTo(0));
+		Assert.That(dd.FieldsByTag[QuickFix.Fields.Tags.StatusValue].EnumDict.Count, Is.EqualTo(4));
+	}
+
+    [Test]
+    public void FieldHasValueTest()
+    {
+        DataDictionary dd = new();
+        dd.LoadFIXSpec("FIX44");
+        Assert.That(dd.FieldHasValue(QuickFix.Fields.Tags.StatusValue, "1"), Is.EqualTo(true));
+        Assert.That(dd.FieldHasValue(QuickFix.Fields.Tags.StatusValue, "CONNECTED"), Is.EqualTo(false));
+        Assert.That(dd.FieldsByTag[1].HasEnums(), Is.False);
+        Assert.That(dd.FieldsByTag[945].HasEnums(), Is.True);
+    }
+
+    [Test]
+    public void FieldHasDescriptionTest()
+    {
+        DataDictionary dd = new();
+        dd.LoadFIXSpec("FIX44");
+        Assert.That("COMPLETED", Is.EqualTo(dd.FieldsByTag[945].EnumDict["2"]));
+        Assert.That(dd.FieldsByTag[35].EnumDict["A"], Is.Not.EqualTo("HEARTBEAT"));
+    }
+
+    [Test]
+    public void BasicMessageTest()
+    {
+        DataDictionary dd = new();
+        dd.LoadFIXSpec("FIX44");
+        Assert.That(dd.Messages["3"].Fields.Count, Is.EqualTo(7));
+    }
+
+    [Test]
+    public void ComponentSmokeTest()
+    {
+        DataDictionary dd = new();
+        dd.LoadFIXSpec("FIX44");
+        DDMap tcr = dd.Messages["AE"];
+        Assert.That(tcr.Fields.ContainsKey(55), Is.True);
+        Assert.That(tcr.Fields.ContainsKey(5995), Is.False);
+    }
+
+    [Test]
+    public void GroupTest()
+    {
+        DataDictionary dd = new();
+        dd.LoadFIXSpec("FIX44");
+        DDMap tcrr = dd.Messages["AD"];
+        Assert.That(tcrr.IsGroup(711), Is.True);
+        Assert.That(tcrr.IsField(711), Is.True);  // No Field also a field
+        Assert.That(tcrr.GetGroup(711).IsField(311), Is.True);
+        Assert.That(tcrr.Groups[711].Fields[311].Name, Is.EqualTo("UnderlyingSymbol"));
+        Assert.That(tcrr.Groups[711].Delim, Is.EqualTo(311));
+        DDMap tcr = dd.Messages["AE"];
+        Assert.That(tcr.Groups[711].Groups[457].Fields[458].Name, Is.EqualTo("UnderlyingSecurityAltID"));
+    }
+
+    [Test]
+    public void NestedGroupTest()
+    {
+        DataDictionary dd = new();
+        dd.LoadFIXSpec("FIX44");
+        DDMap msgJ = dd.Messages["J"];
+
+        Assert.That(msgJ.IsGroup(73), Is.True);
+        Assert.That(msgJ.IsGroup(756), Is.False);
+        Assert.That(msgJ.GetGroup(73).IsGroup(756), Is.True);
+    }
+
+    [Test]
+    public void GroupBeginsGroupTest()
+    {
+        DataDictionary dd = new();
+        dd.LoadTestFIXSpec("group_begins_group");
+        DDMap msg = dd.Messages["magic"];
+        Assert.That(msg.IsGroup(6660), Is.True); // NoMagics group
+        Assert.That(msg.GetGroup(6660).IsGroup(7770), Is.True); // NoMagics/NoRabbits
+        Assert.That(msg.GetGroup(6660).IsField(6661), Is.True); // NoMagics/MagicWord
+        Assert.That(msg.GetGroup(6660).GetGroup(7770).IsField(7711), Is.True); // NoMagics/NoRabbits/RabbitName
+        Assert.That(msg.GetGroup(6660).Delim, Is.EqualTo(7770)); // NoMagics delim is NoRabbits counter
+        Assert.That(msg.GetGroup(6660).GetGroup(7770).Delim, Is.EqualTo(7711)); // NoRabbits delim is RabbitName
+    }
+
+    [Test]
+    public void HeaderGroupTest()
+    {
+        DataDictionary dd = new();
+        dd.LoadFIXSpec("FIX44");
+        DDMap headerMap = dd.Header;
+        Assert.That(headerMap.IsGroup(627), Is.True);
+        DDGrp grpMap = headerMap.GetGroup(627);
+        Assert.That(dd.Header.GetGroup(627).IsField(628), Is.True);
+        Assert.That(grpMap.IsField(628), Is.True);
+    }
+
+    [Test]
+    public void ReqFldTest()
+    {
+        DataDictionary dd = new();
+        dd.LoadFIXSpec("FIX44");
+        Assert.That(dd.Messages["AE"].ReqFields.Contains(571), Is.True);
+        Assert.That(dd.Messages["AE"].ReqFields.Contains(828), Is.False);
+    }
+
+    [Test]
+    public void HeaderTest()
+    {
+        DataDictionary dd = new();
+        dd.LoadFIXSpec("FIX44");
+        Assert.That(dd.Header.ReqFields.Contains(9), Is.True);
+        Assert.That(dd.Header.Fields.Count, Is.EqualTo(27));
+    }
+
+    [Test]
+    public void TrailerTest()
+    {
+        DataDictionary dd = new();
+        dd.LoadFIXSpec("FIX44");
+        Assert.That(dd.Trailer.ReqFields.Contains(10), Is.True);
+        Assert.That(dd.Trailer.Fields.Count, Is.EqualTo(3));
+    }
+
+    [Test]
+    public void CheckValidFormat()
+    {
+        DataDictionary dd = new();
+        dd.LoadFIXSpec("FIX44");
+        dd.CheckFieldsHaveValues = true;
+
+        var goodFields = new QuickFix.Fields.StringField[] {
+            new(QuickFix.Fields.Tags.Symbol, "foo"), // string
+            new(QuickFix.Fields.Tags.Side, "2"), // char
+            new(QuickFix.Fields.Tags.LastQty, "123"), // int
+            new(QuickFix.Fields.Tags.AvgPx, "1.23"), // decimal
+            new(QuickFix.Fields.Tags.ReportToExch, "Y"), // bool
+            new(QuickFix.Fields.Tags.ContraTradeTime, "20011217-09:30:47.123"), // datetime
+            new(QuickFix.Fields.Tags.MDEntryDate, "20030910"), // dateonly
+            new(QuickFix.Fields.Tags.MDEntryTime, "13:20:00.123"), // timeonly
+            new(QuickFix.Fields.Tags.Symbol, "") // string
+        };
+
+        foreach (var datum in goodFields)
         {
-            DataDictionary dd44 = new();
-            dd44.LoadFIXSpec("FIX44");
-            Assert.That(dd44.MajorVersion, Is.EqualTo("4"));
-            Assert.That(dd44.MinorVersion, Is.EqualTo("4"));
-            Assert.That(dd44.Version, Is.EqualTo("FIX.4.4"));
+            Assert.DoesNotThrow(delegate { dd.CheckValidFormat(datum); });
         }
 
-        [Test]
-        public void LoadFieldsTest()
+        var badFields = new QuickFix.Fields.StringField[]
         {
-            DataDictionary dd = new();
-            dd.LoadFIXSpec("FIX44");
-            Assert.That(dd.FieldsByTag[1].Name, Is.EqualTo("Account"));
-            Assert.That(dd.FieldsByName["Account"].Tag, Is.EqualTo(1));
-            Assert.That(dd.FieldsByTag[1].EnumDict.Count, Is.EqualTo(0));
-            Assert.That(dd.FieldsByTag[QuickFix.Fields.Tags.StatusValue].EnumDict.Count, Is.EqualTo(4));
-        }
+            new(QuickFix.Fields.Tags.Side, "toolong"), // char
+            new(QuickFix.Fields.Tags.LastQty, "notint"), // int
+            new(QuickFix.Fields.Tags.AvgPx, "notdec"), // decimal
+            new(QuickFix.Fields.Tags.ReportToExch, "notbool"), // bool
+            new(QuickFix.Fields.Tags.ContraTradeTime, "notdatetime"), // datetime
+            new(QuickFix.Fields.Tags.MDEntryDate, "notdate"), // dateonly
+            new(QuickFix.Fields.Tags.MDEntryTime, "nottime") // timeonly
+        };
 
-		[Test]
-		public void LoadFieldsFromStreamTest()
-		{
-			DataDictionary dd = new();
-		    Stream stream = new FileStream(Path.Combine(TestContext.CurrentContext.TestDirectory, "spec", "fix", "FIX44.xml"), FileMode.Open, FileAccess.Read);
-			dd.Load(stream);
-			Assert.That(dd.FieldsByTag[1].Name, Is.EqualTo("Account"));
-			Assert.That(dd.FieldsByName["Account"].Tag, Is.EqualTo(1));
-			Assert.That(dd.FieldsByTag[1].EnumDict.Count, Is.EqualTo(0));
-			Assert.That(dd.FieldsByTag[QuickFix.Fields.Tags.StatusValue].EnumDict.Count, Is.EqualTo(4));
-		}
-
-        [Test]
-        public void FieldHasValueTest()
+        foreach (var datum in badFields)
         {
-            DataDictionary dd = new();
-            dd.LoadFIXSpec("FIX44");
-            Assert.That(dd.FieldHasValue(QuickFix.Fields.Tags.StatusValue, "1"), Is.EqualTo(true));
-            Assert.That(dd.FieldHasValue(QuickFix.Fields.Tags.StatusValue, "CONNECTED"), Is.EqualTo(false));
-            Assert.That(dd.FieldsByTag[1].HasEnums(), Is.False);
-            Assert.That(dd.FieldsByTag[945].HasEnums(), Is.True);
+            Assert.Throws(typeof(IncorrectDataFormat), delegate { dd.CheckValidFormat(datum); });
         }
 
-        [Test]
-        public void FieldHasDescriptionTest()
+        var emptyFields = new QuickFix.Fields.StringField[]
         {
-            DataDictionary dd = new();
-            dd.LoadFIXSpec("FIX44");
-            Assert.That("COMPLETED", Is.EqualTo(dd.FieldsByTag[945].EnumDict["2"]));
-            Assert.That(dd.FieldsByTag[35].EnumDict["A"], Is.Not.EqualTo("HEARTBEAT"));
-        }
+            new(QuickFix.Fields.Tags.Side, ""), // char
+            new(QuickFix.Fields.Tags.LastQty, ""), // int
+            new(QuickFix.Fields.Tags.AvgPx, ""), // decimal
+            new(QuickFix.Fields.Tags.ReportToExch, ""), // bool
+            new(QuickFix.Fields.Tags.ContraTradeTime, ""), // datetime
+            new(QuickFix.Fields.Tags.MDEntryDate, ""), // dateonly
+            new(QuickFix.Fields.Tags.MDEntryTime, "") // timeonly
+        };
 
-        [Test]
-        public void BasicMessageTest()
+        foreach (var datum in emptyFields)
         {
-            DataDictionary dd = new();
-            dd.LoadFIXSpec("FIX44");
-            Assert.That(dd.Messages["3"].Fields.Count, Is.EqualTo(7));
+            Assert.Throws(typeof(IncorrectDataFormat), delegate { dd.CheckValidFormat(datum); });
         }
 
-        [Test]
-        public void ComponentSmokeTest()
+        // Setting change!
+        dd.CheckFieldsHaveValues = false;
+        foreach (var datum in emptyFields)
         {
-            DataDictionary dd = new();
-            dd.LoadFIXSpec("FIX44");
-            DDMap tcr = dd.Messages["AE"];
-            Assert.That(tcr.Fields.ContainsKey(55), Is.True);
-            Assert.That(tcr.Fields.ContainsKey(5995), Is.False);
+            Assert.DoesNotThrow(delegate { dd.CheckValidFormat(datum); });
         }
+    }
 
-        [Test]
-        public void GroupTest()
+    [Test]
+    public void CheckValidTagNumberTest()
+    {
+        DataDictionary dd = new();
+        dd.LoadFIXSpec("FIX44");
+
+        Assert.DoesNotThrow(delegate { dd.CheckValidTagNumber(35); });
+
+        Assert.Throws(typeof(InvalidTagNumber),
+            delegate { dd.CheckValidTagNumber(999); });
+
+        dd.AllowUnknownMessageFields = true;
+        Assert.DoesNotThrow(delegate { dd.CheckValidTagNumber(999); });
+    }
+
+    [Test]
+    public void CheckValue()
+    {
+        DataDictionary dd = new();
+        dd.LoadFIXSpec("FIX44");
+
+        // unknown field
+        Assert.DoesNotThrow(delegate { dd.CheckValue(new QuickFix.Fields.CharField(20, '0')); });
+        // not an enum
+        Assert.DoesNotThrow(delegate { dd.CheckValue(new QuickFix.Fields.ListSeqNo(5)); });
+        // regular enum, ok
+        Assert.DoesNotThrow(delegate { dd.CheckValue(new QuickFix.Fields.TickDirection('2')); });
+        // multiple-value field, ok
+        Assert.DoesNotThrow(delegate { dd.CheckValue(new QuickFix.Fields.QuoteCondition("A C D")); });
+
+        // regular enum, invalid value
+        Assert.Throws(typeof(IncorrectTagValue),
+            delegate { dd.CheckValue(new QuickFix.Fields.TickDirection('9')); });
+        // multiple-value field, one value is invalid
+        Assert.Throws(typeof(IncorrectTagValue),
+           delegate { dd.CheckValue(new QuickFix.Fields.QuoteCondition("A @ D")); });
+
+        // Disable some checks
+        dd.AllowUnknownEnumValues = true;
+        // regular enum, invalid value
+        Assert.DoesNotThrow(delegate { dd.CheckValue(new QuickFix.Fields.TickDirection('9')); });
+        // multiple-value field, one value is invalid
+        Assert.DoesNotThrow(delegate { dd.CheckValue(new QuickFix.Fields.QuoteCondition("A @ D")); });
+    }
+
+    [Test]
+    public void CheckIsInMessageTest()
+    {
+        DataDictionary dd = new();
+        dd.LoadFIXSpec("FIX44");
+
+        Assert.DoesNotThrow(delegate { dd.CheckIsInMessage(new QuickFix.Fields.MDReqID("foo"), "W"); });
+
+        Assert.Throws(typeof(TagNotDefinedForMessage),
+            delegate { dd.CheckIsInMessage(new QuickFix.Fields.EmailThreadID("foo"), "W"); });
+
+        dd.AllowUnknownMessageFields = true;
+        Assert.DoesNotThrow(delegate { dd.CheckIsInMessage(new QuickFix.Fields.EmailThreadID("foo"), "W"); });
+    }
+
+    [Test]
+    public void CheckIsInGroupTest()
+    {
+        DataDictionary dd = new();
+        dd.LoadFIXSpec("FIX44");
+        DDGrp g = dd.Messages["B"].GetGroup(33);
+
+        QuickFix.Fields.Text textField = new QuickFix.Fields.Text("woot");
+        QuickFix.Fields.ClOrdID clOrdIdField = new QuickFix.Fields.ClOrdID("not woot");
+
+        Assert.DoesNotThrow(delegate { DataDictionary.CheckIsInGroup(textField, g, "B"); });
+        Assert.Throws(typeof(TagNotDefinedForMessage), delegate { DataDictionary.CheckIsInGroup(clOrdIdField, g, "B"); });
+    }
+
+    [Test]
+    public void CheckGroupCountTest()
+    {
+        DataDictionary dd = new();
+        dd.LoadFIXSpec("FIX42");
+
+        QuickFix.FIX42.NewOrderSingle n = new QuickFix.FIX42.NewOrderSingle();
+
+        string s = ("8=FIX.4.2|9=148|35=D|34=2|49=TW|52=20111011-15:06:23.103|56=ISLD|"
+                    + "11=ID|21=1|40=1|54=1|38=200.00|55=INTC|"
+                    + "386=3|336=PRE-OPEN|336=AFTER-HOURS|"
+                    + "60=20111011-15:06:23.103|"
+                    + "10=35|").Replace('|', Message.SOH);
+
+        n.FromString(s, true, dd, dd, _defaultMsgFactory);
+
+        //verify that FromString didn't correct the counter
+        //HEY YOU, READ THIS NOW: if these fail, first check if MessageTests::FromString_DoNotCorrectCounter() passes
+        Assert.That(n.NoTradingSessions.ToStringField(), Is.EqualTo("386=3"));
+        Assert.That(n.ConstructString(), Does.Contain("386=3"));
+
+        Assert.Throws<RepeatingGroupCountMismatch>(delegate { dd.CheckGroupCount(n.NoTradingSessions, n, "D"); });
+    }
+
+
+    [Test]
+    public void DuplicateEnumsDoesNotThrow()
+    {
+        // If this test throws, it failed.
+        DataDictionary dd = new();
+        dd.LoadTestFIXSpec("FIX43_dup_enum");
+    }
+
+    [Test]
+    public void ComponentFieldsRequirements()
+    {
+        DataDictionary dd = new();
+        dd.LoadFIXSpec("FIX44");
+
+        // AD => Instrument component (optional) => 55 (Symbol)
+        Assert.That(dd.Messages["AD"].ReqFields.Contains(55), Is.False);
+        // 7 => Instrument component (required) => 55 (Symbol)
+        Assert.That(dd.Messages["7"].ReqFields.Contains(55), Is.True);
+    }
+
+    [Test]
+    public void Issue134_RequiredIsOptional()
+    {
+        DataDictionary dd = new();
+        dd.LoadTestFIXSpec("required_is_optional");
+        Assert.That(dd.Messages["magic"].ReqFields.Contains(1111), Is.True);  //base required field
+        Assert.That(dd.Messages["magic"].ReqFields.Contains(5555), Is.False); //base optional field
+        Assert.That(dd.Messages["magic"].ReqFields.Contains(5556), Is.False); //component optional field
+
+        Assert.That(dd.Messages["magic"].Groups[6660].Required, Is.False); // group isn't required
+        Assert.That(dd.Messages["magic"].Groups[6660].ReqFields.Contains(6662), Is.False); // group optional field
+    }
+
+    [Test] // Issue #493
+    public void ParseThroughComments()
+    {
+        DataDictionary dd = new();
+        dd.LoadTestFIXSpec("comments");
+
+        // The fact that it doesn't throw is sufficient, but we'll do some other checks anyway.
+
+        DDMap logon = dd.GetMapForMessage("A")!;
+        Assert.That(logon.IsField(108), Is.True); // HeartBtInt
+        Assert.That(logon.IsField(9000), Is.True); // CustomField
+
+        DDMap news = dd.GetMapForMessage("B")!;
+        Assert.That(news.IsField(148), Is.True); // Headline
+        Assert.That(news.IsGroup(33), Is.True); // LinesOfText
+        Assert.That(news.GetGroup(33).IsField(355), Is.True); // EncodedText
+    }
+
+    [Test]
+    public void TestCheckMsgType() {
+        DataDictionary dd = new();
+        dd.LoadTestFIXSpec("msg_type_test");
+
+        Assert.Throws(typeof(InvalidMessageType), delegate { dd.CheckMsgType("foo"); });
+
+        // True check, case 1: DD has a <message> definition for this one
+        Assert.DoesNotThrow(delegate { dd.CheckMsgType("B"); });
+
+        // True check, case 2: Type is in field 35, but there is no Message type
+        Assert.That(dd.Messages, Does.Not.ContainKey("bar")); // Sanity check; if fails, fix the test.
+        Assert.DoesNotThrow(delegate { dd.CheckMsgType("bar"); });
+    }
+
+    private static XmlNode MakeNode(string xmlString)
+    {
+        XmlDocument doc = new XmlDocument();
+        if (xmlString.StartsWith('<'))
         {
-            DataDictionary dd = new();
-            dd.LoadFIXSpec("FIX44");
-            DDMap tcrr = dd.Messages["AD"];
-            Assert.That(tcrr.IsGroup(711), Is.True);
-            Assert.That(tcrr.IsField(711), Is.True);  // No Field also a field
-            Assert.That(tcrr.GetGroup(711).IsField(311), Is.True);
-            Assert.That(tcrr.Groups[711].Fields[311].Name, Is.EqualTo("UnderlyingSymbol"));
-            Assert.That(tcrr.Groups[711].Delim, Is.EqualTo(311));
-            DDMap tcr = dd.Messages["AE"];
-            Assert.That(tcr.Groups[711].Groups[457].Fields[458].Name, Is.EqualTo("UnderlyingSecurityAltID"));
+            doc.LoadXml(xmlString);
+            return doc.DocumentElement!;
         }
+        return doc.CreateTextNode(xmlString);
+    }
 
-        [Test]
-        public void NestedGroupTest()
-        {
-            DataDictionary dd = new();
-            dd.LoadFIXSpec("FIX44");
-            DDMap msgJ = dd.Messages["J"];
+    [Test]
+    public void VerifyChildNodeAndReturnNameAtt() {
+        XmlNode parentNode = MakeNode("<parentnode name='Daddy'/>");
 
-            Assert.That(msgJ.IsGroup(73), Is.True);
-            Assert.That(msgJ.IsGroup(756), Is.False);
-            Assert.That(msgJ.GetGroup(73).IsGroup(756), Is.True);
-        }
+        Assert.That(DataDictionary.VerifyChildNodeAndReturnNameAtt(MakeNode("<sometag name='qty'/>"), parentNode),
+            Is.EqualTo("qty"));
 
-        [Test]
-        public void GroupBeginsGroupTest()
-        {
-            DataDictionary dd = new();
-            dd.LoadTestFIXSpec("group_begins_group");
-            DDMap msg = dd.Messages["magic"];
-            Assert.That(msg.IsGroup(6660), Is.True); // NoMagics group
-            Assert.That(msg.GetGroup(6660).IsGroup(7770), Is.True); // NoMagics/NoRabbits
-            Assert.That(msg.GetGroup(6660).IsField(6661), Is.True); // NoMagics/MagicWord
-            Assert.That(msg.GetGroup(6660).GetGroup(7770).IsField(7711), Is.True); // NoMagics/NoRabbits/RabbitName
-            Assert.That(msg.GetGroup(6660).Delim, Is.EqualTo(7770)); // NoMagics delim is NoRabbits counter
-            Assert.That(msg.GetGroup(6660).GetGroup(7770).Delim, Is.EqualTo(7711)); // NoRabbits delim is RabbitName
-        }
+        DictionaryParseException dpx = Assert.Throws<DictionaryParseException>(
+            delegate { DataDictionary.VerifyChildNodeAndReturnNameAtt(MakeNode("foo"), parentNode); })!;
+        Assert.That(dpx.Message, Is.EqualTo("Malformed data dictionary: Found text-only node containing 'foo'"));
 
-        [Test]
-        public void HeaderGroupTest()
-        {
-            DataDictionary dd = new();
-            dd.LoadFIXSpec("FIX44");
-            DDMap headerMap = dd.Header;
-            Assert.That(headerMap.IsGroup(627), Is.True);
-            DDGrp grpMap = headerMap.GetGroup(627);
-            Assert.That(dd.Header.GetGroup(627).IsField(628), Is.True);
-            Assert.That(grpMap.IsField(628), Is.True);
-        }
+        dpx = Assert.Throws<DictionaryParseException>(
+            delegate { DataDictionary.VerifyChildNodeAndReturnNameAtt(MakeNode("<field>qty</field>"), parentNode); })!;
+        Assert.That(dpx.Message, Is.EqualTo("Malformed data dictionary: Found 'field' node without 'name' within parent 'parentnode/Daddy'"));
 
-        [Test]
-        public void ReqFldTest()
-        {
-            DataDictionary dd = new();
-            dd.LoadFIXSpec("FIX44");
-            Assert.That(dd.Messages["AE"].ReqFields.Contains(571), Is.True);
-            Assert.That(dd.Messages["AE"].ReqFields.Contains(828), Is.False);
-        }
-
-        [Test]
-        public void HeaderTest()
-        {
-            DataDictionary dd = new();
-            dd.LoadFIXSpec("FIX44");
-            Assert.That(dd.Header.ReqFields.Contains(9), Is.True);
-            Assert.That(dd.Header.Fields.Count, Is.EqualTo(27));
-        }
-
-        [Test]
-        public void TrailerTest()
-        {
-            DataDictionary dd = new();
-            dd.LoadFIXSpec("FIX44");
-            Assert.That(dd.Trailer.ReqFields.Contains(10), Is.True);
-            Assert.That(dd.Trailer.Fields.Count, Is.EqualTo(3));
-        }
-
-        [Test]
-        public void CheckValidFormat()
-        {
-            DataDictionary dd = new();
-            dd.LoadFIXSpec("FIX44");
-            dd.CheckFieldsHaveValues = true;
-
-            var goodFields = new QuickFix.Fields.StringField[] {
-                new(QuickFix.Fields.Tags.Symbol, "foo"), // string
-                new(QuickFix.Fields.Tags.Side, "2"), // char
-                new(QuickFix.Fields.Tags.LastQty, "123"), // int
-                new(QuickFix.Fields.Tags.AvgPx, "1.23"), // decimal
-                new(QuickFix.Fields.Tags.ReportToExch, "Y"), // bool
-                new(QuickFix.Fields.Tags.ContraTradeTime, "20011217-09:30:47.123"), // datetime
-                new(QuickFix.Fields.Tags.MDEntryDate, "20030910"), // dateonly
-                new(QuickFix.Fields.Tags.MDEntryTime, "13:20:00.123"), // timeonly
-                new(QuickFix.Fields.Tags.Symbol, "") // string
-            };
-
-            foreach (var datum in goodFields)
-            {
-                Assert.DoesNotThrow(delegate { dd.CheckValidFormat(datum); });
-            }
-
-            var badFields = new QuickFix.Fields.StringField[]
-            {
-                new(QuickFix.Fields.Tags.Side, "toolong"), // char
-                new(QuickFix.Fields.Tags.LastQty, "notint"), // int
-                new(QuickFix.Fields.Tags.AvgPx, "notdec"), // decimal
-                new(QuickFix.Fields.Tags.ReportToExch, "notbool"), // bool
-                new(QuickFix.Fields.Tags.ContraTradeTime, "notdatetime"), // datetime
-                new(QuickFix.Fields.Tags.MDEntryDate, "notdate"), // dateonly
-                new(QuickFix.Fields.Tags.MDEntryTime, "nottime") // timeonly
-            };
-
-            foreach (var datum in badFields)
-            {
-                Assert.Throws(typeof(IncorrectDataFormat), delegate { dd.CheckValidFormat(datum); });
-            }
-
-            var emptyFields = new QuickFix.Fields.StringField[]
-            {
-                new(QuickFix.Fields.Tags.Side, ""), // char
-                new(QuickFix.Fields.Tags.LastQty, ""), // int
-                new(QuickFix.Fields.Tags.AvgPx, ""), // decimal
-                new(QuickFix.Fields.Tags.ReportToExch, ""), // bool
-                new(QuickFix.Fields.Tags.ContraTradeTime, ""), // datetime
-                new(QuickFix.Fields.Tags.MDEntryDate, ""), // dateonly
-                new(QuickFix.Fields.Tags.MDEntryTime, "") // timeonly
-            };
-
-            foreach (var datum in emptyFields)
-            {
-                Assert.Throws(typeof(IncorrectDataFormat), delegate { dd.CheckValidFormat(datum); });
-            }
-
-            // Setting change!
-            dd.CheckFieldsHaveValues = false;
-            foreach (var datum in emptyFields)
-            {
-                Assert.DoesNotThrow(delegate { dd.CheckValidFormat(datum); });
-            }
-        }
-
-        [Test]
-        public void CheckValidTagNumberTest()
-        {
-            DataDictionary dd = new();
-            dd.LoadFIXSpec("FIX44");
-
-            Assert.DoesNotThrow(delegate { dd.CheckValidTagNumber(35); });
-
-            Assert.Throws(typeof(InvalidTagNumber),
-                delegate { dd.CheckValidTagNumber(999); });
-
-            dd.AllowUnknownMessageFields = true;
-            Assert.DoesNotThrow(delegate { dd.CheckValidTagNumber(999); });
-        }
-
-        [Test]
-        public void CheckValue()
-        {
-            DataDictionary dd = new();
-            dd.LoadFIXSpec("FIX44");
-
-            // unknown field
-            Assert.DoesNotThrow(delegate { dd.CheckValue(new QuickFix.Fields.CharField(20, '0')); });
-            // not an enum
-            Assert.DoesNotThrow(delegate { dd.CheckValue(new QuickFix.Fields.ListSeqNo(5)); });
-            // regular enum, ok
-            Assert.DoesNotThrow(delegate { dd.CheckValue(new QuickFix.Fields.TickDirection('2')); });
-            // multiple-value field, ok
-            Assert.DoesNotThrow(delegate { dd.CheckValue(new QuickFix.Fields.QuoteCondition("A C D")); });
-
-            // regular enum, invalid value
-            Assert.Throws(typeof(IncorrectTagValue),
-                delegate { dd.CheckValue(new QuickFix.Fields.TickDirection('9')); });
-            // multiple-value field, one value is invalid
-            Assert.Throws(typeof(IncorrectTagValue),
-               delegate { dd.CheckValue(new QuickFix.Fields.QuoteCondition("A @ D")); });
-
-            // Disable some checks
-            dd.AllowUnknownEnumValues = true;
-            // regular enum, invalid value
-            Assert.DoesNotThrow(delegate { dd.CheckValue(new QuickFix.Fields.TickDirection('9')); });
-            // multiple-value field, one value is invalid
-            Assert.DoesNotThrow(delegate { dd.CheckValue(new QuickFix.Fields.QuoteCondition("A @ D")); });
-        }
-
-        [Test]
-        public void CheckIsInMessageTest()
-        {
-            DataDictionary dd = new();
-            dd.LoadFIXSpec("FIX44");
-
-            Assert.DoesNotThrow(delegate { dd.CheckIsInMessage(new QuickFix.Fields.MDReqID("foo"), "W"); });
-
-            Assert.Throws(typeof(TagNotDefinedForMessage),
-                delegate { dd.CheckIsInMessage(new QuickFix.Fields.EmailThreadID("foo"), "W"); });
-
-            dd.AllowUnknownMessageFields = true;
-            Assert.DoesNotThrow(delegate { dd.CheckIsInMessage(new QuickFix.Fields.EmailThreadID("foo"), "W"); });
-        }
-
-        [Test]
-        public void CheckIsInGroupTest()
-        {
-            DataDictionary dd = new();
-            dd.LoadFIXSpec("FIX44");
-            DDGrp g = dd.Messages["B"].GetGroup(33);
-
-            QuickFix.Fields.Text textField = new QuickFix.Fields.Text("woot");
-            QuickFix.Fields.ClOrdID clOrdIdField = new QuickFix.Fields.ClOrdID("not woot");
-
-            Assert.DoesNotThrow(delegate { DataDictionary.CheckIsInGroup(textField, g, "B"); });
-            Assert.Throws(typeof(TagNotDefinedForMessage), delegate { DataDictionary.CheckIsInGroup(clOrdIdField, g, "B"); });
-        }
-
-        [Test]
-        public void CheckGroupCountTest()
-        {
-            DataDictionary dd = new();
-            dd.LoadFIXSpec("FIX42");
-
-            QuickFix.FIX42.NewOrderSingle n = new QuickFix.FIX42.NewOrderSingle();
-
-            string s = ("8=FIX.4.2|9=148|35=D|34=2|49=TW|52=20111011-15:06:23.103|56=ISLD|"
-                        + "11=ID|21=1|40=1|54=1|38=200.00|55=INTC|"
-                        + "386=3|336=PRE-OPEN|336=AFTER-HOURS|"
-                        + "60=20111011-15:06:23.103|"
-                        + "10=35|").Replace('|', Message.SOH);
-
-            n.FromString(s, true, dd, dd, _defaultMsgFactory);
-
-            //verify that FromString didn't correct the counter
-            //HEY YOU, READ THIS NOW: if these fail, first check if MessageTests::FromString_DoNotCorrectCounter() passes
-            Assert.That(n.NoTradingSessions.ToStringField(), Is.EqualTo("386=3"));
-            Assert.That(n.ConstructString(), Does.Contain("386=3"));
-
-            Assert.Throws<RepeatingGroupCountMismatch>(delegate { dd.CheckGroupCount(n.NoTradingSessions, n, "D"); });
-        }
-
-
-        [Test]
-        public void DuplicateEnumsDoesNotThrow()
-        {
-            // If this test throws, it failed.
-            DataDictionary dd = new();
-            dd.LoadTestFIXSpec("FIX43_dup_enum");
-        }
-
-        [Test]
-        public void ComponentFieldsRequirements()
-        {
-            DataDictionary dd = new();
-            dd.LoadFIXSpec("FIX44");
-
-            // AD => Instrument component (optional) => 55 (Symbol)
-            Assert.That(dd.Messages["AD"].ReqFields.Contains(55), Is.False);
-            // 7 => Instrument component (required) => 55 (Symbol)
-            Assert.That(dd.Messages["7"].ReqFields.Contains(55), Is.True);
-        }
-
-        [Test]
-        public void Issue134_RequiredIsOptional()
-        {
-            DataDictionary dd = new();
-            dd.LoadTestFIXSpec("required_is_optional");
-            Assert.That(dd.Messages["magic"].ReqFields.Contains(1111), Is.True);  //base required field
-            Assert.That(dd.Messages["magic"].ReqFields.Contains(5555), Is.False); //base optional field
-            Assert.That(dd.Messages["magic"].ReqFields.Contains(5556), Is.False); //component optional field
-
-            Assert.That(dd.Messages["magic"].Groups[6660].Required, Is.False); // group isn't required
-            Assert.That(dd.Messages["magic"].Groups[6660].ReqFields.Contains(6662), Is.False); // group optional field
-        }
-
-        [Test] // Issue #493
-        public void ParseThroughComments()
-        {
-            DataDictionary dd = new();
-            dd.LoadTestFIXSpec("comments");
-
-            // The fact that it doesn't throw is sufficient, but we'll do some other checks anyway.
-
-            DDMap logon = dd.GetMapForMessage("A")!;
-            Assert.That(logon.IsField(108), Is.True); // HeartBtInt
-            Assert.That(logon.IsField(9000), Is.True); // CustomField
-
-            DDMap news = dd.GetMapForMessage("B")!;
-            Assert.That(news.IsField(148), Is.True); // Headline
-            Assert.That(news.IsGroup(33), Is.True); // LinesOfText
-            Assert.That(news.GetGroup(33).IsField(355), Is.True); // EncodedText
-        }
-
-        [Test]
-        public void TestCheckMsgType() {
-            DataDictionary dd = new();
-            dd.LoadTestFIXSpec("msg_type_test");
-
-            Assert.Throws(typeof(InvalidMessageType), delegate { dd.CheckMsgType("foo"); });
-
-            // True check, case 1: DD has a <message> definition for this one
-            Assert.DoesNotThrow(delegate { dd.CheckMsgType("B"); });
-
-            // True check, case 2: Type is in field 35, but there is no Message type
-            Assert.That(dd.Messages, Does.Not.ContainKey("bar")); // Sanity check; if fails, fix the test.
-            Assert.DoesNotThrow(delegate { dd.CheckMsgType("bar"); });
-        }
-
-        private static XmlNode MakeNode(string xmlString)
-        {
-            XmlDocument doc = new XmlDocument();
-            if (xmlString.StartsWith('<'))
-            {
-                doc.LoadXml(xmlString);
-                return doc.DocumentElement!;
-            }
-            return doc.CreateTextNode(xmlString);
-        }
-
-        [Test]
-        public void VerifyChildNodeAndReturnNameAtt() {
-            XmlNode parentNode = MakeNode("<parentnode name='Daddy'/>");
-
-            Assert.That(DataDictionary.VerifyChildNodeAndReturnNameAtt(MakeNode("<sometag name='qty'/>"), parentNode),
-                Is.EqualTo("qty"));
-
-            DictionaryParseException dpx = Assert.Throws<DictionaryParseException>(
-                delegate { DataDictionary.VerifyChildNodeAndReturnNameAtt(MakeNode("foo"), parentNode); })!;
-            Assert.That(dpx.Message, Is.EqualTo("Malformed data dictionary: Found text-only node containing 'foo'"));
-
-            dpx = Assert.Throws<DictionaryParseException>(
-                delegate { DataDictionary.VerifyChildNodeAndReturnNameAtt(MakeNode("<field>qty</field>"), parentNode); })!;
-            Assert.That(dpx.Message, Is.EqualTo("Malformed data dictionary: Found 'field' node without 'name' within parent 'parentnode/Daddy'"));
-
-            // alt error message, where parent has no name
-            parentNode = MakeNode("<parentnode/>");
-            dpx = Assert.Throws<DictionaryParseException>(
-                delegate { DataDictionary.VerifyChildNodeAndReturnNameAtt(MakeNode("<field>qty</field>"), parentNode); })!;
-            Assert.That(dpx.Message, Is.EqualTo("Malformed data dictionary: Found 'field' node without 'name' within parent 'parentnode/parentnode'"));
-        }
+        // alt error message, where parent has no name
+        parentNode = MakeNode("<parentnode/>");
+        dpx = Assert.Throws<DictionaryParseException>(
+            delegate { DataDictionary.VerifyChildNodeAndReturnNameAtt(MakeNode("<field>qty</field>"), parentNode); })!;
+        Assert.That(dpx.Message, Is.EqualTo("Malformed data dictionary: Found 'field' node without 'name' within parent 'parentnode/parentnode'"));
     }
 }

--- a/UnitTests/DataDictionaryTests.cs
+++ b/UnitTests/DataDictionaryTests.cs
@@ -63,7 +63,7 @@ namespace UnitTests
         {
             DataDictionary dd = new DataDictionary();
             dd.LoadFIXSpec("FIX44");
-            Assert.That(dd.FieldsByTag[945].EnumDict.GetType(), Is.EqualTo(typeof(Dictionary<string, string>)));
+            //Assert.That(dd.FieldsByTag[945].EnumDict.GetType(), Is.EqualTo(typeof(Dictionary<string, string>)));
             Assert.That("COMPLETED", Is.EqualTo(dd.FieldsByTag[945].EnumDict["2"]));
             Assert.That(dd.FieldsByTag[35].EnumDict["A"], Is.Not.EqualTo("HEARTBEAT"));
         }

--- a/UnitTests/DataDictionaryTests.cs
+++ b/UnitTests/DataDictionaryTests.cs
@@ -17,7 +17,7 @@ namespace UnitTests
         [Test]
         public void VersionTest()
         {
-            DataDictionary dd44 = new DataDictionary();
+            DataDictionary dd44 = new();
             dd44.LoadFIXSpec("FIX44");
             Assert.That(dd44.MajorVersion, Is.EqualTo("4"));
             Assert.That(dd44.MinorVersion, Is.EqualTo("4"));
@@ -27,7 +27,7 @@ namespace UnitTests
         [Test]
         public void LoadFieldsTest()
         {
-            DataDictionary dd = new DataDictionary();
+            DataDictionary dd = new();
             dd.LoadFIXSpec("FIX44");
             Assert.That(dd.FieldsByTag[1].Name, Is.EqualTo("Account"));
             Assert.That(dd.FieldsByName["Account"].Tag, Is.EqualTo(1));
@@ -38,7 +38,7 @@ namespace UnitTests
 		[Test]
 		public void LoadFieldsFromStreamTest()
 		{
-			DataDictionary dd = new DataDictionary();
+			DataDictionary dd = new();
 		    Stream stream = new FileStream(Path.Combine(TestContext.CurrentContext.TestDirectory, "spec", "fix", "FIX44.xml"), FileMode.Open, FileAccess.Read);
 			dd.Load(stream);
 			Assert.That(dd.FieldsByTag[1].Name, Is.EqualTo("Account"));
@@ -50,7 +50,7 @@ namespace UnitTests
         [Test]
         public void FieldHasValueTest()
         {
-            DataDictionary dd = new DataDictionary();
+            DataDictionary dd = new();
             dd.LoadFIXSpec("FIX44");
             Assert.That(dd.FieldHasValue(QuickFix.Fields.Tags.StatusValue, "1"), Is.EqualTo(true));
             Assert.That(dd.FieldHasValue(QuickFix.Fields.Tags.StatusValue, "CONNECTED"), Is.EqualTo(false));
@@ -61,9 +61,8 @@ namespace UnitTests
         [Test]
         public void FieldHasDescriptionTest()
         {
-            DataDictionary dd = new DataDictionary();
+            DataDictionary dd = new();
             dd.LoadFIXSpec("FIX44");
-            //Assert.That(dd.FieldsByTag[945].EnumDict.GetType(), Is.EqualTo(typeof(Dictionary<string, string>)));
             Assert.That("COMPLETED", Is.EqualTo(dd.FieldsByTag[945].EnumDict["2"]));
             Assert.That(dd.FieldsByTag[35].EnumDict["A"], Is.Not.EqualTo("HEARTBEAT"));
         }
@@ -71,7 +70,7 @@ namespace UnitTests
         [Test]
         public void BasicMessageTest()
         {
-            DataDictionary dd = new DataDictionary();
+            DataDictionary dd = new();
             dd.LoadFIXSpec("FIX44");
             Assert.That(dd.Messages["3"].Fields.Count, Is.EqualTo(7));
         }
@@ -79,7 +78,7 @@ namespace UnitTests
         [Test]
         public void ComponentSmokeTest()
         {
-            DataDictionary dd = new DataDictionary();
+            DataDictionary dd = new();
             dd.LoadFIXSpec("FIX44");
             DDMap tcr = dd.Messages["AE"];
             Assert.That(tcr.Fields.ContainsKey(55), Is.True);
@@ -89,7 +88,7 @@ namespace UnitTests
         [Test]
         public void GroupTest()
         {
-            DataDictionary dd = new DataDictionary();
+            DataDictionary dd = new();
             dd.LoadFIXSpec("FIX44");
             DDMap tcrr = dd.Messages["AD"];
             Assert.That(tcrr.IsGroup(711), Is.True);
@@ -104,7 +103,7 @@ namespace UnitTests
         [Test]
         public void NestedGroupTest()
         {
-            DataDictionary dd = new DataDictionary();
+            DataDictionary dd = new();
             dd.LoadFIXSpec("FIX44");
             DDMap msgJ = dd.Messages["J"];
 
@@ -116,7 +115,7 @@ namespace UnitTests
         [Test]
         public void GroupBeginsGroupTest()
         {
-            DataDictionary dd = new DataDictionary();
+            DataDictionary dd = new();
             dd.LoadTestFIXSpec("group_begins_group");
             DDMap msg = dd.Messages["magic"];
             Assert.That(msg.IsGroup(6660), Is.True); // NoMagics group
@@ -130,7 +129,7 @@ namespace UnitTests
         [Test]
         public void HeaderGroupTest()
         {
-            DataDictionary dd = new DataDictionary();
+            DataDictionary dd = new();
             dd.LoadFIXSpec("FIX44");
             DDMap headerMap = dd.Header;
             Assert.That(headerMap.IsGroup(627), Is.True);
@@ -142,7 +141,7 @@ namespace UnitTests
         [Test]
         public void ReqFldTest()
         {
-            DataDictionary dd = new DataDictionary();
+            DataDictionary dd = new();
             dd.LoadFIXSpec("FIX44");
             Assert.That(dd.Messages["AE"].ReqFields.Contains(571), Is.True);
             Assert.That(dd.Messages["AE"].ReqFields.Contains(828), Is.False);
@@ -151,7 +150,7 @@ namespace UnitTests
         [Test]
         public void HeaderTest()
         {
-            DataDictionary dd = new DataDictionary();
+            DataDictionary dd = new();
             dd.LoadFIXSpec("FIX44");
             Assert.That(dd.Header.ReqFields.Contains(9), Is.True);
             Assert.That(dd.Header.Fields.Count, Is.EqualTo(27));
@@ -160,7 +159,7 @@ namespace UnitTests
         [Test]
         public void TrailerTest()
         {
-            DataDictionary dd = new DataDictionary();
+            DataDictionary dd = new();
             dd.LoadFIXSpec("FIX44");
             Assert.That(dd.Trailer.ReqFields.Contains(10), Is.True);
             Assert.That(dd.Trailer.Fields.Count, Is.EqualTo(3));
@@ -169,7 +168,7 @@ namespace UnitTests
         [Test]
         public void CheckValidFormat()
         {
-            DataDictionary dd = new DataDictionary();
+            DataDictionary dd = new();
             dd.LoadFIXSpec("FIX44");
             dd.CheckFieldsHaveValues = true;
 
@@ -233,7 +232,7 @@ namespace UnitTests
         [Test]
         public void CheckValidTagNumberTest()
         {
-            DataDictionary dd = new DataDictionary();
+            DataDictionary dd = new();
             dd.LoadFIXSpec("FIX44");
 
             Assert.DoesNotThrow(delegate { dd.CheckValidTagNumber(35); });
@@ -248,7 +247,7 @@ namespace UnitTests
         [Test]
         public void CheckValue()
         {
-            DataDictionary dd = new DataDictionary();
+            DataDictionary dd = new();
             dd.LoadFIXSpec("FIX44");
 
             // unknown field
@@ -278,7 +277,7 @@ namespace UnitTests
         [Test]
         public void CheckIsInMessageTest()
         {
-            DataDictionary dd = new DataDictionary();
+            DataDictionary dd = new();
             dd.LoadFIXSpec("FIX44");
 
             Assert.DoesNotThrow(delegate { dd.CheckIsInMessage(new QuickFix.Fields.MDReqID("foo"), "W"); });
@@ -293,7 +292,7 @@ namespace UnitTests
         [Test]
         public void CheckIsInGroupTest()
         {
-            DataDictionary dd = new DataDictionary();
+            DataDictionary dd = new();
             dd.LoadFIXSpec("FIX44");
             DDGrp g = dd.Messages["B"].GetGroup(33);
 
@@ -307,7 +306,7 @@ namespace UnitTests
         [Test]
         public void CheckGroupCountTest()
         {
-            DataDictionary dd = new DataDictionary();
+            DataDictionary dd = new();
             dd.LoadFIXSpec("FIX42");
 
             QuickFix.FIX42.NewOrderSingle n = new QuickFix.FIX42.NewOrderSingle();
@@ -333,14 +332,14 @@ namespace UnitTests
         public void DuplicateEnumsDoesNotThrow()
         {
             // If this test throws, it failed.
-            DataDictionary dd = new DataDictionary();
+            DataDictionary dd = new();
             dd.LoadTestFIXSpec("FIX43_dup_enum");
         }
 
         [Test]
         public void ComponentFieldsRequirements()
         {
-            DataDictionary dd = new DataDictionary();
+            DataDictionary dd = new();
             dd.LoadFIXSpec("FIX44");
 
             // AD => Instrument component (optional) => 55 (Symbol)
@@ -352,7 +351,7 @@ namespace UnitTests
         [Test]
         public void Issue134_RequiredIsOptional()
         {
-            DataDictionary dd = new DataDictionary();
+            DataDictionary dd = new();
             dd.LoadTestFIXSpec("required_is_optional");
             Assert.That(dd.Messages["magic"].ReqFields.Contains(1111), Is.True);  //base required field
             Assert.That(dd.Messages["magic"].ReqFields.Contains(5555), Is.False); //base optional field
@@ -365,7 +364,7 @@ namespace UnitTests
         [Test] // Issue #493
         public void ParseThroughComments()
         {
-            DataDictionary dd = new DataDictionary();
+            DataDictionary dd = new();
             dd.LoadTestFIXSpec("comments");
 
             // The fact that it doesn't throw is sufficient, but we'll do some other checks anyway.
@@ -382,7 +381,7 @@ namespace UnitTests
 
         [Test]
         public void TestCheckMsgType() {
-            DataDictionary dd = new DataDictionary();
+            DataDictionary dd = new();
             dd.LoadTestFIXSpec("msg_type_test");
 
             Assert.Throws(typeof(InvalidMessageType), delegate { dd.CheckMsgType("foo"); });


### PR DESCRIPTION
Reduce unnecessary ContainsKey function calls to avoid multiple duplicate key lookups. 
For example, quality rules: [CA1854](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1854), [CA8464](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1864), etc...