### PR TITLE
some Session-related refactoring

### DIFF
--- a/QuickFIXn/Session.cs
+++ b/QuickFIXn/Session.cs
@@ -379,6 +379,8 @@ namespace QuickFix
         /// <summary>
         /// Sets some internal state variables to disable the session.
         /// Users will be disconnected on next cycle.
+        /// (This function is for actively initiating a logout,
+        /// it is NOT for processing a logout request from the counterparty.)
         /// </summary>
         public void Logout(string reason = "")
         {
@@ -1198,7 +1200,7 @@ namespace QuickFix
                 return;
             }
 
-            Log.OnEvent("Error sending ResendRequest (" + beginSeqNum + " ," + endChunkSeqNum + ")");
+            Log.OnEvent($"Error sending ResendRequest ({beginSeqNum}, {endChunkSeqNum})");
         }
 
         /// <summary>

--- a/UnitTests/SessionTest.cs
+++ b/UnitTests/SessionTest.cs
@@ -2,222 +2,24 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
-using NUnit.Framework;
 using System.Threading;
+using NUnit.Framework;
+using QuickFix.Fields;
 using QuickFix.Logger;
 using QuickFix.Store;
 
 namespace UnitTests;
 
 [TestFixture]
-public class SessionTest
+public class SessionTest : SessionTestBase
 {
-    private SessionTestSupport.MockResponder _responder = new();
-
-    private QuickFix.SessionID _sessionId = new("unset", "unset", "unset");
-    private QuickFix.SessionSettings _settings = new();
-    private SessionTestSupport.MockApplication _application = new();
-    private QuickFix.Session? _session = null;
-    private QuickFix.Session? _session2 = null;
-    private QuickFix.SettingsDictionary _config = new();
-    private SeqNumType _seqNum = 1;
     private readonly Regex _msRegex = new(@"\.[\d]{1,3}$");
     private readonly Regex _microsecondRegex = new(@"\.[\d]{1,6}$");
 
     [SetUp]
     public void Setup()
     {
-        _responder = new SessionTestSupport.MockResponder();
-        _sessionId = new QuickFix.SessionID("FIX.4.2", "SENDER", "TARGET");
-        _application = new SessionTestSupport.MockApplication();
-        _settings = new QuickFix.SessionSettings();
-
-        _config = new QuickFix.SettingsDictionary();
-        _config.SetBool(QuickFix.SessionSettings.PERSIST_MESSAGES, false);
-        _config.SetString(QuickFix.SessionSettings.CONNECTION_TYPE, "initiator");
-        _config.SetString(QuickFix.SessionSettings.START_TIME, "00:00:00");
-        _config.SetString(QuickFix.SessionSettings.END_TIME, "00:00:00");
-        _settings.Set(_sessionId, _config);
-
-        var logFactory = new NullLogFactory(); // use QuickFix.ScreenLogFactory(settings) if you need to see output
-
-        // acceptor
-        _session = new QuickFix.Session(false, _application, new MemoryStoreFactory(), _sessionId,
-            new QuickFix.DataDictionaryProvider(),new QuickFix.SessionSchedule(_config), 0, logFactory, new QuickFix.DefaultMessageFactory(), "blah");
-        _session.SetResponder(_responder);
-        _session.CheckLatency = false;
-
-        // initiator
-        _session2 = new QuickFix.Session(true, _application, new MemoryStoreFactory(), new QuickFix.SessionID("FIX.4.2", "OTHER_SENDER", "OTHER_TARGET"),
-            new QuickFix.DataDictionaryProvider(), new QuickFix.SessionSchedule(_config), 0, logFactory, new QuickFix.DefaultMessageFactory(), "blah");
-        _session2.SetResponder(_responder);
-        _session2.CheckLatency = false;
-
-        _seqNum = 1;
-    }
-
-    public void Logon()
-    {
-        SendLogon(new QuickFix.FIX42.Logon());
-    }
-
-    public void Logon40()
-    {
-        SendLogon(new QuickFix.FIX40.Logon());
-    }
-
-    private void SendLogon(QuickFix.Message msg, SeqNumType n = 0)
-    {
-        msg.Header.SetField(new QuickFix.Fields.TargetCompID(_sessionId.SenderCompID));
-        msg.Header.SetField(new QuickFix.Fields.SenderCompID(_sessionId.TargetCompID));
-        msg.Header.SetField(new QuickFix.Fields.MsgSeqNum(n == 0 ? _seqNum++ : n));
-        msg.Header.SetField(new QuickFix.Fields.SendingTime(DateTime.UtcNow));
-        msg.SetField(new QuickFix.Fields.HeartBtInt(1));
-        _session!.Next(msg.ConstructString());
-    }
-
-    public bool SENT_SEQUENCE_RESET()
-    {
-        return _responder.MsgLookup.ContainsKey(QuickFix.Fields.MsgType.SEQUENCE_RESET) &&
-            _responder.MsgLookup[QuickFix.Fields.MsgType.SEQUENCE_RESET].Count > 0;
-    }
-
-    public bool SENT_RESEND_REQUEST()
-    {
-        return _responder.MsgLookup.ContainsKey(QuickFix.Fields.MsgType.RESEND_REQUEST) &&
-            _responder.MsgLookup[QuickFix.Fields.MsgType.RESEND_REQUEST].Count > 0;
-    }
-
-    public bool RESENT()
-    {
-        if (_responder.Dups.Count == 0)
-            return false;
-
-        _responder.Dups.Dequeue();
-        return true;
-    }
-
-    public bool SENT_REJECT()
-    {
-        return _responder.MsgLookup.ContainsKey(QuickFix.Fields.MsgType.REJECT) &&
-            _responder.MsgLookup[QuickFix.Fields.MsgType.REJECT].Count>0;
-    }
-
-	    public bool SENT_HEART_BEAT()
-	    {
-        return _responder.MsgLookup.ContainsKey(QuickFix.Fields.MsgType.HEARTBEAT) &&
-            _responder.MsgLookup[QuickFix.Fields.MsgType.HEARTBEAT].Count > 0;
-	    }
-
-    public bool SENT_BUSINESS_REJECT()
-    {
-        return _responder.MsgLookup.ContainsKey(QuickFix.Fields.MsgType.BUSINESS_MESSAGE_REJECT) &&
-            _responder.MsgLookup[QuickFix.Fields.MsgType.BUSINESS_MESSAGE_REJECT].Count > 0;
-    }
-
-    public bool SENT_BUSINESS_REJECT(int reason)
-    {
-        if (!SENT_BUSINESS_REJECT())
-            return false;
-
-        QuickFix.Message msg = _responder.MsgLookup[QuickFix.Fields.MsgType.BUSINESS_MESSAGE_REJECT].First();
-
-        if (!msg.IsSetField(QuickFix.Fields.Tags.BusinessRejectReason))
-            return false;
-
-        QuickFix.Fields.BusinessRejectReason reasonField = new QuickFix.Fields.BusinessRejectReason();
-        msg.GetField(reasonField);
-        return reasonField.Value == reason;
-    }
-
-    public bool SENT_LOGOUT()
-    {
-        return _responder.MsgLookup.ContainsKey(QuickFix.Fields.MsgType.LOGOUT) &&
-            _responder.MsgLookup[QuickFix.Fields.MsgType.LOGOUT].Count > 0;
-    }
-
-    public bool SENT_NOS()
-    {
-        return _responder.MsgLookup.ContainsKey(QuickFix.Fields.MsgType.NEWORDERSINGLE) &&
-            _responder.MsgLookup[QuickFix.Fields.MsgType.NEWORDERSINGLE].Count > 0;
-    }
-
-    public bool DISCONNECTED()
-    {
-        return _responder.Disconnected;
-    }
-
-    public bool SENT_REJECT(int reason, int refTag)
-    {
-        if (!SENT_REJECT())
-            return false;
-
-        QuickFix.Message msg = _responder.MsgLookup[QuickFix.Fields.MsgType.REJECT].First();
-
-        if (!msg.IsSetField(QuickFix.Fields.Tags.SessionRejectReason))
-            return false;
-
-        QuickFix.Fields.SessionRejectReason reasonField = new QuickFix.Fields.SessionRejectReason();
-        msg.GetField(reasonField);
-        if(reasonField.Value != reason)
-            return false;
-
-        if (!msg.IsSetField(QuickFix.Fields.Tags.RefTagID))
-            return false;
-
-        QuickFix.Fields.RefTagID refTagField = new QuickFix.Fields.RefTagID();
-        msg.GetField(refTagField);
-        return refTagField.Value == refTag;
-    }
-
-    public QuickFix.FIX42.NewOrderSingle CreateNOSMessage(SeqNumType n)
-    {
-        QuickFix.FIX42.NewOrderSingle order = new QuickFix.FIX42.NewOrderSingle(
-            new QuickFix.Fields.ClOrdID("1"),
-            new QuickFix.Fields.HandlInst(QuickFix.Fields.HandlInst.MANUAL_ORDER),
-            new QuickFix.Fields.Symbol("IBM"),
-            new QuickFix.Fields.Side(QuickFix.Fields.Side.BUY),
-            new QuickFix.Fields.TransactTime(),
-            new QuickFix.Fields.OrdType(QuickFix.Fields.OrdType.LIMIT));
-
-        order.Header.SetField(new QuickFix.Fields.TargetCompID(_sessionId.SenderCompID));
-        order.Header.SetField(new QuickFix.Fields.SenderCompID(_sessionId.TargetCompID));
-        order.Header.SetField(new QuickFix.Fields.SendingTime(DateTime.UtcNow));
-        order.Header.SetField(new QuickFix.Fields.MsgSeqNum(n));
-        return order;
-    }
-
-    public void SendNOSMessage()
-    {
-        _session!.Next(CreateNOSMessage(_seqNum++).ConstructString());
-    }
-
-    public void SendNOSMessage(SeqNumType n)
-    {
-        _session!.Next(CreateNOSMessage(n).ConstructString());
-    }
-
-    public void SendResendRequest(SeqNumType begin, SeqNumType end)
-    {
-        SendTheMessage(new QuickFix.FIX42.ResendRequest(
-            new QuickFix.Fields.BeginSeqNo(begin),
-            new QuickFix.Fields.EndSeqNo(end)));
-    }
-
-    public void SendResendRequest40(SeqNumType begin, SeqNumType end)
-    {
-        SendTheMessage(new QuickFix.FIX40.ResendRequest(
-            new QuickFix.Fields.BeginSeqNo(begin),
-            new QuickFix.Fields.EndSeqNo(end)));
-    }
-
-    private void SendTheMessage(QuickFix.Message msg)
-    {
-        msg.Header.SetField(new QuickFix.Fields.TargetCompID(_sessionId.SenderCompID));
-        msg.Header.SetField(new QuickFix.Fields.SenderCompID(_sessionId.TargetCompID));
-        msg.Header.SetField(new QuickFix.Fields.MsgSeqNum(_seqNum++));
-
-        _session!.Next(msg.ConstructString());
+        BaseSetup();
     }
 
     [Test]
@@ -239,7 +41,6 @@ public class SessionTest
         Logon();
         SendNOSMessage();
         Assert.That(SENT_REJECT(QuickFix.Fields.SessionRejectReason.VALUE_IS_INCORRECT,54));
-
     }
 
     [Test]
