### PR TITLE
Reusing StringBuilder with Object Pooling

### DIFF
--- a/QuickFIXn/HttpServer.cs
+++ b/QuickFIXn/HttpServer.cs
@@ -6,6 +6,7 @@ using System.Net;
 using System.Text;
 using System.Threading;
 using QuickFix.Fields.Converters;
+using QuickFix.ObjectPooling;
 
 namespace QuickFix;
 
@@ -96,7 +97,8 @@ public class HttpServer : IDisposable {
                 HttpListenerRequest request = context.Request;
                 HttpListenerResponse response = context.Response;
 
-                StringBuilder sb = new StringBuilder();
+                using PooledStringBuilder pooledSb = new PooledStringBuilder();
+                StringBuilder sb = pooledSb.Builder;
                 sb.AppendLine("<html>");
                 sb.AppendLine("  <head>");
                 sb.AppendLine("    <title>QuickFIX/n Engine Simple Web Interface</title>");

--- a/QuickFIXn/Logger/FileLog.cs
+++ b/QuickFIXn/Logger/FileLog.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using QuickFix.Fields.Converters;
+using QuickFix.ObjectPooling;
 using QuickFix.Util;
 
 namespace QuickFix.Logger;
@@ -43,8 +44,8 @@ public class FileLog : ILog
 
     public static string Prefix(SessionID sessionId)
     {
-        System.Text.StringBuilder prefix = new System.Text.StringBuilder(sessionId.BeginString)
-            .Append('-').Append(sessionId.SenderCompID);
+        using PooledStringBuilder pooledSb = new PooledStringBuilder();
+        System.Text.StringBuilder prefix = pooledSb.Builder.Append(sessionId.BeginString).Append('-').Append(sessionId.SenderCompID);
         if (SessionID.IsSet(sessionId.SenderSubID))
             prefix.Append('_').Append(sessionId.SenderSubID);
         if (SessionID.IsSet(sessionId.SenderLocationID))
@@ -143,7 +144,7 @@ public class FileLog : ILog
         GC.SuppressFinalize(this);
     }
 
-    private bool _disposed = false;
+    private bool _disposed;
     protected virtual void Dispose(bool disposing)
     {
         if (!disposing)

--- a/QuickFIXn/Message/FieldMap.cs
+++ b/QuickFIXn/Message/FieldMap.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using QuickFix.Fields;
 using QuickFix.Fields.Converters;
+using QuickFix.ObjectPooling;
 
 namespace QuickFix
 {
@@ -582,7 +583,8 @@ namespace QuickFix
         /// <returns></returns>
         public virtual string CalculateString()
         {
-            return CalculateString(new StringBuilder(), FieldOrder);
+            using PooledStringBuilder pooledSb = new PooledStringBuilder();
+            return CalculateString(pooledSb.Builder, FieldOrder);
         }
 
         /// <summary>
@@ -599,11 +601,11 @@ namespace QuickFix
             {
                 if (IsSetField(preField))
                 {
-                    sb.Append(preField + "=" + GetString(preField)).Append(Message.SOH);
+                    sb.Append(preField).Append('=').Append(GetString(preField)).Append(Message.SOH);
                     if (groupCounterTags.Contains(preField))
                     {
-                        List<Group> glist = _groups[preField];
-                        foreach (Group g in glist)
+                        List<Group> groupList = _groups[preField];
+                        foreach (Group g in groupList)
                             sb.Append(g.CalculateString());
                     }
                 }
@@ -615,7 +617,7 @@ namespace QuickFix
                     continue;
                 if (preFields.Contains(field.Tag))
                     continue; //already did this one
-                sb.Append($"{field.Tag}={field.ToString()}");
+                sb.Append(field.Tag).Append('=').Append(field.ToString());
                 sb.Append(Message.SOH);
             }
 

--- a/QuickFIXn/Message/Group.cs
+++ b/QuickFIXn/Message/Group.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using QuickFix.ObjectPooling;
+using System;
 using System.Text;
 
 namespace QuickFix
@@ -66,8 +67,10 @@ namespace QuickFix
         /// Creates a FIX (ish) string representation of this FieldMap (does not change the object state)
         /// </summary>
         /// <returns></returns>
-        public override string CalculateString() {
-            return base.CalculateString(new StringBuilder(), FieldOrder ?? new[] { Delim });
+        public override string CalculateString()
+        {
+            using PooledStringBuilder pooledSb = new PooledStringBuilder();
+            return base.CalculateString(pooledSb.Builder, FieldOrder ?? new[] { Delim });
         }
 
         public override string ToString()

--- a/QuickFIXn/Message/Header.cs
+++ b/QuickFIXn/Message/Header.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using QuickFix.Fields;
+using QuickFix.ObjectPooling;
 
 namespace QuickFix {
     public class Header : FieldMap {
@@ -17,8 +18,10 @@ namespace QuickFix {
         /// Creates a FIX (ish) string representation of this FieldMap (does not change the object state)
         /// </summary>
         /// <returns></returns>
-        public override string CalculateString() {
-            return base.CalculateString(new StringBuilder(), HEADER_FIELD_ORDER);
+        public override string CalculateString()
+        {
+            using PooledStringBuilder pooledSb = new PooledStringBuilder();
+            return base.CalculateString(pooledSb.Builder, HEADER_FIELD_ORDER);
         }
 
         /// <summary>

--- a/QuickFIXn/Message/Message.cs
+++ b/QuickFIXn/Message/Message.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using System.Collections.Generic;
 using QuickFix.DataDictionary;
 using DD = QuickFix.DataDictionary.DataDictionary;
+using QuickFix.ObjectPooling;
 
 namespace QuickFix
 {
@@ -853,7 +854,8 @@ namespace QuickFix
 
         private static string FieldMapToXml(DD? dd, FieldMap fields)
         {
-            StringBuilder s = new StringBuilder();
+            using PooledStringBuilder pooledSb = new PooledStringBuilder();
+            StringBuilder s = pooledSb.Builder;
 
             // fields
             foreach (var f in fields)
@@ -861,10 +863,10 @@ namespace QuickFix
                s.Append("<field ");
                if (dd is not null && dd.FieldsByTag.TryGetValue(f.Key, out var value))
                {
-                   s.Append("name=\"" + value.Name + "\" ");
+                   s.Append("name=\"").Append(value.Name).Append("\" ");
                }
-               s.Append("number=\"" + f.Key + "\">");
-               s.Append("<![CDATA[" + f.Value + "]]>");
+               s.Append("number=\"").Append(f.Key).Append("\">");
+               s.Append("<![CDATA[").Append(f.Value).Append("]]>");
                s.Append("</field>");
             }
             // now groups
@@ -965,7 +967,8 @@ namespace QuickFix
         /// <returns>an XML string</returns>
         public string ToXML(DD? dataDictionary = null)
         {
-            StringBuilder s = new StringBuilder();
+            using PooledStringBuilder pooledSb = new PooledStringBuilder();
+            StringBuilder s = pooledSb.Builder;
             s.Append("<message>");
             s.Append("<header>");
             s.Append(FieldMapToXml(dataDictionary, Header));
@@ -999,7 +1002,8 @@ namespace QuickFix
                     $"Must be non-null if '{nameof(convertEnumsToDescriptions)}' is true.");
             }
 
-            StringBuilder sb = new StringBuilder().Append('{').Append("\"Header\":{");
+            using PooledStringBuilder pooledSb = new PooledStringBuilder();
+            StringBuilder sb = pooledSb.Builder.Append('{').Append("\"Header\":{");
             FieldMapToJson(sb, dataDictionary, Header, convertEnumsToDescriptions).Append("},\"Body\":{");
             FieldMapToJson(sb, dataDictionary, this, convertEnumsToDescriptions).Append("},\"Trailer\":{");
             FieldMapToJson(sb, dataDictionary, Trailer, convertEnumsToDescriptions).Append("}}");

--- a/QuickFIXn/Message/Trailer.cs
+++ b/QuickFIXn/Message/Trailer.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using QuickFix.Fields;
+using QuickFix.ObjectPooling;
 
 namespace QuickFix {
     public class Trailer : FieldMap {
@@ -17,8 +18,10 @@ namespace QuickFix {
         /// Creates a FIX (ish) string representation of this FieldMap (does not change the object state)
         /// </summary>
         /// <returns></returns>
-        public override string CalculateString() {
-            return base.CalculateString(new StringBuilder(), TRAILER_FIELD_ORDER);
+        public override string CalculateString() 
+        {
+            using PooledStringBuilder pooledSb = new PooledStringBuilder();
+            return base.CalculateString(pooledSb.Builder, TRAILER_FIELD_ORDER);
         }
 
         /// <summary>

--- a/QuickFIXn/ObjectPooling/DefaultObjectPool.cs
+++ b/QuickFIXn/ObjectPooling/DefaultObjectPool.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Threading;
+
+namespace QuickFix.ObjectPooling;
+
+/// <summary>
+/// Default object pool implementation.
+/// </summary>
+internal sealed class DefaultObjectPool<T> : ObjectPool<T> where T : class
+{
+    private T? _fastItem;
+    private readonly ConcurrentQueue<T> _items = new();
+    private int _numItems;
+
+    internal int Capacity { get; init; } = Environment.ProcessorCount * 2;
+
+    public override T? Get()
+    {
+        T? item = _fastItem;
+        if (item == null || Interlocked.CompareExchange(ref _fastItem, null, item) != item)
+        {
+            if (_items.TryDequeue(out item))
+            {
+                Interlocked.Decrement(ref _numItems);
+            }
+        }
+
+        return item;
+    }
+
+    public override bool Return(T item)
+    {
+        if (_fastItem != null || Interlocked.CompareExchange(ref _fastItem, item, null) != null)
+        {
+            if (Interlocked.Increment(ref _numItems) <= Capacity)
+            {
+                _items.Enqueue(item);
+                return true;
+            }
+
+            Interlocked.Decrement(ref _numItems);
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/QuickFIXn/ObjectPooling/ObjectPool.cs
+++ b/QuickFIXn/ObjectPooling/ObjectPool.cs
@@ -1,0 +1,41 @@
+﻿namespace QuickFix.ObjectPooling;
+
+/// <summary>
+/// Object pooling base class.
+/// </summary>
+internal abstract class ObjectPool<T> where T : class
+{
+    private static readonly DefaultObjectPool<T> s_shared = new();
+    private static readonly DefaultObjectPool<T> s_bigShared = new() { Capacity = 128 };
+
+    /// <summary>
+    /// Get an object from the pool. If no objects are available, return <see langword="null"/>.
+    /// </summary>
+    /// <returns>
+    /// The object from the pool, or <see langword="null"/> if no objects are available.
+    /// </returns>
+    public abstract T? Get();
+
+    /// <summary>
+    /// Return an object to the pool. If the pool is full, the object will not be returned.
+    /// </summary>
+    /// <returns>
+    /// <see langword="true"/> if the object was returned to the pool, <see langword="false"/> if the pool is full.
+    /// </returns>
+    public abstract bool Return(T item);
+
+    /// <summary>
+    /// A shared object pool with a default capacity.
+    /// </summary>
+    public static ObjectPool<T> Shared => s_shared;
+
+    /// <summary>
+    /// A shared object pool with a larger capacity.
+    /// </summary>
+    public static ObjectPool<T> BigShared => s_bigShared;
+
+    /// <summary>
+    /// Create a new object pool with the specified capacity.
+    /// </summary>
+    public static ObjectPool<T> Create(int capacity) => new DefaultObjectPool<T>() { Capacity = capacity };
+}

--- a/QuickFIXn/ObjectPooling/PooledStringBuilder.cs
+++ b/QuickFIXn/ObjectPooling/PooledStringBuilder.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Text;
+
+namespace QuickFix.ObjectPooling;
+
+/// <summary>
+/// A pooled StringBuilder that can be used to reduce memory allocations.
+/// </summary>
+internal readonly struct PooledStringBuilder : IDisposable
+{
+    private static readonly ObjectPool<StringBuilder> _pool = ObjectPool<StringBuilder>.BigShared;
+
+    public StringBuilder Builder { get; }
+
+    public PooledStringBuilder()
+    {
+        Builder = _pool.Get() ?? new StringBuilder(4096);
+    }
+
+    public override string ToString() => Builder.ToString();
+
+    public void Dispose()
+    {
+        if (Builder.Length > 64 * 1024)
+        {
+            return;
+        }
+
+        Builder.Clear();
+        _pool.Return(Builder);
+    }
+}

--- a/QuickFIXn/SessionSettings.cs
+++ b/QuickFIXn/SessionSettings.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using QuickFix.ObjectPooling;
+using System.Collections.Generic;
 using System.IO;
 
 namespace QuickFix;
@@ -233,8 +234,8 @@ public class SessionSettings
 
     public override string ToString()
     {
-        System.Text.StringBuilder s = new System.Text.StringBuilder();
-        s.AppendLine("[DEFAULT]");
+        using PooledStringBuilder pooledSb = new PooledStringBuilder();
+        System.Text.StringBuilder s = pooledSb.Builder.AppendLine("[DEFAULT]");
 
         foreach (System.Collections.Generic.KeyValuePair<string, string> entry in _defaults)
             s.Append(entry.Key).Append('=').AppendLine(entry.Value);

--- a/QuickFIXn/Store/FileStore.cs
+++ b/QuickFIXn/Store/FileStore.cs
@@ -2,6 +2,7 @@
 using System.Buffers;
 using System.Collections.Generic;
 using System.Text;
+using QuickFix.ObjectPooling;
 using QuickFix.Util;
 
 namespace QuickFix.Store;
@@ -226,8 +227,8 @@ public class FileStore : IMessageStore
 
         using ValueDisposable _ = CharEncoding.GetBytes(msg.AsSpan(), out ReadOnlySpan<byte> msgBytes);
 
-        StringBuilder b = new StringBuilder();
-        b.Append(msgSeqNum).Append(',').Append(offset).Append(',').Append(msgBytes.Length);
+        using PooledStringBuilder pooledSb = new PooledStringBuilder();
+        StringBuilder b = pooledSb.Builder.Append(msgSeqNum).Append(',').Append(offset).Append(',').Append(msgBytes.Length);
         _headerFile.WriteLine(b.ToString());
         _headerFile.Flush();
 


### PR DESCRIPTION
Reuse StringBuilder using an object pool to reduce memory allocation.

I have an additional poll, would people be more inclined to introduce the [Microsoft.Extensions.ObjectPool](https://www.nuget.org/packages/Microsoft.Extensions.ObjectPool) package?