### PR TITLE
Fallback to System Certificate Store when CA Certificate Path Is Not Present

### DIFF
--- a/QuickFIXn/Transport/SslStreamFactory.cs
+++ b/QuickFIXn/Transport/SslStreamFactory.cs
@@ -1,12 +1,12 @@
-using Microsoft.Extensions.Logging;
-using QuickFix.Logger;
-using QuickFix.Util;
 using System;
 using System.Diagnostics;
 using System.IO;
 using System.Net.Security;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
+using Microsoft.Extensions.Logging;
+using QuickFix.Logger;
+using QuickFix.Util;
 
 namespace QuickFix.Transport;
 

--- a/QuickFIXn/Transport/SslStreamFactory.cs
+++ b/QuickFIXn/Transport/SslStreamFactory.cs
@@ -2,7 +2,6 @@ using Microsoft.Extensions.Logging;
 using QuickFix.Logger;
 using QuickFix.Util;
 using System;
-using System.Data;
 using System.Diagnostics;
 using System.IO;
 using System.Net.Security;

--- a/QuickFIXn/Transport/SslStreamFactory.cs
+++ b/QuickFIXn/Transport/SslStreamFactory.cs
@@ -182,7 +182,7 @@ internal sealed class SslStreamFactory
 
         // If CA Certificate is specified then validate against the CA certificate, otherwise it is validated against the installed certificates
         if (string.IsNullOrEmpty(_socketSettings.CACertificatePath)) {
-            _nonSessionLog.Log(LogLevel.Warning, "CACertificatePath is not specified");
+            _nonSessionLog.Log(LogLevel.Warning, "CACertificatePath is not specified, using machine store");
 
             X509Chain chain = new();
             chain.ChainPolicy.RevocationMode = _socketSettings.CheckCertificateRevocation ? X509RevocationMode.Online : X509RevocationMode.NoCheck;

--- a/QuickFIXn/Transport/SslStreamFactory.cs
+++ b/QuickFIXn/Transport/SslStreamFactory.cs
@@ -209,8 +209,7 @@ internal sealed class SslStreamFactory
                 else
                     sslPolicyErrors |= SslPolicyErrors.RemoteCertificateChainErrors;
             }
-            else
-            {
+            else {
                 foreach (var status in chain.ChainStatus)
                 {
                     _nonSessionLog.Log(LogLevel.Error,


### PR DESCRIPTION
"Fixes" #990

This isn't final, too duplicative. Need someone to verify it works on Windows/Linux as we've been bitten by behavior differences before and I don't have an admin box I can trust the generated CA with.

@dimaaik27 Please verify this works in your implementation before I clean up the code.

[@gbirchmeier added: resolves #990 ]