@@ -305,7 +106,7 @@ public class SessionTest
         order.Header.SetField(new QuickFix.Fields.TargetCompID(_sessionId.TargetCompID));
         order.Header.SetField(new QuickFix.Fields.SenderCompID(_sessionId.SenderCompID));
 
-        SeqNumType[] gapStarts = new[] { 1UL, 5UL, 11UL }; // 1st gap  from seq num 1 to 2 is just the Logon message
+        SeqNumType[] gapStarts = new[] { 1UL, 5UL, 11UL }; // 1st gap from seq num 1 to 2 is just the Logon message
         SeqNumType[] gapEnds = new[] { 2UL, 8UL, 15UL };
         int orderCount = 0;
 
@@ -861,32 +662,32 @@ public class SessionTest
 
         // <= FIX41
         _session.GenerateResendRequest(QuickFix.FixValues.BeginString.FIX41, 125);
-        Assert.That(_responder.GetCount(QuickFix.Fields.MsgType.RESEND_REQUEST), Is.EqualTo(1));
-        var rr = _responder.MsgLookup[QuickFix.Fields.MsgType.RESEND_REQUEST].Dequeue();
-        Assert.That(rr.GetInt(QuickFix.Fields.Tags.BeginSeqNo), Is.EqualTo(100));
-        Assert.That(rr.GetInt(QuickFix.Fields.Tags.EndSeqNo), Is.EqualTo(999999));
+        Assert.That(_responder.GetCount(MsgType.RESEND_REQUEST), Is.EqualTo(1));
+        var rr = _responder.MsgLookup[MsgType.RESEND_REQUEST].Dequeue();
+        Assert.That(rr.GetInt(Tags.BeginSeqNo), Is.EqualTo(100));
+        Assert.That(rr.GetInt(Tags.EndSeqNo), Is.EqualTo(999999));
 
         // >= FIX42
         _session.GenerateResendRequest(QuickFix.FixValues.BeginString.FIX42, 125);
-        Assert.That(_responder.GetCount(QuickFix.Fields.MsgType.RESEND_REQUEST), Is.EqualTo(1));
-        rr = _responder.MsgLookup[QuickFix.Fields.MsgType.RESEND_REQUEST].Dequeue();
-        Assert.That(rr.GetInt(QuickFix.Fields.Tags.BeginSeqNo), Is.EqualTo(100));
-        Assert.That(rr.GetInt(QuickFix.Fields.Tags.EndSeqNo), Is.EqualTo(0));
+        Assert.That(_responder.GetCount(MsgType.RESEND_REQUEST), Is.EqualTo(1));
+        rr = _responder.MsgLookup[MsgType.RESEND_REQUEST].Dequeue();
+        Assert.That(rr.GetInt(Tags.BeginSeqNo), Is.EqualTo(100));
+        Assert.That(rr.GetInt(Tags.EndSeqNo), Is.EqualTo(0));
 
         // Max resend is set: request is greater than max resend
         _session.MaxMessagesInResendRequest = 100;
         _session.GenerateResendRequest(QuickFix.FixValues.BeginString.FIX42, 225);
-        Assert.That(_responder.GetCount(QuickFix.Fields.MsgType.RESEND_REQUEST), Is.EqualTo(1));
-        rr = _responder.MsgLookup[QuickFix.Fields.MsgType.RESEND_REQUEST].Dequeue();
-        Assert.That(rr.GetInt(QuickFix.Fields.Tags.BeginSeqNo), Is.EqualTo(100));
-        Assert.That(rr.GetInt(QuickFix.Fields.Tags.EndSeqNo), Is.EqualTo(199));
+        Assert.That(_responder.GetCount(MsgType.RESEND_REQUEST), Is.EqualTo(1));
+        rr = _responder.MsgLookup[MsgType.RESEND_REQUEST].Dequeue();
+        Assert.That(rr.GetInt(Tags.BeginSeqNo), Is.EqualTo(100));
+        Assert.That(rr.GetInt(Tags.EndSeqNo), Is.EqualTo(199));
 
         // Max resend is set: request is lesser than max resend
         _session.GenerateResendRequest(QuickFix.FixValues.BeginString.FIX42, 175);
-        Assert.That(_responder.GetCount(QuickFix.Fields.MsgType.RESEND_REQUEST), Is.EqualTo(1));
-        rr = _responder.MsgLookup[QuickFix.Fields.MsgType.RESEND_REQUEST].Dequeue();
-        Assert.That(rr.GetInt(QuickFix.Fields.Tags.BeginSeqNo), Is.EqualTo(100));
-        Assert.That(rr.GetInt(QuickFix.Fields.Tags.EndSeqNo), Is.EqualTo(174));
+        Assert.That(_responder.GetCount(MsgType.RESEND_REQUEST), Is.EqualTo(1));
+        rr = _responder.MsgLookup[MsgType.RESEND_REQUEST].Dequeue();
+        Assert.That(rr.GetInt(Tags.BeginSeqNo), Is.EqualTo(100));
+        Assert.That(rr.GetInt(Tags.EndSeqNo), Is.EqualTo(174));
     }
 
     [Test]
@@ -899,10 +700,9 @@ public class SessionTest
         Assert.That(_session!.NextTargetMsgSeqNum, Is.EqualTo(3));
 
         SendNOSMessage(6);
-        Assert.That(_responder.GetCount(QuickFix.Fields.MsgType.RESEND_REQUEST), Is.EqualTo(1));
+        Assert.That(_responder.GetCount(MsgType.RESEND_REQUEST), Is.EqualTo(1));
 
-        var resendRequest =
-            (QuickFix.FIX42.ResendRequest)_responder.MsgLookup[QuickFix.Fields.MsgType.RESEND_REQUEST].Dequeue();
+        var resendRequest = (QuickFix.FIX42.ResendRequest)_responder.MsgLookup[MsgType.RESEND_REQUEST].Dequeue();
         Assert.That(resendRequest.BeginSeqNo.Value, Is.EqualTo(3));
         Assert.That(resendRequest.EndSeqNo.Value, Is.EqualTo(0)); // 0 is infinity, but actually we just want until 5
 
