### PR TITLE
IMessageStore extended with method SetAndIncrNextSenderMsgSeqNum, resolves issue #987

### DIFF
--- a/QuickFIXn/Session.cs
+++ b/QuickFIXn/Session.cs
@@ -1646,9 +1646,12 @@ public class Session : IDisposable
         if (PersistMessages)
         {
             SeqNumType msgSeqNum = message.Header.GetULong(Fields.Tags.MsgSeqNum);
-            _state.Set(msgSeqNum, messageString);
+            _state.SetAndIncrNextSenderMsgSeqNum(msgSeqNum, messageString);
         }
-        _state.IncrNextSenderMsgSeqNum();
+        else
+        {
+            _state.IncrNextSenderMsgSeqNum();
+        }
     }
 
     protected bool IsGoodTime(Message msg)

--- a/QuickFIXn/SessionState.cs
+++ b/QuickFIXn/SessionState.cs
@@ -399,6 +399,11 @@ public class SessionState : IDisposable
         lock (_sync) { MessageStore.Refresh(); }
     }
 
+    public bool SetAndIncrNextSenderMsgSeqNum(SeqNumType msgSeqNum, string msg)
+    {
+        lock (_sync) { return MessageStore.SetAndIncrNextSenderMsgSeqNum(msgSeqNum, msg); }
+    }
+
     #endregion
 
     public void Dispose()

--- a/QuickFIXn/SessionState.cs
+++ b/QuickFIXn/SessionState.cs
@@ -373,6 +373,11 @@ public class SessionState : IDisposable
         lock (_sync) { MessageStore.IncrNextTargetMsgSeqNum(); }
     }
 
+    public bool SetAndIncrNextSenderMsgSeqNum(SeqNumType msgSeqNum, string msg)
+    {
+        lock (_sync) { return MessageStore.SetAndIncrNextSenderMsgSeqNum(msgSeqNum, msg); }
+    }
+
     public DateTime? CreationTime
     {
         get
@@ -397,11 +402,6 @@ public class SessionState : IDisposable
     public void Refresh()
     {
         lock (_sync) { MessageStore.Refresh(); }
-    }
-
-    public bool SetAndIncrNextSenderMsgSeqNum(SeqNumType msgSeqNum, string msg)
-    {
-        lock (_sync) { return MessageStore.SetAndIncrNextSenderMsgSeqNum(msgSeqNum, msg); }
     }
 
     #endregion

--- a/QuickFIXn/Store/IMessageStore.cs
+++ b/QuickFIXn/Store/IMessageStore.cs
@@ -48,4 +48,11 @@ public interface IMessageStore : IDisposable
     /// or throw an exception.
     /// </summary>
     void Refresh();
+
+    public bool SetAndIncrNextSenderMsgSeqNum(SeqNumType msgSeqNum, string msg)
+    {
+        bool result = Set(msgSeqNum, msg);
+        IncrNextSenderMsgSeqNum();
+        return result;
+    }
 }

--- a/QuickFIXn/Store/IMessageStore.cs
+++ b/QuickFIXn/Store/IMessageStore.cs
@@ -49,6 +49,16 @@ public interface IMessageStore : IDisposable
     /// </summary>
     void Refresh();
 
+    /// <summary>
+    /// Adds a raw fix message to the store with the give sequence number
+    /// and increments the <see cref="NextSenderMsgSeqNum" />. This method
+    /// has a default implementation calling <see cref="Set(SeqNumType, string)" />
+    /// and <see cref="IncrNextSenderMsgSeqNum()" />. It is not intended to change
+    /// this default implementation in custom IMessageStore implementations.
+    /// </summary>
+    /// <param name="msgSeqNum">the sequence number</param>
+    /// <param name="msg">the raw FIX message string</param>
+    /// <returns>true if successful, false otherwise</returns>
     public bool SetAndIncrNextSenderMsgSeqNum(SeqNumType msgSeqNum, string msg)
     {
         bool result = Set(msgSeqNum, msg);

--- a/QuickFIXn/Store/IMessageStore.cs
+++ b/QuickFIXn/Store/IMessageStore.cs
@@ -18,7 +18,7 @@ public interface IMessageStore : IDisposable
     void Get(SeqNumType startSeqNum, SeqNumType endSeqNum, List<string> messages);
 
     /// <summary>
-    /// Adds a raw fix message to the store with the give sequence number
+    /// Adds a raw fix message to the store with the given sequence number
     /// </summary>
     /// <param name="msgSeqNum">the sequence number</param>
     /// <param name="msg">the raw FIX message string</param>
@@ -31,6 +31,24 @@ public interface IMessageStore : IDisposable
     void IncrNextSenderMsgSeqNum();
     void IncrNextTargetMsgSeqNum();
 
+    /// <summary>
+    /// The purpose of this method is to combine <see cref="Set(SeqNumType, string)"/>
+    /// and <see cref="IncrNextSenderMsgSeqNum()"/> into one call, for use in situations
+    /// when these operations should be performed together.
+    /// The default implementation simply calls those two functions.
+    /// Certain custom IMessageStore implementations (e.g. DB-backed stores)
+    /// may need to override the default implementation to ensure that these two behaviors
+    /// are combined into a single atomic operation.
+    /// <param name="msgSeqNum">the sequence number</param>
+    /// <param name="msg">the raw FIX message string</param>
+    /// <returns>true if successful, false otherwise</returns>
+    /// </summary>
+    bool SetAndIncrNextSenderMsgSeqNum(SeqNumType msgSeqNum, string msg)
+    {
+        bool result = Set(msgSeqNum, msg);
+        IncrNextSenderMsgSeqNum();
+        return result;
+    }
 
     DateTime? CreationTime { get; }
 
@@ -48,21 +66,5 @@ public interface IMessageStore : IDisposable
     /// or throw an exception.
     /// </summary>
     void Refresh();
-
-    /// <summary>
-    /// Adds a raw fix message to the store with the give sequence number
-    /// and increments the <see cref="NextSenderMsgSeqNum" />. This method
-    /// has a default implementation calling <see cref="Set(SeqNumType, string)" />
-    /// and <see cref="IncrNextSenderMsgSeqNum()" />. It is not intended to change
-    /// this default implementation in custom IMessageStore implementations.
-    /// </summary>
-    /// <param name="msgSeqNum">the sequence number</param>
-    /// <param name="msg">the raw FIX message string</param>
-    /// <returns>true if successful, false otherwise</returns>
-    public bool SetAndIncrNextSenderMsgSeqNum(SeqNumType msgSeqNum, string msg)
-    {
-        bool result = Set(msgSeqNum, msg);
-        IncrNextSenderMsgSeqNum();
-        return result;
-    }
 }
