### PR TITLE
Add support for devcontainer to simplify development environment setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,36 @@
+# Use the official .NET SDK image for building and running .NET applications
+FROM mcr.microsoft.com/dotnet/sdk:8.0
+
+# Avoid warnings by explicitly setting the locale
+ENV LANG=C.UTF-8
+
+# Install additional packages if needed
+RUN apt-get update && apt-get install -y \
+    git \
+    curl \
+    vim \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create a non-root user and add them to the sudo group
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    # [Optional] Add sudo support
+    && apt-get update \
+    && apt-get install -y sudo \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME
+
+# Switch to the non-root user
+USER $USERNAME
+
+# Set the working directory
+WORKDIR /workspace
+
+# Expose common .NET ports
+EXPOSE 5000 5001
+
+# Set the default command to bash
+CMD ["bash"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+{
+	"name": "QuickFIX/n .NET Development",
+	"dockerFile": "./Dockerfile",
+	
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-dotnettools.dotnet-interactive-vscode",
+				"ms-dotnettools.csdevkit"
+			]
+		}
+	},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [5000, 5001],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "dotnet restore",
+
+	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode"
+}


### PR DESCRIPTION
Hi there,

With this PR I propose adding devcontainer support. I believe it would make development env setup easier for contributors, since modern editor and IDEs (i.e vscode) integrate and support devcontainer very well.