@@ -913,8 +713,8 @@ public class SessionTest
         foreach (SeqNumType i in new[] { 3, 4, 5, 7, 8 }) {
             var msg = CreateNOSMessage(i);
             if (i < 7) {
-                msg.Header.SetField(new QuickFix.Fields.PossDupFlag(true));
-                msg.Header.SetField(new QuickFix.Fields.OrigSendingTime(DateTime.MinValue)); // (value doesn't matter for test)
+                msg.Header.SetField(new PossDupFlag(true));
+                msg.Header.SetField(new OrigSendingTime(DateTime.MinValue)); // (value doesn't matter for test)
                 _session.Next(msg.ConstructString());
             }
             _session.Next(msg.ConstructString());
@@ -935,10 +735,10 @@ public class SessionTest
         Assert.That(_session!.NextTargetMsgSeqNum, Is.EqualTo(3));
 
         SendNOSMessage(6);
-        Assert.That(_responder.GetCount(QuickFix.Fields.MsgType.RESEND_REQUEST), Is.EqualTo(1));
+        Assert.That(_responder.GetCount(MsgType.RESEND_REQUEST), Is.EqualTo(1));
 
         var resendRequest =
-            (QuickFix.FIX42.ResendRequest)_responder.MsgLookup[QuickFix.Fields.MsgType.RESEND_REQUEST].Dequeue();
+            (QuickFix.FIX42.ResendRequest)_responder.MsgLookup[MsgType.RESEND_REQUEST].Dequeue();
         Assert.That(resendRequest.BeginSeqNo.Value, Is.EqualTo(3));
         Assert.That(resendRequest.EndSeqNo.Value, Is.EqualTo(5));
 
@@ -949,8 +749,8 @@ public class SessionTest
         foreach (SeqNumType i in new[] { 3, 4, 5, 7, 8 }) {
             var msg = CreateNOSMessage(i);
             if (i < 7) {
-                msg.Header.SetField(new QuickFix.Fields.PossDupFlag(true));
-                msg.Header.SetField(new QuickFix.Fields.OrigSendingTime(DateTime.MinValue)); // (value doesn't matter for test)
+                msg.Header.SetField(new PossDupFlag(true));
+                msg.Header.SetField(new OrigSendingTime(DateTime.MinValue)); // (value doesn't matter for test)
                 _session.Next(msg.ConstructString());
             }
             _session.Next(msg.ConstructString());

--- a/UnitTests/SessionTestBase.cs
+++ b/UnitTests/SessionTestBase.cs
@@ -1,0 +1,213 @@
+using System;
+using System.Linq;
+using QuickFix.Logger;
+using QuickFix.Store;
+
+namespace UnitTests;
+
+public abstract class SessionTestBase
+{
+    protected SessionTestSupport.MockResponder _responder = new();
+
+    protected QuickFix.SessionID _sessionId = new("unset", "unset", "unset");
+    protected SessionTestSupport.MockApplication _application = new();
+    protected QuickFix.Session? _session = null;
+    protected QuickFix.Session? _session2 = null;
+    protected QuickFix.SettingsDictionary _config = new();
+    protected SeqNumType _seqNum = 1;
+
+    public void BaseSetup()
+    {
+        _responder = new SessionTestSupport.MockResponder();
+        _sessionId = new QuickFix.SessionID("FIX.4.2", "SENDER", "TARGET");
+        _application = new SessionTestSupport.MockApplication();
+        QuickFix.SessionSettings _settings = new QuickFix.SessionSettings();
+
+        _config = new QuickFix.SettingsDictionary();
+        _config.SetBool(QuickFix.SessionSettings.PERSIST_MESSAGES, false);
+        _config.SetString(QuickFix.SessionSettings.CONNECTION_TYPE, "initiator");
+        _config.SetString(QuickFix.SessionSettings.START_TIME, "00:00:00");
+        _config.SetString(QuickFix.SessionSettings.END_TIME, "00:00:00");
+        _settings.Set(_sessionId, _config);
+
+        var logFactory = new NullLogFactory(); // use QuickFix.ScreenLogFactory(_settings) if you need to see output
+
+        // acceptor
+        _session = new QuickFix.Session(false, _application, new MemoryStoreFactory(), _sessionId,
+            new QuickFix.DataDictionaryProvider(),new QuickFix.SessionSchedule(_config), 0, logFactory, new QuickFix.DefaultMessageFactory(), "blah");
+        _session.SetResponder(_responder);
+        _session.CheckLatency = false;
+
+        // initiator
+        _session2 = new QuickFix.Session(true, _application, new MemoryStoreFactory(), new QuickFix.SessionID("FIX.4.2", "OTHER_SENDER", "OTHER_TARGET"),
+            new QuickFix.DataDictionaryProvider(), new QuickFix.SessionSchedule(_config), 0, logFactory, new QuickFix.DefaultMessageFactory(), "blah");
+        _session2.SetResponder(_responder);
+        _session2.CheckLatency = false;
+
+        _seqNum = 1;
+    }
+
+    public void Logon()
+    {
+        SendLogon(new QuickFix.FIX42.Logon());
+    }
+
+    public void Logon40()
+    {
+        SendLogon(new QuickFix.FIX40.Logon());
+    }
+
+    protected void SendLogon(QuickFix.Message msg, SeqNumType n = 0UL)
+    {
+        msg.Header.SetField(new QuickFix.Fields.TargetCompID(_sessionId.SenderCompID));
+        msg.Header.SetField(new QuickFix.Fields.SenderCompID(_sessionId.TargetCompID));
+        msg.Header.SetField(new QuickFix.Fields.MsgSeqNum(n == 0 ? _seqNum++ : n));
+        msg.Header.SetField(new QuickFix.Fields.SendingTime(DateTime.UtcNow));
+        msg.SetField(new QuickFix.Fields.HeartBtInt(1));
+        _session!.Next(msg.ConstructString());
+    }
+
+    public bool SENT_SEQUENCE_RESET()
+    {
+        return _responder.MsgLookup.ContainsKey(QuickFix.Fields.MsgType.SEQUENCE_RESET) &&
+            _responder.MsgLookup[QuickFix.Fields.MsgType.SEQUENCE_RESET].Count > 0;
+    }
+
+    public bool SENT_RESEND_REQUEST()
+    {
+        return _responder.MsgLookup.ContainsKey(QuickFix.Fields.MsgType.RESEND_REQUEST) &&
+            _responder.MsgLookup[QuickFix.Fields.MsgType.RESEND_REQUEST].Count > 0;
+    }
+
+    public bool RESENT()
+    {
+        if (_responder.Dups.Count == 0)
+            return false;
+
+        _responder.Dups.Dequeue();
+        return true;
+    }
+
+    public bool SENT_REJECT()
+    {
+        return _responder.MsgLookup.ContainsKey(QuickFix.Fields.MsgType.REJECT) &&
+            _responder.MsgLookup[QuickFix.Fields.MsgType.REJECT].Count>0;
+    }
+
+    public bool SENT_HEART_BEAT()
+    {
+        return _responder.MsgLookup.ContainsKey(QuickFix.Fields.MsgType.HEARTBEAT) &&
+            _responder.MsgLookup[QuickFix.Fields.MsgType.HEARTBEAT].Count > 0;
+    }
+
+    public bool SENT_BUSINESS_REJECT()
+    {
+        return _responder.MsgLookup.ContainsKey(QuickFix.Fields.MsgType.BUSINESS_MESSAGE_REJECT) &&
+            _responder.MsgLookup[QuickFix.Fields.MsgType.BUSINESS_MESSAGE_REJECT].Count > 0;
+    }
+
+    public bool SENT_BUSINESS_REJECT(int reason)
+    {
+        if (!SENT_BUSINESS_REJECT())
+            return false;
+
+        QuickFix.Message msg = _responder.MsgLookup[QuickFix.Fields.MsgType.BUSINESS_MESSAGE_REJECT].First();
+
+        if (!msg.IsSetField(QuickFix.Fields.Tags.BusinessRejectReason))
+            return false;
+
+        QuickFix.Fields.BusinessRejectReason reasonField = new QuickFix.Fields.BusinessRejectReason();
+        msg.GetField(reasonField);
+        return reasonField.Value == reason;
+    }
+
+    public bool SENT_LOGOUT()
+    {
+        return _responder.MsgLookup.ContainsKey(QuickFix.Fields.MsgType.LOGOUT) &&
+            _responder.MsgLookup[QuickFix.Fields.MsgType.LOGOUT].Count > 0;
+    }
+
+    public bool SENT_NOS()
+    {
+        return _responder.MsgLookup.ContainsKey(QuickFix.Fields.MsgType.NEWORDERSINGLE) &&
+            _responder.MsgLookup[QuickFix.Fields.MsgType.NEWORDERSINGLE].Count > 0;
+    }
+
+    public bool DISCONNECTED()
+    {
+        return _responder.Disconnected;
+    }
+
+    public bool SENT_REJECT(int reason, int refTag)
+    {
+        if (!SENT_REJECT())
+            return false;
+
+        QuickFix.Message msg = _responder.MsgLookup[QuickFix.Fields.MsgType.REJECT].First();
+
+        if (!msg.IsSetField(QuickFix.Fields.Tags.SessionRejectReason))
+            return false;
+
+        QuickFix.Fields.SessionRejectReason reasonField = new QuickFix.Fields.SessionRejectReason();
+        msg.GetField(reasonField);
+        if(reasonField.Value != reason)
+            return false;
+
+        if (!msg.IsSetField(QuickFix.Fields.Tags.RefTagID))
+            return false;
+
+        QuickFix.Fields.RefTagID refTagField = new QuickFix.Fields.RefTagID();
+        msg.GetField(refTagField);
+        return refTagField.Value == refTag;
+    }
+
+    public QuickFix.FIX42.NewOrderSingle CreateNOSMessage(SeqNumType n)
+    {
+        QuickFix.FIX42.NewOrderSingle order = new QuickFix.FIX42.NewOrderSingle(
+            new QuickFix.Fields.ClOrdID("1"),
+            new QuickFix.Fields.HandlInst(QuickFix.Fields.HandlInst.MANUAL_ORDER),
+            new QuickFix.Fields.Symbol("IBM"),
+            new QuickFix.Fields.Side(QuickFix.Fields.Side.BUY),
+            new QuickFix.Fields.TransactTime(),
+            new QuickFix.Fields.OrdType(QuickFix.Fields.OrdType.LIMIT));
+
+        order.Header.SetField(new QuickFix.Fields.TargetCompID(_sessionId.SenderCompID));
+        order.Header.SetField(new QuickFix.Fields.SenderCompID(_sessionId.TargetCompID));
+        order.Header.SetField(new QuickFix.Fields.SendingTime(DateTime.UtcNow));
+        order.Header.SetField(new QuickFix.Fields.MsgSeqNum(n));
+        return order;
+    }
+
+    public void SendNOSMessage()
+    {
+        _session!.Next(CreateNOSMessage(_seqNum++).ConstructString());
+    }
+
+    public void SendNOSMessage(SeqNumType n)
+    {
+        _session!.Next(CreateNOSMessage(n).ConstructString());
+    }
+
+    public void SendResendRequest(SeqNumType begin, SeqNumType end)
+    {
+        SendTheMessage(new QuickFix.FIX42.ResendRequest(
+            new QuickFix.Fields.BeginSeqNo(begin),
+            new QuickFix.Fields.EndSeqNo(end)));
+    }
+
+    public void SendResendRequest40(SeqNumType begin, SeqNumType end)
+    {
+        SendTheMessage(new QuickFix.FIX40.ResendRequest(
+            new QuickFix.Fields.BeginSeqNo(begin),
+            new QuickFix.Fields.EndSeqNo(end)));
+    }
+
+    protected void SendTheMessage(QuickFix.Message msg, SeqNumType n = 0)
+    {
+        msg.Header.SetField(new QuickFix.Fields.TargetCompID(_sessionId.SenderCompID));
+        msg.Header.SetField(new QuickFix.Fields.SenderCompID(_sessionId.TargetCompID));
+        msg.Header.SetField(new QuickFix.Fields.MsgSeqNum(n == 0 ? _seqNum++ : n));
+
+        _session!.Next(msg.ConstructString());
+    }
+}

--- a/UnitTests/SessionTestSupport/MockApplication.cs
+++ b/UnitTests/SessionTestSupport/MockApplication.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace UnitTests.SessionTestSupport;
 
-internal class MockApplication : QuickFix.IApplication
+public class MockApplication : QuickFix.IApplication
 {
     public Exception? FromAppException { get; set; }
     public Exception? FromAdminException { get; set; }
@@ -35,10 +35,7 @@ internal class MockApplication : QuickFix.IApplication
 
     public void OnCreate(QuickFix.SessionID sessionId) { }
 
-    public void OnLogout(QuickFix.SessionID sessionId)
-    {
-        throw new NotImplementedException();
-    }
+    public void OnLogout(QuickFix.SessionID sessionId) { }
 
     public void OnLogon(QuickFix.SessionID sessionId) { }
 }

--- a/UnitTests/SessionTestSupport/MockResponder.cs
+++ b/UnitTests/SessionTestSupport/MockResponder.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace UnitTests.SessionTestSupport;
 
-internal class MockResponder : QuickFix.IResponder
+public class MockResponder : QuickFix.IResponder
 {
     private readonly QuickFix.DefaultMessageFactory _messageFactory = new();
     private readonly QuickFix.IMessageFactory _defaultMsgFactory = new QuickFix.DefaultMessageFactory();

--- a/UnitTests/ThreadedSocketAcceptor_RestartTests.cs
+++ b/UnitTests/ThreadedSocketAcceptor_RestartTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Net;
 using System.Net.Sockets;
@@ -12,560 +13,552 @@ using QuickFix;
 using QuickFix.Logger;
 using QuickFix.Store;
 
-namespace UnitTests
+namespace UnitTests;
+
+[TestFixture]
+public class ThreadedSocketAcceptor_RestartTests
 {
-    [TestFixture]
-    public class ThreadedSocketAcceptor_RestartTests
+    private const string Host = "127.0.0.1";
+    private const int AcceptPort = 55101;
+    private const string StaticAcceptorCompID = "acc01";
+    private const string StaticAcceptorCompID2 = "acc02";
+    private const string ServerCompID = "dummy";
+    private ThreadedSocketAcceptor? _acceptor;
+    private const string FIXMessageEnd = @"\x0110=\d{3}\x01";
+    private const string FIXMessageDelimit = @"(8=FIX|\A).*?(" + FIXMessageEnd + @"|\z)";
+    private Dictionary<string, SocketState> _sessions = new Dictionary<string, SocketState>();
+    private HashSet<string> _loggedOnCompIDs = new HashSet<string>();
+    private SeqNumType _senderSequenceNumber = 1;
+
+    public class TestApplication : IApplication
     {
-        private const string Host = "127.0.0.1";
-        private const int AcceptPort = 55101;
-        private const string StaticAcceptorCompID = "acc01";
-        private const string StaticAcceptorCompID2 = "acc02";
-        private const string ServerCompID = "dummy";
-        private ThreadedSocketAcceptor? _acceptor;
-        private const string FIXMessageEnd = @"\x0110=\d{3}\x01";
-        private const string FIXMessageDelimit = @"(8=FIX|\A).*?(" + FIXMessageEnd + @"|\z)";
-        private Dictionary<string, SocketState> _sessions = new Dictionary<string, SocketState>();
-        private HashSet<string> _loggedOnCompIDs = new HashSet<string>();
-        private ulong _senderSequenceNumber = 1;
+        private readonly Action<string> _logonNotify;
+        private readonly Action<string> _logoffNotify;
 
-        public class TestApplication : IApplication
+        public TestApplication(Action<string> logonNotify, Action<string> logoffNotify)
         {
-            private Action<string> _logonNotify;
-            private Action<string> _logoffNotify;
-
-            public TestApplication(Action<string> logonNotify, Action<string> logoffNotify)
-            {
-                _logonNotify = logonNotify;
-                _logoffNotify = logoffNotify;
-            }
-
-            public void FromAdmin(Message message, SessionID sessionID)
-            { }
-
-            public void FromApp(Message message, SessionID sessionID)
-            { }
-
-            public void OnCreate(SessionID sessionID) { }
-            public void OnLogout(SessionID sessionID)
-            {
-                _logoffNotify(sessionID.TargetCompID);
-            }
-            public void OnLogon(SessionID sessionID)
-            {
-                _logonNotify(sessionID.TargetCompID);
-            }
-
-            public void ToAdmin(Message message, SessionID sessionID) { }
-            public void ToApp(Message message, SessionID sessionID) { }
-
+            _logonNotify = logonNotify;
+            _logoffNotify = logoffNotify;
         }
 
-        private void LogonCallback(string compID)
-        {
-            lock (_loggedOnCompIDs)
-            {
-                _loggedOnCompIDs.Add(compID);
-                Monitor.Pulse(_loggedOnCompIDs);
-            }
-        }
-        private void LogoffCallback(string compID)
-        {
-            lock (_loggedOnCompIDs)
-            {
-                _loggedOnCompIDs.Remove(compID);
-                Monitor.Pulse(_loggedOnCompIDs);
-            }
-        }
+        public void FromAdmin(Message message, SessionID sessionID)
+        { }
 
-        private class SocketState
+        public void FromApp(Message message, SessionID sessionID)
+        { }
+
+        public void OnCreate(SessionID sessionID) { }
+        public void OnLogout(SessionID sessionID)
         {
-            public SocketState(Socket s)
-            {
-                _socket = s;
-            }
-            public Socket _socket;
-            public byte[] _rxBuffer = new byte[1024];
-            public string _messageFragment = string.Empty;
-            public string _exMessage = string.Empty;
+            _logoffNotify(sessionID.TargetCompID);
+        }
+        public void OnLogon(SessionID sessionID)
+        {
+            _logonNotify(sessionID.TargetCompID);
         }
 
+        public void ToAdmin(Message message, SessionID sessionID) { }
+        public void ToApp(Message message, SessionID sessionID) { }
 
-        const int ConnectPort = 55100;
-        private SettingsDictionary CreateSessionConfig()
+    }
+
+    private void LogonCallback(string compID)
+    {
+        lock (_loggedOnCompIDs)
         {
-            SettingsDictionary settings = new SettingsDictionary();
-            settings.SetString(SessionSettings.CONNECTION_TYPE, "acceptor");
-            settings.SetString(SessionSettings.USE_DATA_DICTIONARY, "N");
-            settings.SetString(SessionSettings.START_TIME, "12:00:00");
-            settings.SetString(SessionSettings.END_TIME, "12:00:00");
-            settings.SetString(SessionSettings.HEARTBTINT, "300");
-            settings.SetString(SessionSettings.SOCKET_CONNECT_HOST, Host);
-            settings.SetString(SessionSettings.SOCKET_CONNECT_PORT, ConnectPort.ToString());
-            settings.SetString(SessionSettings.SOCKET_ACCEPT_HOST, Host);
-            settings.SetString(SessionSettings.SOCKET_ACCEPT_PORT, AcceptPort.ToString());
-            var directory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)
-                            ?? throw new InvalidOperationException("Could not determine the directory of the executing assembly.");
-            var logPath = Path.Combine(directory, "log");
-            settings.SetString(SessionSettings.FILE_LOG_PATH, logPath);
-            return settings;
+            _loggedOnCompIDs.Add(compID);
+            Monitor.Pulse(_loggedOnCompIDs);
         }
-
-        private SessionID CreateSessionID(string targetCompID)
+    }
+    private void LogoffCallback(string compID)
+    {
+        lock (_loggedOnCompIDs)
         {
-            return new SessionID(QuickFix.Values.BeginString_FIX42, ServerCompID, targetCompID);
+            _loggedOnCompIDs.Remove(compID);
+            Monitor.Pulse(_loggedOnCompIDs);
         }
+    }
 
-        private void CreateAcceptorFromSessionConfig()
+    private class SocketState
+    {
+        public SocketState(Socket s)
         {
-            TestApplication application = new TestApplication(LogonCallback, LogoffCallback);
-            IMessageStoreFactory storeFactory = new MemoryStoreFactory();
-            ILogFactory logFactory = new ScreenLogFactory(false, false, false);
-            SessionSettings settings = new SessionSettings();
-
-            settings.Set(CreateSessionID(StaticAcceptorCompID), CreateSessionConfig());
-            settings.Set(CreateSessionID(StaticAcceptorCompID2), CreateSessionConfig());
-            _acceptor = new ThreadedSocketAcceptor(application, storeFactory, settings, logFactory);
+            Socket = s;
         }
+        public readonly Socket Socket;
+        public readonly byte[] RxBuffer = new byte[1024];
+        public string MessageFragment = string.Empty;
+    }
 
-        private Socket ConnectToEngine()
-        {
-            return ConnectToEngine( false );
-        }
 
-        private Socket ConnectToEngine( bool expectFailure )
+    private const int ConnectPort = 55100;
+    private static SettingsDictionary CreateSessionConfig()
+    {
+        SettingsDictionary settings = new SettingsDictionary();
+        settings.SetString(SessionSettings.CONNECTION_TYPE, "acceptor");
+        settings.SetString(SessionSettings.USE_DATA_DICTIONARY, "N");
+        settings.SetString(SessionSettings.START_TIME, "12:00:00");
+        settings.SetString(SessionSettings.END_TIME, "12:00:00");
+        settings.SetString(SessionSettings.HEARTBTINT, "300");
+        settings.SetString(SessionSettings.SOCKET_CONNECT_HOST, Host);
+        settings.SetString(SessionSettings.SOCKET_CONNECT_PORT, ConnectPort.ToString());
+        settings.SetString(SessionSettings.SOCKET_ACCEPT_HOST, Host);
+        settings.SetString(SessionSettings.SOCKET_ACCEPT_PORT, AcceptPort.ToString());
+        var directory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)
+                        ?? throw new InvalidOperationException("Could not determine the directory of the executing assembly.");
+        var logPath = Path.Combine(directory, "log");
+        settings.SetString(SessionSettings.FILE_LOG_PATH, logPath);
+        return settings;
+    }
+
+    private static SessionID CreateSessionID(string targetCompID)
+    {
+        return new SessionID(QuickFix.Values.BeginString_FIX42, ServerCompID, targetCompID);
+    }
+
+    private void CreateAcceptorFromSessionConfig()
+    {
+        TestApplication application = new TestApplication(LogonCallback, LogoffCallback);
+        IMessageStoreFactory storeFactory = new MemoryStoreFactory();
+        ILogFactory logFactory = new ScreenLogFactory(false, false, false);
+        SessionSettings settings = new SessionSettings();
+
+        settings.Set(CreateSessionID(StaticAcceptorCompID), CreateSessionConfig());
+        settings.Set(CreateSessionID(StaticAcceptorCompID2), CreateSessionConfig());
+        _acceptor = new ThreadedSocketAcceptor(application, storeFactory, settings, logFactory);
+    }
+
+    private Socket ConnectToEngine(bool expectFailure = false)
+    {
+        var address = IPAddress.Parse(Host);
+        var endpoint = new IPEndPoint(address, AcceptPort);
+        var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        try
         {
-            var address = IPAddress.Parse(Host);
-            var endpoint = new IPEndPoint(address, AcceptPort);
-            var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-            try
-            {
-                socket.Connect(endpoint);
-                ReceiveAsync(new SocketState(socket));
-                return socket;
-            }
-            catch (Exception ex)
-            {
-                if (expectFailure) throw;
-                Assert.Fail(string.Format("Failed to connect: {0}", ex.Message));
-            }
+            socket.Connect(endpoint);
+            ReceiveAsync(new SocketState(socket));
             return socket;
         }
-
-        private void ReceiveAsync(SocketState socketState)
+        catch (Exception ex)
         {
-            try
-            {
-                if (socketState._socket == null || !socketState._socket.Connected)
-                    return; // Socket already closed, don't attempt receive
+            if (expectFailure) throw;
+            Assert.Fail($"Failed to connect: {ex.Message}");
+        }
+        return socket;
+    }
 
-                socketState._socket.BeginReceive(
-                    socketState._rxBuffer, 0, socketState._rxBuffer.Length,
-                    SocketFlags.None, new AsyncCallback(ProcessRxData), socketState);
-            }
-            catch (SocketException e)
+    private void ReceiveAsync(SocketState socketState)
+    {
+        try
+        {
+            if (!socketState.Socket.Connected)
+                return; // Socket already closed, don't attempt receive
+
+            socketState.Socket.BeginReceive(
+                socketState.RxBuffer, 0, socketState.RxBuffer.Length,
+                SocketFlags.None, ProcessRxData, socketState);
+        }
+        catch (SocketException e)
+        {
+            if (e.SocketErrorCode != SocketError.Shutdown)
             {
-                if (e.SocketErrorCode != SocketError.Shutdown)
-                {
-                    throw;
-                }
-            }
-            catch (ObjectDisposedException)
-            {
-                // Socket was disposed between check and operation: ignore safely
+                throw;
             }
         }
-
-        private void CloseAndNotify(Socket s)
+        catch (ObjectDisposedException)
         {
-            lock (s)
+            // Socket was disposed between check and operation: ignore safely
+        }
+    }
+
+    private static void CloseAndNotify(Socket s)
+    {
+        lock (s)
+        {
+            if (s.Connected)
             {
-                if (s.Connected)
-                {
-                    try { s.Shutdown(SocketShutdown.Both); } catch {}
-                }
-                s.Close();
-                SafePulse(s);
+                try { s.Shutdown(SocketShutdown.Both); } catch {}
+            }
+            s.Close();
+            SafePulse(s);
+        }
+    }
+    
+    private static void SafePulse(object socket)
+    {
+        try
+        {
+            lock (socket)
+            {
+                Monitor.Pulse(socket);
             }
         }
-        
-        private void SafePulse(object socket)
+        catch (ObjectDisposedException)
         {
-            try
-            {
-                lock (socket)
-                {
-                    Monitor.Pulse(socket);
-                }
-            }
-            catch (ObjectDisposedException)
-            {
-                // Ignore, socket already disposed
-            }
-            catch (SynchronizationLockException)
-            {
-                // Ignore, socket already finalized and GC'ed
-            }
+            // Ignore, socket already disposed
         }
-        
-        private void ProcessRxData(IAsyncResult ar)
+        catch (SynchronizationLockException)
         {
-            SocketState socketState = (SocketState)ar.AsyncState!;
-            int bytesReceived = 0;
-            try
-            {
-                bytesReceived = socketState._socket.EndReceive(ar);
-            }
-            catch (ObjectDisposedException)
-            {
-                CloseAndNotify(socketState._socket);
-                return;
-            }
-            catch (Exception ex)
-            {
-                socketState._exMessage = ex.InnerException == null ? ex.Message : ex.InnerException.Message;
-                CloseAndNotify(socketState._socket);
-                return;
-            }
-
-            if (bytesReceived == 0)
-            {
-                CloseAndNotify(socketState._socket);
-                return;
-            }
-            string msgText = Encoding.ASCII.GetString(socketState._rxBuffer, 0, bytesReceived);
-            foreach (Match m in Regex.Matches(msgText, FIXMessageDelimit))
-            {
-                socketState._messageFragment += m.Value;
-                if (Regex.IsMatch(socketState._messageFragment, FIXMessageEnd))
-                {
-                    Message message = new Message(socketState._messageFragment);
-                    socketState._messageFragment = string.Empty;
-                    string targetCompID = message.Header.GetString(QuickFix.Fields.Tags.TargetCompID);
-                    if (message.Header.GetString(QuickFix.Fields.Tags.MsgType) == QuickFix.Fields.MsgType.LOGON)
-                        lock (_sessions)
-                        {
-                            _sessions[targetCompID] = socketState;
-                            SafePulse(_sessions);
-                        }
-                    if (message.Header.GetString(QuickFix.Fields.Tags.MsgType) == QuickFix.Fields.MsgType.LOGOUT)
-                        lock (_sessions)
-                        {
-                            SendLogout(socketState._socket, targetCompID );
-                            _sessions.Remove( targetCompID );
-                            SafePulse(_sessions);
-                        }
-                }
-            }
-            if (socketState._socket.Connected)
-            {
-                ReceiveAsync(socketState);
-            }
+            // Ignore, socket already finalized and GC'ed
+        }
+    }
+    
+    private void ProcessRxData(IAsyncResult ar)
+    {
+        SocketState socketState = (SocketState)ar.AsyncState!;
+        int bytesReceived = 0;
+        try
+        {
+            bytesReceived = socketState.Socket.EndReceive(ar);
+        }
+        catch (ObjectDisposedException)
+        {
+            CloseAndNotify(socketState.Socket);
+            return;
+        }
+        catch (Exception)
+        {
+            CloseAndNotify(socketState.Socket);
+            return;
         }
 
-        private void SendLogon(Socket s, string senderCompID)
+        if (bytesReceived == 0)
         {
-            var msg = new QuickFix.FIX42.Logon();
-            msg.Header.SetField(new QuickFix.Fields.TargetCompID(ServerCompID));
-            msg.Header.SetField(new QuickFix.Fields.SenderCompID(senderCompID));
-            msg.Header.SetField(new QuickFix.Fields.MsgSeqNum(_senderSequenceNumber++));
-            msg.Header.SetField(new QuickFix.Fields.SendingTime(System.DateTime.UtcNow));
-            msg.SetField(new QuickFix.Fields.HeartBtInt(300));
-            s.Send(Encoding.ASCII.GetBytes(msg.ConstructString()));
+            CloseAndNotify(socketState.Socket);
+            return;
         }
-
-        private void SendLogout(Socket s, string senderCompID)
+        string msgText = Encoding.ASCII.GetString(socketState.RxBuffer, 0, bytesReceived);
+        foreach (Match m in Regex.Matches(msgText, FIXMessageDelimit))
         {
-            var msg = new QuickFix.FIX42.Logout();
-            msg.Header.SetField(new QuickFix.Fields.TargetCompID(ServerCompID));
-            msg.Header.SetField(new QuickFix.Fields.SenderCompID(senderCompID));
-            msg.Header.SetField(new QuickFix.Fields.MsgSeqNum(_senderSequenceNumber++));
-            msg.Header.SetField(new QuickFix.Fields.SendingTime(System.DateTime.UtcNow));
-            s.Send(Encoding.ASCII.GetBytes(msg.ConstructString()));
-        }
-
-        private bool WaitForSessionStatus(string acceptorCompId)
-        {
-            lock (_sessions)
+            socketState.MessageFragment += m.Value;
+            if (Regex.IsMatch(socketState.MessageFragment, FIXMessageEnd))
             {
-                if (!_sessions.ContainsKey(acceptorCompId))
-                    Monitor.Wait(_sessions, 10000);
-                return _sessions.ContainsKey(acceptorCompId);
+                Message message = new Message(socketState.MessageFragment);
+                socketState.MessageFragment = string.Empty;
+                string targetCompID = message.Header.GetString(QuickFix.Fields.Tags.TargetCompID);
+                if (message.Header.GetString(QuickFix.Fields.Tags.MsgType) == QuickFix.Fields.MsgType.LOGON)
+                    lock (_sessions)
+                    {
+                        _sessions[targetCompID] = socketState;
+                        SafePulse(_sessions);
+                    }
+                if (message.Header.GetString(QuickFix.Fields.Tags.MsgType) == QuickFix.Fields.MsgType.LOGOUT)
+                    lock (_sessions)
+                    {
+                        SendLogout(socketState.Socket, targetCompID );
+                        _sessions.Remove( targetCompID );
+                        SafePulse(_sessions);
+                    }
             }
         }
-
-        private bool WaitForLogonStatus(string targetCompID, int waitTime = 10000 )
+        if (socketState.Socket.Connected)
         {
-            lock (_loggedOnCompIDs)
-            {
-                if (!_loggedOnCompIDs.Contains(targetCompID))
-                    Monitor.Wait(_loggedOnCompIDs, waitTime);
-                return _loggedOnCompIDs.Contains(targetCompID);
-            }
+            ReceiveAsync(socketState);
         }
+    }
 
-        private bool WaitForDisconnect(Socket s)
+    private void SendLogon(Socket s, string senderCompID)
+    {
+        var msg = new QuickFix.FIX42.Logon();
+        msg.Header.SetField(new QuickFix.Fields.TargetCompID(ServerCompID));
+        msg.Header.SetField(new QuickFix.Fields.SenderCompID(senderCompID));
+        msg.Header.SetField(new QuickFix.Fields.MsgSeqNum(_senderSequenceNumber++));
+        msg.Header.SetField(new QuickFix.Fields.SendingTime(DateTime.UtcNow));
+        msg.SetField(new QuickFix.Fields.HeartBtInt(300));
+        s.Send(Encoding.ASCII.GetBytes(msg.ConstructString()));
+    }
+
+    private void SendLogout(Socket s, string senderCompID)
+    {
+        var msg = new QuickFix.FIX42.Logout();
+        msg.Header.SetField(new QuickFix.Fields.TargetCompID(ServerCompID));
+        msg.Header.SetField(new QuickFix.Fields.SenderCompID(senderCompID));
+        msg.Header.SetField(new QuickFix.Fields.MsgSeqNum(_senderSequenceNumber++));
+        msg.Header.SetField(new QuickFix.Fields.SendingTime(DateTime.UtcNow));
+        s.Send(Encoding.ASCII.GetBytes(msg.ConstructString()));
+    }
+
+    private bool WaitForSessionStatus(string acceptorCompId)
+    {
+        lock (_sessions)
         {
-            lock (s)
-            {
-                var timeoutMilliseconds = 10000; // total 10 seconds
-                var stopwatch = System.Diagnostics.Stopwatch.StartNew();
-
-                while (IsSocketConnected(s))
-                {
-                    var remainingTimeout = timeoutMilliseconds - (int)stopwatch.ElapsedMilliseconds;
-                    if (remainingTimeout <= 0)
-                        break;
-
-                    Monitor.Wait(s, Math.Min(remainingTimeout, 500)); // Wait at most 500ms or remaining
-                }
-
-                return !IsSocketConnected(s);
-            }
+            if (!_sessions.ContainsKey(acceptorCompId))
+                Monitor.Wait(_sessions, 10000);
+            return _sessions.ContainsKey(acceptorCompId);
         }
-        
-        private bool IsSocketConnected(Socket socket)
-        {
-            try
-            {
-                if (socket == null || !socket.Connected)
-                    return false;
+    }
 
-                bool connectionClosed = socket.Poll(0, SelectMode.SelectRead);
-                bool dataAvailable = (socket.Available == 0);
-                return !(connectionClosed && dataAvailable);
-            }
-            catch (SocketException)
+    private bool WaitForLogonStatus(string targetCompID, int waitTime = 10000 )
+    {
+        lock (_loggedOnCompIDs)
+        {
+            if (!_loggedOnCompIDs.Contains(targetCompID))
+                Monitor.Wait(_loggedOnCompIDs, waitTime);
+            return _loggedOnCompIDs.Contains(targetCompID);
+        }
+    }
+
+    private static bool WaitForDisconnect(Socket s)
+    {
+        lock (s)
+        {
+            const int timeoutMilliseconds = 10000; // total 10 seconds
+            Stopwatch stopwatch = Stopwatch.StartNew();
+
+            while (IsSocketConnected(s))
             {
+                int remainingTimeout = timeoutMilliseconds - (int)stopwatch.ElapsedMilliseconds;
+                if (remainingTimeout <= 0)
+                    break;
+
+                Monitor.Wait(s, Math.Min(remainingTimeout, 500)); // Wait at most 500ms or remaining
+            }
+
+            return !IsSocketConnected(s);
+        }
+    }
+    
+    private static bool IsSocketConnected(Socket socket)
+    {
+        try
+        {
+            if (!socket.Connected)
                 return false;
-            }
-            catch (ObjectDisposedException)
-            {
-                return false;
-            }
-        }
 
-        [SetUp]
-        public void Setup()
+            bool connectionClosed = socket.Poll(0, SelectMode.SelectRead);
+            bool dataAvailable = (socket.Available == 0);
+            return !(connectionClosed && dataAvailable);
+        }
+        catch (SocketException)
         {
-            CreateAcceptorFromSessionConfig();
-            _sessions = new Dictionary<string, SocketState>();
-            _loggedOnCompIDs = new HashSet<string>();
-            _senderSequenceNumber = 1;
+            return false;
         }
-
-        [TearDown]
-        public void TearDown()
+        catch (ObjectDisposedException)
         {
-            _acceptor!.Stop( true );
-            _acceptor.Dispose();
+            return false;
         }
+    }
+
+    [SetUp]
+    public void Setup()
+    {
+        CreateAcceptorFromSessionConfig();
+        _sessions = new Dictionary<string, SocketState>();
+        _loggedOnCompIDs = new HashSet<string>();
+        _senderSequenceNumber = 1;
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _acceptor!.Stop( true );
+        _acceptor.Dispose();
+    }
 
 
-        [Test]
-        public void TestAcceptorInStoppedStateOnInitialisation()
+    [Test]
+    public void TestAcceptorInStoppedStateOnInitialisation()
+    {
+        //GIVEN - an acceptor created in SetUp
+        //THEN - is should be stopped
+        Assert.That(_acceptor!.IsStarted, Is.False);
+        Assert.That(_acceptor.AreSocketsRunning, Is.False);
+        Assert.That(_acceptor.IsLoggedOn, Is.False);
+    }
+
+    [Test]
+    public void TestAcceptorInStoppedStateOnInitialisationThenCannotReceiveConnections()
+    {
+        //GIVEN - an acceptor created in SetUp
+        // a connection is received
+        bool exceptionFound = false;
+        try
         {
-            //GIVEN - an acceptor created in SetUp
-            //THEN - is should be stopped
-            Assert.That(_acceptor!.IsStarted, Is.False);
-            Assert.That(_acceptor.AreSocketsRunning, Is.False);
-            Assert.That(_acceptor.IsLoggedOn, Is.False);
+            Socket _ = ConnectToEngine(true);
         }
-
-        [Test]
-        public void TestAcceptorInStoppedStateOnInitialisationThenCannotReceiveConnections()
+        //THEN - Expect failure to connect
+        catch (SocketException)
         {
-            //GIVEN - an acceptor created in SetUp
-            // a connection is received
-            bool exceptionFound = false;
-            try
-            {
-                var socket01 = ConnectToEngine(true);
-            }
-            //THEN - Expect failure to connect
-            catch (SocketException)
-            {
-                //SUCCESS
-                exceptionFound = true;
-            }
-            Assert.That(exceptionFound, Is.True);
+            //SUCCESS
+            exceptionFound = true;
         }
+        Assert.That(exceptionFound, Is.True);
+    }
 
-        [Test]
-        public void TestCanStartAcceptor()
-        {
-            //GIVEN - an acceptor created in SetUp
-            //WHEN - it is started
-            _acceptor!.Start();
-            //THEN - is be running
-            Assert.That(_acceptor.IsStarted, Is.True);
-            Assert.That(_acceptor.AreSocketsRunning, Is.True);
-            Assert.That(_acceptor.IsLoggedOn, Is.False);
-        }
+    [Test]
+    public void TestCanStartAcceptor()
+    {
+        //GIVEN - an acceptor created in SetUp
+        //WHEN - it is started
+        _acceptor!.Start();
+        //THEN - is be running
+        Assert.That(_acceptor.IsStarted, Is.True);
+        Assert.That(_acceptor.AreSocketsRunning, Is.True);
+        Assert.That(_acceptor.IsLoggedOn, Is.False);
+    }
 
-        [Test]
-        public void TestStartedAcceptorAndReceiveConnection()
-        {
-            //GIVEN - a started acceptor created in SetUp
-            _acceptor!.Start();
-            //WHEN - a connection is received
-            var socket01 = ConnectToEngine();
-            SendLogon( socket01, StaticAcceptorCompID );
-            //THEN - is be running
-            Assert.That(WaitForLogonStatus(StaticAcceptorCompID), Is.True);
-            Assert.That(_acceptor.IsLoggedOn, Is.True);
+    [Test]
+    public void TestStartedAcceptorAndReceiveConnection()
+    {
+        //GIVEN - a started acceptor created in SetUp
+        _acceptor!.Start();
+        //WHEN - a connection is received
+        var socket01 = ConnectToEngine();
+        SendLogon( socket01, StaticAcceptorCompID );
+        //THEN - is be running
+        Assert.That(WaitForLogonStatus(StaticAcceptorCompID), Is.True);
+        Assert.That(_acceptor.IsLoggedOn, Is.True);
 
-            //CLEANUP - disconnect client connections
-            DisconnectSocket(socket01);
-        }
+        //CLEANUP - disconnect client connections
+        DisconnectSocket(socket01);
+    }
 
-        [Test]
-        public void TestStartedAcceptorAndReceiveMultipleConnections()
-        {
-            //GIVEN - a started acceptor created in SetUp
-            _acceptor!.Start();
-            //WHEN - a connection is received
-            var socket01 = ConnectToEngine();
-            SendLogon(socket01, StaticAcceptorCompID);
-            var socket02 = ConnectToEngine();
-            SendLogon(socket02, StaticAcceptorCompID2);
-            //THEN - is be running
-            Assert.That(WaitForLogonStatus(StaticAcceptorCompID), Is.True);
-            Assert.That(WaitForLogonStatus(StaticAcceptorCompID2), Is.True);
-            Assert.That(_acceptor.IsLoggedOn, Is.True);
-
-
-            //CLEANUP - disconnect client connections
-            DisconnectSocket(socket02);
-            DisconnectSocket(socket01);
-        }
-
-        private void DisconnectSocket(Socket socket)
-        {
-            socket.Shutdown(SocketShutdown.Both);
-            socket.Dispose();
-        }
-
-        [Test]
-        public void TestCanStopAcceptor()
-        {
-            //GIVEN - started acceptor created in SetUp
-            _acceptor!.Start();
-            //WHEN - it is stopped
-            _acceptor.Stop();
-            //THEN - it should no longer be running
-            Assert.That(_acceptor.IsStarted, Is.False);
-            Assert.That(_acceptor.AreSocketsRunning, Is.False);
-            Assert.That(_acceptor.IsLoggedOn, Is.False);
-        }
-
-        [Test]
-        public void TestCanForceStopAcceptorAndLogOffCounterpartyIfLoggedOn()
-        {
-            //GIVEN - started acceptor with a logged on session created in SetUp
-            _acceptor!.Start();
-            var socket01 = ConnectToEngine();
-            SendLogon(socket01, StaticAcceptorCompID);
-            //WHEN - it is stopped with forced disconnection
-            _acceptor.Stop(true);
-            //THEN - it should no longer be running
-            Assert.That(WaitForDisconnect(socket01), Is.True);
-            Assert.That(_acceptor.AreSocketsRunning, Is.False);
-        }
-
-        [Test]
-        public void TestCanStopAcceptorAndLogOffCounterpartyIfLoggedOn()
-        {
-            //GIVEN - started acceptor with a logged on session created in SetUp
-            _acceptor!.Start();
-            var socket01 = ConnectToEngine();
-            SendLogon(socket01, StaticAcceptorCompID);
-            Assert.That(WaitForLogonStatus(StaticAcceptorCompID), Is.True);
-            //WHEN - it is stopped
-            _acceptor.Stop();
-            //THEN - it should no longer be running
-            Assert.That(WaitForDisconnect(socket01), Is.True);
-            Assert.That(_loggedOnCompIDs.Contains(StaticAcceptorCompID), Is.False);
-            Assert.That(_sessions.ContainsKey(StaticAcceptorCompID), Is.False);
-            Assert.That(_acceptor.AreSocketsRunning, Is.False);
-            Assert.That(_acceptor.IsLoggedOn, Is.False);
-        }
-
-        [Test]
-        public void TestCanRestartAcceptorAfterStopping()
-        {
-            //GIVEN - a started then stopped acceptor created in SetUp
-            _acceptor!.Start();
-            _acceptor.Stop();
-            //WHEN - it is started again
-            _acceptor.Start();
-            //THEN - it should be marked as running
-            Assert.That(_acceptor.IsStarted, Is.True);
-            Assert.That(_acceptor.AreSocketsRunning, Is.True);
-            Assert.That(_acceptor.IsLoggedOn, Is.False);
-        }
-
-        [Test]
-        public void TestCanRestartAcceptorAfterStoppingAndCounterPartyCanThenLogon()
-        {
-            //GIVEN - a started then stopped acceptor created in SetUp
-            _acceptor!.Start();
-            _acceptor.Stop();
-            //WHEN - it is started again
-            _acceptor.Start();
-            //THEN - a counterparty should be able to logon
-            Assert.That(_acceptor.IsStarted, Is.True);
-            Assert.That(_acceptor.AreSocketsRunning, Is.True);
-            var socket01 = ConnectToEngine();
-            SendLogon(socket01, StaticAcceptorCompID);
-            Assert.That(WaitForLogonStatus(StaticAcceptorCompID), Is.True);
-            Assert.That(_acceptor.IsLoggedOn, Is.True);
-            Assert.That(WaitForSessionStatus(StaticAcceptorCompID), Is.True);
-        }
-
-        [Test]
-        public void TestCanRestartAcceptorAndCounterPartyCanLogonAfterCounterParttyLoggedOnThenAcceptorStopped()
-        {
-            //GIVEN - a started then stopped acceptor created in SetUp
-            _acceptor!.Start();
-            var socket01 = ConnectToEngine();
-            SendLogon(socket01, StaticAcceptorCompID);
-            Assert.That(WaitForLogonStatus(StaticAcceptorCompID), Is.True);
-            _acceptor.Stop();
-            //WHEN - it is started again
-            _acceptor.Start();
-            //THEN - a counterparty should be able to logon
-            Assert.That(_acceptor.IsStarted, Is.True);
-            Assert.That(_acceptor.AreSocketsRunning, Is.True);
-            socket01 = ConnectToEngine();
-            SendLogon(socket01, StaticAcceptorCompID);
-            Assert.That(WaitForLogonStatus(StaticAcceptorCompID), Is.True);
-            Assert.That(_acceptor.IsLoggedOn, Is.True);
-            Assert.That(WaitForSessionStatus(StaticAcceptorCompID), Is.True);
-        }
+    [Test]
+    public void TestStartedAcceptorAndReceiveMultipleConnections()
+    {
+        //GIVEN - a started acceptor created in SetUp
+        _acceptor!.Start();
+        //WHEN - a connection is received
+        var socket01 = ConnectToEngine();
+        SendLogon(socket01, StaticAcceptorCompID);
+        var socket02 = ConnectToEngine();
+        SendLogon(socket02, StaticAcceptorCompID2);
+        //THEN - is be running
+        Assert.That(WaitForLogonStatus(StaticAcceptorCompID), Is.True);
+        Assert.That(WaitForLogonStatus(StaticAcceptorCompID2), Is.True);
+        Assert.That(_acceptor.IsLoggedOn, Is.True);
 
 
-        [Test]
-        public void TestCanRestartAcceptorAndCounterPartyCanLogonAfterCounterParttyLoggedOnThenAcceptorForceStopped()
-        {
-            //GIVEN - a started then stopped acceptor created in SetUp
-            _acceptor!.Start();
-            var socket01 = ConnectToEngine();
-            SendLogon(socket01, StaticAcceptorCompID);
-            Assert.That(WaitForLogonStatus(StaticAcceptorCompID), Is.True);
-            _acceptor.Stop(true);
-            //WHEN - it is started again
-            _acceptor.Start();
-            //THEN - a counterparty should be able to logon
-            Assert.That(_acceptor.IsStarted, Is.True);
-            Assert.That(_acceptor.AreSocketsRunning, Is.True);
-            socket01 = ConnectToEngine();
-            SendLogon(socket01, StaticAcceptorCompID);
-            Assert.That(WaitForLogonStatus(StaticAcceptorCompID, 60000), Is.True);
-            Assert.That(_acceptor.IsLoggedOn, Is.True);
+        //CLEANUP - disconnect client connections
+        DisconnectSocket(socket02);
+        DisconnectSocket(socket01);
+    }
 
-            //CLEANUP - disconnect client connections
-            DisconnectSocket(socket01);
-        }
+    private void DisconnectSocket(Socket socket)
+    {
+        socket.Shutdown(SocketShutdown.Both);
+        socket.Dispose();
+    }
+
+    [Test]
+    public void TestCanStopAcceptor()
+    {
+        //GIVEN - started acceptor created in SetUp
+        _acceptor!.Start();
+        //WHEN - it is stopped
+        _acceptor.Stop();
+        //THEN - it should no longer be running
+        Assert.That(_acceptor.IsStarted, Is.False);
+        Assert.That(_acceptor.AreSocketsRunning, Is.False);
+        Assert.That(_acceptor.IsLoggedOn, Is.False);
+    }
+
+    [Test]
+    public void TestCanForceStopAcceptorAndLogOffCounterpartyIfLoggedOn()
+    {
+        //GIVEN - started acceptor with a logged on session created in SetUp
+        _acceptor!.Start();
+        var socket01 = ConnectToEngine();
+        SendLogon(socket01, StaticAcceptorCompID);
+        //WHEN - it is stopped with forced disconnection
+        _acceptor.Stop(true);
+        //THEN - it should no longer be running
+        Assert.That(WaitForDisconnect(socket01), Is.True);
+        Assert.That(_acceptor.AreSocketsRunning, Is.False);
+    }
+
+    [Test]
+    public void TestCanStopAcceptorAndLogOffCounterpartyIfLoggedOn()
+    {
+        //GIVEN - started acceptor with a logged on session created in SetUp
+        _acceptor!.Start();
+        var socket01 = ConnectToEngine();
+        SendLogon(socket01, StaticAcceptorCompID);
+        Assert.That(WaitForLogonStatus(StaticAcceptorCompID), Is.True);
+        //WHEN - it is stopped
+        _acceptor.Stop();
+        //THEN - it should no longer be running
+        Assert.That(WaitForDisconnect(socket01), Is.True);
+        Assert.That(_loggedOnCompIDs.Contains(StaticAcceptorCompID), Is.False);
+        Assert.That(_sessions.ContainsKey(StaticAcceptorCompID), Is.False);
+        Assert.That(_acceptor.AreSocketsRunning, Is.False);
+        Assert.That(_acceptor.IsLoggedOn, Is.False);
+    }
+
+    [Test]
+    public void TestCanRestartAcceptorAfterStopping()
+    {
+        //GIVEN - a started then stopped acceptor created in SetUp
+        _acceptor!.Start();
+        _acceptor.Stop();
+        //WHEN - it is started again
+        _acceptor.Start();
+        //THEN - it should be marked as running
+        Assert.That(_acceptor.IsStarted, Is.True);
+        Assert.That(_acceptor.AreSocketsRunning, Is.True);
+        Assert.That(_acceptor.IsLoggedOn, Is.False);
+    }
+
+    [Test]
+    public void TestCanRestartAcceptorAfterStoppingAndCounterPartyCanThenLogon()
+    {
+        //GIVEN - a started then stopped acceptor created in SetUp
+        _acceptor!.Start();
+        _acceptor.Stop();
+        //WHEN - it is started again
+        _acceptor.Start();
+        //THEN - a counterparty should be able to logon
+        Assert.That(_acceptor.IsStarted, Is.True);
+        Assert.That(_acceptor.AreSocketsRunning, Is.True);
+        var socket01 = ConnectToEngine();
+        SendLogon(socket01, StaticAcceptorCompID);
+        Assert.That(WaitForLogonStatus(StaticAcceptorCompID), Is.True);
+        Assert.That(_acceptor.IsLoggedOn, Is.True);
+        Assert.That(WaitForSessionStatus(StaticAcceptorCompID), Is.True);
+    }
+
+    [Test]
+    public void TestCanRestartAcceptorAndCounterPartyCanLogonAfterCounterParttyLoggedOnThenAcceptorStopped()
+    {
+        //GIVEN - a started then stopped acceptor created in SetUp
+        _acceptor!.Start();
+        var socket01 = ConnectToEngine();
+        SendLogon(socket01, StaticAcceptorCompID);
+        Assert.That(WaitForLogonStatus(StaticAcceptorCompID), Is.True);
+        _acceptor.Stop();
+        //WHEN - it is started again
+        _acceptor.Start();
+        //THEN - a counterparty should be able to logon
+        Assert.That(_acceptor.IsStarted, Is.True);
+        Assert.That(_acceptor.AreSocketsRunning, Is.True);
+        socket01 = ConnectToEngine();
+        SendLogon(socket01, StaticAcceptorCompID);
+        Assert.That(WaitForLogonStatus(StaticAcceptorCompID), Is.True);
+        Assert.That(_acceptor.IsLoggedOn, Is.True);
+        Assert.That(WaitForSessionStatus(StaticAcceptorCompID), Is.True);
+    }
+
+
+    [Test]
+    public void TestCanRestartAcceptorAndCounterPartyCanLogonAfterCounterParttyLoggedOnThenAcceptorForceStopped()
+    {
+        //GIVEN - a started then stopped acceptor created in SetUp
+        _acceptor!.Start();
+        var socket01 = ConnectToEngine();
+        SendLogon(socket01, StaticAcceptorCompID);
+        Assert.That(WaitForLogonStatus(StaticAcceptorCompID), Is.True);
+        _acceptor.Stop(true);
+        //WHEN - it is started again
+        _acceptor.Start();
+        //THEN - a counterparty should be able to logon
+        Assert.That(_acceptor.IsStarted, Is.True);
+        Assert.That(_acceptor.AreSocketsRunning, Is.True);
+        socket01 = ConnectToEngine();
+        SendLogon(socket01, StaticAcceptorCompID);
+        Assert.That(WaitForLogonStatus(StaticAcceptorCompID, 60000), Is.True);
+        Assert.That(_acceptor.IsLoggedOn, Is.True);
+
+        //CLEANUP - disconnect client connections
+        DisconnectSocket(socket01);
     }
 }

--- a/UnitTests/ThreadedSocketAcceptor_RestartTests.cs
+++ b/UnitTests/ThreadedSocketAcceptor_RestartTests.cs
@@ -15,7 +15,7 @@ using QuickFix.Store;
 namespace UnitTests
 {
     [TestFixture]
-    public class RestartingTheThreadedSocketAcceptorTests
+    public class ThreadedSocketAcceptor_RestartTests
     {
         private const string Host = "127.0.0.1";
         private const int AcceptPort = 55101;


### PR DESCRIPTION
I have a few feature PR coming, but I won't be able to merge it for a few months.  I did some refactoring in that PR that is adjacent to that feature, and I want to get it in the main build to reduce the merge conflicts that will accrue.

So to reiterate: this PR is all refactoring.  No functionality is changed.

The biggest change is that I've split out the core SessionTest setup/teardown logic into a SessionTestBase class, because my upcoming feature work will add a new set of Session tests that will exist in a separate file, but use the common base.

**Reviewers:** reviewing this one commit at a time will probably be easier