### PR TITLE
new MessageFactoryNotFound exception

### DIFF
--- a/QuickFIXn/DefaultMessageFactory.cs
+++ b/QuickFIXn/DefaultMessageFactory.cs
@@ -89,7 +89,7 @@ public class DefaultMessageFactory : IMessageFactory
         if (_factories.TryGetValue(key, out IMessageFactory? factory))
             return factory.Create(beginString, msgType, groupCounterTag);
 
-        throw new UnsupportedVersion(beginString);
+        throw new MessageFactoryNotFound(beginString);
     }
 
     #endregion

--- a/QuickFIXn/Exceptions.cs
+++ b/QuickFIXn/Exceptions.cs
@@ -78,6 +78,18 @@ public class UnsupportedVersion : QuickFIXException
 }
 
 /// <summary>
+/// DefaultMessageFactory can't find a factory that matches this BeginString.
+/// This may indicate a missing package dependency,
+/// e.g. user forgot to add the QuickFIXn.FIX42 or .FIX50SP2 package.
+/// </summary>
+public class MessageFactoryNotFound : QuickFIXException
+{
+    public MessageFactoryNotFound(string beginString)
+        : base($"Message factory not found for BeginString={beginString}.")
+    { }
+}
+
+/// <summary>
 /// Message type is not supported by application
 /// </summary>
 public class UnsupportedMessageType : QuickFIXException

--- a/QuickFIXn/Session.cs
+++ b/QuickFIXn/Session.cs
@@ -671,6 +671,21 @@ namespace QuickFix
                     _state.IncrNextTargetMsgSeqNum();
                 }
             }
+            catch (MessageFactoryNotFound mfnf)
+            {
+                if (MsgType.LOGOUT.Equals(msgBuilder.MsgType.Value))
+                {
+                    NextLogout(message!);
+                }
+                else
+                {
+                    // We shouldn't send that question to the counterparty, but local devs should see it
+                    Log.Log(LogLevel.Error, mfnf,
+                        "{Message} (Did you forget a message package dependency?)", mfnf.ToString());
+                    GenerateLogout(mfnf.Message);
+                    _state.IncrNextTargetMsgSeqNum();
+                }
+            }
             catch (UnsupportedMessageType e)
             {
                 Log.Log(LogLevel.Error, e, "Unsupported message type: {Message}", e.Message);

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -36,6 +36,7 @@ What's New
 * #1001 - AcceptanceTests bug: double.Parse with InvariantCulture (gbirchmeier)
 * #562 - deprecate Message.IsHeaderField without transport DD param (gbirchmeier)
 * #949 - new settings RedactFieldsInLogs & RedactionLogText (gbirchmeier)
+* #983 - new MessageFactoryNotFound exception provides better feedback (gbirchmeier)
 
 
 ### v1.14.0

--- a/UnitTests/DefaultMessageFactoryTests.cs
+++ b/UnitTests/DefaultMessageFactoryTests.cs
@@ -33,4 +33,13 @@ public class DefaultMessageFactoryTests
         Group? g50sp2 = dmf.Create("FIXT.1.1", "CD", QuickFix.Fields.Tags.NoAsgnReqs);
         Assert.That(g50sp2, Is.InstanceOf<QuickFix.FIX50SP2.StreamAssignmentReport.NoAsgnReqsGroup>());
     }
+
+    [Test]
+    public void GroupCreateTest_NotFound()
+    {
+        DefaultMessageFactory dmf = new DefaultMessageFactory();
+        var ex = Assert.Throws<MessageFactoryNotFound>(() => { dmf.Create("FIX.4.99", "B", 33); });
+        string exMsg = "Message factory not found for BeginString=FIX.4.99.";
+        Assert.That(ex!.Message, Is.EqualTo(exMsg));
+    }
 }


### PR DESCRIPTION
resolves #983

Replaces UnsupportedVersion in current implementation, for when DefaultMessageFactory cannot match a factory to BeginString.

This exception's message should be more helpful to developers, and distinguishes this root cause from other causes that trigger UnsupportedVersion.