### PR TITLE
fix #963 NonSessionLog concurrency bug on Windows

### DIFF
--- a/QuickFIXn/ThreadedSocketAcceptor.cs
+++ b/QuickFIXn/ThreadedSocketAcceptor.cs
@@ -274,7 +274,6 @@ namespace QuickFix
             LogoutAllSessions(force);
             DisposeSessions();
             _sessions.Clear();
-            _nonSessionLog.Dispose();
             _isStarted = false;
 
             // FIXME StopSessionTimer();

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -42,6 +42,7 @@ What's New
 * #942 - fix #942: field 369 (LastMsgSeqNumProcessed) wrong in ResendRequest message (gbirchmeier)
 * #940 - Create an alternate CharEncoding.GetBytes impl which uses ArrayPool to improve memory performance (VAllens)
 * #951 - fix: restore Session disconnect during SocketInitiatorThread.Read exception (gbirchmeier/trevor-bush)
+* #963 - fix: concurrency bug with NonSessionLog on Windows (gbirchmeier)
 
 ### v1.13.1
 * backport #951 to 1.13

--- a/UnitTests/Logger/NonSessionLogTests.cs
+++ b/UnitTests/Logger/NonSessionLogTests.cs
@@ -5,22 +5,17 @@ using QuickFix.Logger;
 namespace UnitTests.Logger;
 
 [TestFixture]
-public class NonSessionLogTests {
+public class NonSessionLogTests
+{
     private readonly string _logDirectory = Path.Combine(TestContext.CurrentContext.TestDirectory, "log");
-
-    private NonSessionLog? _nslog;
-    private NonSessionLog? _nslog2;
 
     [TearDown]
     public void Teardown()
     {
-        _nslog?.Dispose();
-        _nslog = null;
-        _nslog2?.Dispose();
-        _nslog2 = null;
     }
 
-    private FileLogFactory CreateFileLogFactory() {
+    private FileLogFactory CreateFileLogFactory()
+    {
         if (Directory.Exists(_logDirectory))
             Directory.Delete(_logDirectory, true);
 
@@ -35,28 +30,27 @@ public class NonSessionLogTests {
                                TargetCompID=TARGETCOMP
                                """;
 
-        QuickFix.SessionSettings settings = new QuickFix.SessionSettings(
+        QuickFix.SessionSettings settings = new(
             new StringReader(configString));
 
         return new FileLogFactory(settings);
     }
 
     [Test]
-    public void TestWithFileLogFactory() {
+    public void TestWithFileLogFactory()
+    {
         FileLogFactory flf = CreateFileLogFactory();
-        _nslog = new NonSessionLog(flf);
+        NonSessionLog nslog = new(flf);
 
         // Log artifact not created before first log-write
         Assert.That(Directory.Exists(_logDirectory), Is.False);
 
         // Log artifact exists after first log-write
-        _nslog.OnEvent("some text");
+        nslog.OnEvent("some text");
         Assert.That(Directory.Exists(_logDirectory));
         Assert.That(File.Exists(Path.Combine(_logDirectory, "Non-Session-Log.event.current.log")));
 
         // cleanup (don't delete log unless success)
-        _nslog.Dispose();
-        _nslog = null;
         Directory.Delete(_logDirectory, true);
     }
 
@@ -64,36 +58,31 @@ public class NonSessionLogTests {
     public void TestTwoFileLogs()
     {
         FileLogFactory flf = CreateFileLogFactory();
-        _nslog = new NonSessionLog(flf);
-        _nslog.OnEvent("log1");
+        NonSessionLog nslog = new(flf);
+        nslog.OnEvent("log1");
 
-        _nslog2 = new NonSessionLog(flf);
-        _nslog2.OnEvent("log2");
+        NonSessionLog nslog2 = new(flf);
+        nslog2.OnEvent("log2");
 
         // cleanup (don't delete log unless success)
-        _nslog.Dispose();
-        _nslog = null;
-        _nslog2.Dispose();
-        _nslog2 = null;
         Directory.Delete(_logDirectory, true);
     }
 
     [Test]
-    public void TestWithCompositeLogFactory() {
+    public void TestWithCompositeLogFactory()
+    {
         CompositeLogFactory clf = new CompositeLogFactory([CreateFileLogFactory(), new NullLogFactory()]);
-        _nslog = new NonSessionLog(clf);
+        NonSessionLog nslog = new(clf);
 
         // Log artifact not created before first log-write
         Assert.That(Directory.Exists(_logDirectory), Is.False);
 
         // Log artifact exists after first log-write
-        _nslog.OnEvent("some text");
+        nslog.OnEvent("some text");
         Assert.That(Directory.Exists(_logDirectory));
         Assert.That(File.Exists(Path.Combine(_logDirectory, "Non-Session-Log.event.current.log")));
 
         // cleanup (don't delete log unless success)
-        _nslog.Dispose();
-        _nslog = null;
         Directory.Delete(_logDirectory, true);
     }
 }

--- a/UnitTests/Logger/NonSessionLogTests.cs
+++ b/UnitTests/Logger/NonSessionLogTests.cs
@@ -9,14 +9,17 @@ public class NonSessionLogTests {
     private readonly string _logDirectory = Path.Combine(TestContext.CurrentContext.TestDirectory, "log");
 
     private NonSessionLog? _nslog;
+    private NonSessionLog? _nslog2;
 
     [TearDown]
     public void Teardown()
     {
         _nslog?.Dispose();
         _nslog = null;
+        _nslog2?.Dispose();
+        _nslog2 = null;
     }
-    
+
     private FileLogFactory CreateFileLogFactory() {
         if (Directory.Exists(_logDirectory))
             Directory.Delete(_logDirectory, true);
@@ -54,6 +57,24 @@ public class NonSessionLogTests {
         // cleanup (don't delete log unless success)
         _nslog.Dispose();
         _nslog = null;
+        Directory.Delete(_logDirectory, true);
+    }
+
+    [Test]
+    public void TestTwoFileLogs()
+    {
+        FileLogFactory flf = CreateFileLogFactory();
+        _nslog = new NonSessionLog(flf);
+        _nslog.OnEvent("log1");
+
+        _nslog2 = new NonSessionLog(flf);
+        _nslog2.OnEvent("log2");
+
+        // cleanup (don't delete log unless success)
+        _nslog.Dispose();
+        _nslog = null;
+        _nslog2.Dispose();
+        _nslog2 = null;
         Directory.Delete(_logDirectory, true);
     }
 


### PR DESCRIPTION
resolves #963

Now each NSL.OnEvent call fully opens/writes/closes the log
in a sync block, so that two processes can never try to open it
at once.

OnEvent is only called rarely, so this should not pose
a performance issue.  (If OnEvent *is* called often enough
to be a perf issue, then you have a bigger problem than perf.)