+

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -38,6 +38,7 @@ What's New
 * #949 - new settings RedactFieldsInLogs & RedactionLogText (gbirchmeier)
 * #983 - new MessageFactoryNotFound exception provides better feedback (gbirchmeier)
 * #1014 - deprecate DateTimeConverter.ParseToTimeOnly (gbirchmeier)
+* #987 - new interface method IMessageStore.SetAndIncrNextSenderMsgSeqNum (asmeisne)
 
 
 ### v1.14.0

--- a/UnitTests/FileStoreTests.cs
+++ b/UnitTests/FileStoreTests.cs
@@ -208,4 +208,30 @@ public class FileStoreTests
 
         Assert.That(msgs, Is.EqualTo(expected));
     }
+
+    [Test]
+    public void SetAndIncrNextSenderMsgSeqNumTest()
+    {
+        IMessageStore messageStore = _store ?? throw new InvalidProgramException();
+
+        messageStore.SetAndIncrNextSenderMsgSeqNum(1, "dude");
+        messageStore.SetAndIncrNextSenderMsgSeqNum(2, "pude");
+        messageStore.SetAndIncrNextSenderMsgSeqNum(3, "ok");
+        messageStore.SetAndIncrNextSenderMsgSeqNum(4, "ohai");
+
+        var msgs = new List<string>();
+        _store.Get(2, 3, msgs);
+        var expected = new List<string>() { "pude", "ok" };
+
+        Assert.That(msgs, Is.EqualTo(expected));
+        Assert.That(_store.NextSenderMsgSeqNum, Is.EqualTo(5));
+
+        RebuildStore();
+
+        msgs = new List<string>();
+        _store.Get(2, 3, msgs);
+
+        Assert.That(msgs, Is.EqualTo(expected));
+        Assert.That(_store.NextSenderMsgSeqNum, Is.EqualTo(5));
+    }
 }

--- a/UnitTests/MemoryStoreTest.cs
+++ b/UnitTests/MemoryStoreTest.cs
@@ -24,4 +24,23 @@ public class MemoryStoreTests
         store.Get(5, 6, msgs);
         Assert.That(msgs, Is.Empty);
     }
+
+    [Test]
+    public void SetAndIncrNextSenderMsgSeqNumTest()
+    {
+        IMessageStore store = new MemoryStore();
+        store.SetAndIncrNextSenderMsgSeqNum(1, "dude");
+        store.SetAndIncrNextSenderMsgSeqNum(2, "pude");
+        store.SetAndIncrNextSenderMsgSeqNum(3, "ok");
+        store.SetAndIncrNextSenderMsgSeqNum(4, "ohai");
+        var msgs = new List<string>();
+        store.Get(2, 3, msgs);
+        var expected = new List<string>() { "pude", "ok" };
+        Assert.That(msgs, Is.EqualTo(expected));
+
+        msgs = new List<string>();
+        store.Get(5, 6, msgs);
+        Assert.That(msgs, Is.Empty);
+        Assert.That(store.NextSenderMsgSeqNum, Is.EqualTo(5));
+    }
 }


### PR DESCRIPTION
The `IMessageStore` interface is extended with a new method `SetAndIncrNextSenderMsgSeqNum` with a default implementation to ensure backwards compatibility. This new method now is used in `Session.Persist()` to allow execution of methods `IMessageStore.Set()` and `IMessageStore.IncrNextSenderMsgSeqNum()` in one transaction. Two unit tests for `FileStore` and `MemoryStore` are added.

resolves #987 