### PR TITLE
deprecate IsHeaderField without dd

### DIFF
--- a/QuickFIXn/DataDictionary/DDField.cs
+++ b/QuickFIXn/DataDictionary/DDField.cs
@@ -13,22 +13,22 @@ public class DDField
     /// <param name="name"></param>
     /// <param name="enums">dictionary of enum=>description values</param>
     /// <param name="fixFldType"></param>
-    public DDField(int tag, String name, IReadOnlyDictionary<String, String> enums, String fixFldType)
+    public DDField(int tag, string name, IReadOnlyDictionary<string, string> enums, string fixFldType)
     {
         this.Tag = tag;
         this.Name = name;
         this.EnumDict = enums.ToFrozenDictionary();
         this.FixFldType = fixFldType;
-        this.FieldType = FieldTypeFromFix(this.FixFldType, out bool isMVFWE);
-        this.IsMultipleValueFieldWithEnums = isMVFWE;
+        this.FieldType = FieldTypeFromFix(this.FixFldType, out bool isMultipleValueFieldWithEnums);
+        this.IsMultipleValueFieldWithEnums = isMultipleValueFieldWithEnums;
     }
 
     public int Tag { get; private set; }
-    public String Name { get; private set; }
+    public string Name { get; private set; }
 
-    public IReadOnlyDictionary<String, String> EnumDict { get; }
+    public IReadOnlyDictionary<string, string> EnumDict { get; }
 
-    public String FixFldType { get; private set; }
+    public string FixFldType { get; private set; }
     public Type FieldType { get; private set; }
 
     /// <summary>
@@ -36,14 +36,14 @@ public class DDField
     /// </summary>
     public bool IsMultipleValueFieldWithEnums { get; private set; }
 
-    public Boolean HasEnums()
+    public bool HasEnums()
     {
         return EnumDict.Count > 0;
     }
 
-    private Type FieldTypeFromFix(String type, out bool multipleValueFieldWithEnums)
+    private Type FieldTypeFromFix(string type, out bool isMultipleValueFieldWithEnums)
     {
-        multipleValueFieldWithEnums = false;
+        isMultipleValueFieldWithEnums = false;
 
         switch (type)
         {
@@ -54,9 +54,9 @@ public class DDField
             case "AMT": return typeof(Fields.DecimalField);
             case "QTY": return typeof(Fields.DecimalField);
             case "CURRENCY": return typeof(Fields.StringField);
-            case "MULTIPLEVALUESTRING": multipleValueFieldWithEnums = true; return typeof(Fields.StringField);
-            case "MULTIPLESTRINGVALUE": multipleValueFieldWithEnums = true; return typeof(Fields.StringField);
-            case "MULTIPLECHARVALUE": multipleValueFieldWithEnums = true; return typeof(Fields.StringField);
+            case "MULTIPLEVALUESTRING": isMultipleValueFieldWithEnums = true; return typeof(Fields.StringField);
+            case "MULTIPLESTRINGVALUE": isMultipleValueFieldWithEnums = true; return typeof(Fields.StringField);
+            case "MULTIPLECHARVALUE": isMultipleValueFieldWithEnums = true; return typeof(Fields.StringField);
             case "EXCHANGE": return typeof(Fields.StringField);
             case "UTCTIMESTAMP": return typeof(Fields.DateTimeField);
             case "BOOLEAN": return typeof(Fields.BooleanField);

--- a/QuickFIXn/DataDictionary/DDMap.cs
+++ b/QuickFIXn/DataDictionary/DDMap.cs
@@ -1,66 +1,66 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace QuickFix.DataDictionary
+namespace QuickFix.DataDictionary;
+
+/// <summary>
+/// Represents the DD definition for a message type
+/// </summary>
+public class DDMap : IFieldMapSpec
 {
-    /// <summary>
-    /// Represents the DD definition for a message type
-    /// </summary>
-    public class DDMap : IFieldMapSpec
+    public Dictionary<int, DDField> Fields = new();
+    public Dictionary<int, DDGrp> Groups = new();
+    public HashSet<int> ReqFields = [];
+
+    public void AddField(DDField fld)
     {
-        public Dictionary<int, DDField> Fields = new();
-        public Dictionary<int, DDGrp> Groups = new();
-        public HashSet<int> ReqFields = [];
+        Fields.Add(fld.Tag, fld);
+    }
 
-        public void AddField(DDField fld)
-        {
-            Fields.Add(fld.Tag, fld);
-        }
+    public void AddGroup(DDGrp grp)
+    {
+        Groups.Add(grp.Delim, grp);
+    }
 
-        public void AddGroup(DDGrp grp)
-        {
-            Groups.Add(grp.Delim, grp);
-        }
+    public Boolean IsGroup(int tag)
+    {
+        return Groups.ContainsKey(tag);
+    }
 
-        public Boolean IsGroup(int tag)
-        {
-            return Groups.ContainsKey(tag);
-        }
+    public Boolean IsField(int tag)
+    {
+        return Fields.ContainsKey(tag);
+    }
 
-        public Boolean IsField(int tag)
-        {
-            return Fields.ContainsKey(tag);
-        }
-
-        public DDGrp GetGroup(int tag)
-        {
-            return Groups[tag];
-        }
-
-        /// <summary>
-        /// Same as GetGroup, just a more-general return type.
-        /// </summary>
-        /// <param name="tag"></param>
-        /// <returns></returns>
-        public IGroupSpec GetGroupSpec(int tag)
-        {
-            return Groups[tag];
-        }
+    public DDGrp GetGroup(int tag)
+    {
+        return Groups[tag];
     }
 
     /// <summary>
-    /// Represents the DD definition for a group type
+    /// Same as GetGroup, just a more-general return type.
     /// </summary>
-    public class DDGrp : DDMap, IGroupSpec
+    /// <param name="tag"></param>
+    /// <returns></returns>
+    public IGroupSpec GetGroupSpec(int tag)
     {
-        public int NumFld { get; set; }
-        public int Delim { get; set; }
-        public Boolean Required = false;
-        public DDGrp() : base()
-        {
-            Delim = 0;
-            NumFld = 0;
-            Required = false;
-        }
+        return Groups[tag];
     }
 }
+
+/// <summary>
+/// Represents the DD definition for a group type
+/// </summary>
+public class DDGrp : DDMap, IGroupSpec
+{
+    public int NumFld { get; set; }
+    public int Delim { get; set; }
+    public Boolean Required = false;
+    public DDGrp() : base()
+    {
+        Delim = 0;
+        NumFld = 0;
+        Required = false;
+    }
+}
+

--- a/QuickFIXn/DataDictionary/DDMap.cs
+++ b/QuickFIXn/DataDictionary/DDMap.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace QuickFix.DataDictionary
 {
@@ -10,9 +8,9 @@ namespace QuickFix.DataDictionary
     /// </summary>
     public class DDMap : IFieldMapSpec
     {
-        public Dictionary<int, DDField> Fields = new Dictionary<int, DDField>();
-        public Dictionary<int, DDGrp> Groups = new Dictionary<int, DDGrp>();
-        public HashSet<int> ReqFields = new HashSet<int>();
+        public Dictionary<int, DDField> Fields = new();
+        public Dictionary<int, DDGrp> Groups = new();
+        public HashSet<int> ReqFields = [];
 
         public void AddField(DDField fld)
         {

--- a/QuickFIXn/DataDictionary/DictionaryParseException.cs
+++ b/QuickFIXn/DataDictionary/DictionaryParseException.cs
@@ -1,13 +1,12 @@
 ﻿using System;
 
-namespace QuickFix
+namespace QuickFix;
+
+public class DictionaryParseException : ApplicationException
 {
-    public class DictionaryParseException : ApplicationException
-    {
-        public DictionaryParseException() { }
-        public DictionaryParseException(string message)
-            : base(message) { }
-        public DictionaryParseException(string message, System.Exception inner)
-            : base(message, inner) { }
-    }
+    public DictionaryParseException() { }
+    public DictionaryParseException(string message)
+        : base(message) { }
+    public DictionaryParseException(string message, System.Exception inner)
+        : base(message, inner) { }
 }

--- a/QuickFIXn/DataDictionary/DictionaryParseException.cs
+++ b/QuickFIXn/DataDictionary/DictionaryParseException.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace QuickFix;
+namespace QuickFix.DataDictionary;
 
 public class DictionaryParseException : ApplicationException
 {

--- a/QuickFIXn/DataDictionary/IFieldMapSpec.cs
+++ b/QuickFIXn/DataDictionary/IFieldMapSpec.cs
@@ -1,31 +1,27 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
-namespace QuickFix.DataDictionary
+namespace QuickFix.DataDictionary;
+
+public interface IFieldMapSpec
 {
-    public interface IFieldMapSpec
-    {
-        /// <summary>
-        /// Returns true if this tag is for a group-counter field defined for this IFieldMapSpec
-        /// </summary>
-        /// <param name="tag"></param>
-        /// <returns></returns>
-        Boolean IsGroup(int tag);
+    /// <summary>
+    /// Returns true if this tag is for a group-counter field defined for this IFieldMapSpec
+    /// </summary>
+    /// <param name="tag"></param>
+    /// <returns></returns>
+    Boolean IsGroup(int tag);
 
-        /// <summary>
-        /// Returns true if this tag is for a field defined for this IFieldMapSpec
-        /// </summary>
-        /// <param name="tag"></param>
-        /// <returns></returns>
-        Boolean IsField(int tag);
-        
-        /// <summary>
-        /// Get the IGroupSpec that corresponds to this group-counter tag
-        /// </summary>
-        /// <param name="tag"></param>
-        /// <returns></returns>
-        IGroupSpec GetGroupSpec(int tag);
-    }
+    /// <summary>
+    /// Returns true if this tag is for a field defined for this IFieldMapSpec
+    /// </summary>
+    /// <param name="tag"></param>
+    /// <returns></returns>
+    Boolean IsField(int tag);
+
+    /// <summary>
+    /// Get the IGroupSpec that corresponds to this group-counter tag
+    /// </summary>
+    /// <param name="tag"></param>
+    /// <returns></returns>
+    IGroupSpec GetGroupSpec(int tag);
 }

--- a/QuickFIXn/DataDictionary/IGroupSpec.cs
+++ b/QuickFIXn/DataDictionary/IGroupSpec.cs
@@ -1,12 +1,11 @@
 ﻿using System;
 
-namespace QuickFix.DataDictionary
+namespace QuickFix.DataDictionary;
+
+public interface IGroupSpec : IFieldMapSpec
 {
-    public interface IGroupSpec : IFieldMapSpec
-    {
-        /// <summary>
-        /// The tag of the delimiter field, i.e. the first field of each group member
-        /// </summary>
-        int Delim { get; set; }
-    }
+    /// <summary>
+    /// The tag of the delimiter field, i.e. the first field of each group member
+    /// </summary>
+    int Delim { get; set; }
 }

--- a/QuickFIXn/DataDictionary/InvalidMessageTypeException.cs
+++ b/QuickFIXn/DataDictionary/InvalidMessageTypeException.cs
@@ -1,19 +1,18 @@
 ﻿using System;
 
-namespace QuickFix
+namespace QuickFix;
+
+[Obsolete("This class will be removed in 1.16 (because it's unused)")]
+public class InvalidMessageTypeException : ApplicationException
 {
     [Obsolete("This class will be removed in a future release (because it's unused)")]
-    public class InvalidMessageTypeException : ApplicationException
-    {
-        [Obsolete("This class will be removed in a future release (because it's unused)")]
-        public InvalidMessageTypeException() { }
+    public InvalidMessageTypeException() { }
 
-        [Obsolete("This class will be removed in a future release (because it's unused)")]
-        public InvalidMessageTypeException(string message)
-            : base(message) { }
+    [Obsolete("This class will be removed in a future release (because it's unused)")]
+    public InvalidMessageTypeException(string message)
+        : base(message) { }
 
-        [Obsolete("This class will be removed in a future release (because it's unused)")]
-        public InvalidMessageTypeException(string message, System.Exception inner)
-            : base(message, inner) { }
-    }
+    [Obsolete("This class will be removed in a future release (because it's unused)")]
+    public InvalidMessageTypeException(string message, System.Exception inner)
+        : base(message, inner) { }
 }

--- a/QuickFIXn/DataDictionary/InvalidMessageTypeException.cs
+++ b/QuickFIXn/DataDictionary/InvalidMessageTypeException.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace QuickFix;
+namespace QuickFix.DataDictionary;
 
 [Obsolete("This class will be removed in 1.16 (because it's unused)")]
 public class InvalidMessageTypeException : ApplicationException

--- a/QuickFIXn/DataDictionary/MissingRequiredFieldException.cs
+++ b/QuickFIXn/DataDictionary/MissingRequiredFieldException.cs
@@ -1,28 +1,24 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 #pragma warning disable 0628 // Suppress "new protected member declared in sealed class" warning.
 
-namespace QuickFix
+namespace QuickFix;
+
+[Obsolete("This class will be removed in 1.16 (because it's unused)")]
+public sealed class MissingRequiredFieldException : ApplicationException
 {
     [Obsolete("This class will be removed in a future release (because it's unused)")]
-    public sealed class MissingRequiredFieldException : ApplicationException
-    {
-        [Obsolete("This class will be removed in a future release (because it's unused)")]
-        public MissingRequiredFieldException() { }
+    public MissingRequiredFieldException() { }
 
-        [Obsolete("This class will be removed in a future release (because it's unused)")]
-        public MissingRequiredFieldException(int field)
-            : base("Missing required field: " + field.ToString()) { }
+    [Obsolete("This class will be removed in a future release (because it's unused)")]
+    public MissingRequiredFieldException(int field)
+        : base($"Missing required field: {field}") { }
 
-        [Obsolete("This class will be removed in a future release (because it's unused)")]
-        public MissingRequiredFieldException(string message)
-            : base(message) { }
+    [Obsolete("This class will be removed in a future release (because it's unused)")]
+    public MissingRequiredFieldException(string message)
+        : base(message) { }
 
-        [Obsolete("This class will be removed in a future release (because it's unused)")]
-        public MissingRequiredFieldException(string message, System.Exception inner)
-            : base(message, inner) { }
-    }
+    [Obsolete("This class will be removed in a future release (because it's unused)")]
+    public MissingRequiredFieldException(string message, System.Exception inner)
+        : base(message, inner) { }
 }

--- a/QuickFIXn/DataDictionary/MissingRequiredFieldException.cs
+++ b/QuickFIXn/DataDictionary/MissingRequiredFieldException.cs
@@ -2,7 +2,7 @@
 
 #pragma warning disable 0628 // Suppress "new protected member declared in sealed class" warning.
 
-namespace QuickFix;
+namespace QuickFix.DataDictionary;
 
 [Obsolete("This class will be removed in 1.16 (because it's unused)")]
 public sealed class MissingRequiredFieldException : ApplicationException

--- a/QuickFIXn/DataDictionary/XMLMsgComponent.cs
+++ b/QuickFIXn/DataDictionary/XMLMsgComponent.cs
@@ -1,40 +1,40 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
-namespace QuickFix
+namespace QuickFix;
+
+[Obsolete("This class will be removed in 1.16 (because it's unused)")]
+partial class DataDictionaryParser
 {
-    partial class DataDictionaryParser
+    private sealed class XMLMsgComponent
     {
-        private sealed class XMLMsgComponent
+        public enum TypeEnum { Field, Component, Group };
+
+        [Obsolete("This class will be removed in 1.16 (because it's unused)")]
+        public XMLMsgComponent(string name, bool req, TypeEnum type )
         {
-            public enum TypeEnum { Field, Component, Group };
+            Name = name;
+            Required = req;
+            SubComponents = new List<XMLMsgComponent>();
+            ComponentType = type;
+        }
+        public TypeEnum ComponentType { get; set; }
+        public string Name { get; set; }
+        public bool Required { get; set; }
+        public List<XMLMsgComponent> SubComponents { get; set; }
 
-            public XMLMsgComponent(string name, bool req, TypeEnum type )
+        [Obsolete("This class will be removed in 1.16 (because it's unused)")]
+        public static TypeEnum GetComponentType(string typestr, string parentName)
+        {
+            TypeEnum ctype;
+            switch (typestr)
             {
-                Name = name;
-                Required = req;
-                SubComponents = new List<XMLMsgComponent>();
-                ComponentType = type;
+                case "field": ctype = TypeEnum.Field; break;
+                case "group": ctype = TypeEnum.Group; break;
+                case "component": ctype = TypeEnum.Component; break;
+                default: throw new MessageParseError("unknown component in msg: " + parentName);
             }
-            public TypeEnum ComponentType { get; set; }
-            public string Name { get; set; }
-            public bool Required { get; set; }
-            public List<XMLMsgComponent> SubComponents { get; set; }
-
-            public static TypeEnum GetComponentType(string typestr, string parentName)
-            {
-                TypeEnum ctype;
-                switch (typestr)
-                {
-                    case "field": ctype = TypeEnum.Field; break;
-                    case "group": ctype = TypeEnum.Group; break;
-                    case "component": ctype = TypeEnum.Component; break;
-                    default: throw new MessageParseError("unknown component in msg: " + parentName);
-                }
-                return ctype;
-            }
+            return ctype;
         }
     }
 }

--- a/QuickFIXn/DataDictionary/XMLMsgComponent.cs
+++ b/QuickFIXn/DataDictionary/XMLMsgComponent.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace QuickFix;
+namespace QuickFix.DataDictionary;
 
 [Obsolete("This class will be removed in 1.16 (because it's unused)")]
 partial class DataDictionaryParser

--- a/QuickFIXn/Message/Message.cs
+++ b/QuickFIXn/Message/Message.cs
@@ -49,7 +49,7 @@ public class Message : FieldMap
     public Message(string msgstr, DD? transportDict, DD? appDict, bool validate)
         : this()
     {
-        PopulateHeaderFromMessageString(msgstr);
+        PopulateHeaderFromMessageString(msgstr, transportDict);
         if (IsAdmin())
             FromString(msgstr, validate, transportDict, transportDict, null, false);
         else
@@ -90,6 +90,14 @@ public class Message : FieldMap
         return tag;
     }
 
+    /// <summary>
+    /// Extract a field whose length is determined by a datalength field
+    /// </summary>
+    /// <param name="msgstr"></param>
+    /// <param name="dataLength"></param>
+    /// <param name="pos"></param>
+    /// <returns></returns>
+    /// <exception cref="MessageParseError"></exception>
     public static StringField ExtractDataField(string msgstr, int dataLength, ref int pos)
     {
         try
@@ -116,6 +124,13 @@ public class Message : FieldMap
         }
     }
 
+    /// <summary>
+    /// Extract a field that ends with SOH
+    /// </summary>
+    /// <param name="msgstr"></param>
+    /// <param name="pos"></param>
+    /// <returns></returns>
+    /// <exception cref="MessageParseError"></exception>
     public static StringField ExtractField(string msgstr, ref int pos)
     {
         try
@@ -123,7 +138,7 @@ public class Message : FieldMap
             int tagend = msgstr.IndexOf('=', pos);
             int tag = Convert.ToInt32(msgstr.Substring(pos, tagend - pos));
             pos = tagend + 1;
-            int fieldvalend = msgstr.IndexOf((char)1, pos);
+            int fieldvalend = msgstr.IndexOf(SOH, pos);
             StringField field =  new StringField(tag, msgstr.Substring(pos, fieldvalend - pos));
 
             pos = fieldvalend + 1;
@@ -149,7 +164,19 @@ public class Message : FieldMap
         return ExtractField(msgstr, ref i).Value;
     }
 
+    [Obsolete("This method is deprecated and will be removed in 1.16. Use IsHeaderField(int tag, DD? dd) instead.")]
     public static bool IsHeaderField(int tag)
+    {
+        return IsGenericHeaderField(tag);
+    }
+
+    /// <summary>
+    /// Determine if field is a header according to the standard vanilla DD.
+    /// The header list in this function is hardcoded.
+    /// </summary>
+    /// <param name="tag"></param>
+    /// <returns></returns>
+    private static bool IsGenericHeaderField(int tag)
     {
         switch (tag)
         {
@@ -184,9 +211,10 @@ public class Message : FieldMap
                 return false;
         }
     }
+
     public static bool IsHeaderField(int tag, DD? dd)
     {
-        if (IsHeaderField(tag))
+        if (IsGenericHeaderField(tag))
             return true;
         if (dd is not null)
             return dd.IsHeaderField(tag);
@@ -319,7 +347,7 @@ public class Message : FieldMap
         Trailer.Clear();
     }
 
-    private void PopulateHeaderFromMessageString(string msgstr)
+    private void PopulateHeaderFromMessageString(string msgstr, DD? dd)
     {
         Clear();
 
@@ -332,7 +360,7 @@ public class Message : FieldMap
             if (count < 3 && Header.HEADER_FIELD_ORDER[count++] != f.Tag)
                 return;
 
-            if(IsHeaderField(f.Tag))
+            if(IsHeaderField(f.Tag, dd))
                 Header.SetField(f, false);
             else
                 break;
@@ -368,18 +396,10 @@ public class Message : FieldMap
 
         while (pos < msgstr.Length)
         {
-            StringField? f = null;
-
             int fieldTag = ExtractFieldTag(msgstr, pos);
-            if (fieldTag == Tags.XmlData)
-            {
-                if (IsHeaderField(Tags.XmlDataLen))
-                    f = ExtractDataField(msgstr, Header.GetInt(Tags.XmlDataLen), ref pos);
-                else if (IsSetField(Tags.XmlDataLen))
-                    f = ExtractDataField(msgstr, GetInt(Tags.XmlDataLen), ref pos);
-            }
-
-            f ??= ExtractField(msgstr, ref pos);
+            StringField f = fieldTag == Tags.XmlData
+                ? ExtractDataField(msgstr, Header.GetInt(Tags.XmlDataLen), ref pos)
+                : ExtractField(msgstr, ref pos);
 
             if (validate && (count < 3) && (Header.HEADER_FIELD_ORDER[count++] != f.Tag))
                 throw new InvalidMessage("Header fields out of order");

--- a/QuickFIXn/Message/Message.cs
+++ b/QuickFIXn/Message/Message.cs
@@ -212,12 +212,20 @@ public class Message : FieldMap
         }
     }
 
-    public static bool IsHeaderField(int tag, DD? dd)
+    /// <summary>
+    /// Determine if field is a header field.
+    /// If transportDataDictionary is null, compares against a hard-coded list of header fields as
+    /// specified in the standard FIX data dictionaries.
+    /// </summary>
+    /// <param name="tag"></param>
+    /// <param name="transportDataDictionary"></param>
+    /// <returns></returns>
+    public static bool IsHeaderField(int tag, DD? transportDataDictionary)
     {
         if (IsGenericHeaderField(tag))
             return true;
-        if (dd is not null)
-            return dd.IsHeaderField(tag);
+        if (transportDataDictionary is not null)
+            return transportDataDictionary.IsHeaderField(tag);
         return false;
     }
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -34,6 +34,7 @@ What's New
 * #841 - experimental support for CME Enhanced Resend (gbirchmeier)
 * #961 - new GenerateKeys app to create Example-app SSL certs (dckorben/gbirchmeier)
 * #1001 - AcceptanceTests bug: double.Parse with InvariantCulture (gbirchmeier)
+* #562 - deprecate Message.IsHeaderField without transport DD param (gbirchmeier)
 
 
 ### v1.14.0

--- a/UnitTests/MessageTests.cs
+++ b/UnitTests/MessageTests.cs
@@ -217,9 +217,18 @@ namespace UnitTests
         [Test]
         public void IsHeaderFieldTest()
         {
-            Assert.That(Message.IsHeaderField(Tags.BeginString), Is.EqualTo(true));
-            Assert.That(Message.IsHeaderField(Tags.TargetCompID), Is.EqualTo(true));
-            Assert.That(Message.IsHeaderField(Tags.Account), Is.EqualTo(false));
+            Assert.That(Message.IsHeaderField(Tags.BeginString, null), Is.EqualTo(true));
+            Assert.That(Message.IsHeaderField(Tags.TargetCompID, null), Is.EqualTo(true));
+            Assert.That(Message.IsHeaderField(Tags.Account, null), Is.EqualTo(false));
+
+            var dd = new QuickFix.DataDictionary.DataDictionary();
+            dd.LoadFIXSpec("FIX44");
+            dd.Header.AddField(
+                new QuickFix.DataDictionary.DDField(901109, "FakeField", new Dictionary<string, string>(), "STRING"));
+
+            Assert.That(Message.IsHeaderField(Tags.TargetCompID, dd), Is.EqualTo(true));
+            Assert.That(Message.IsHeaderField(Tags.Account, dd), Is.EqualTo(false));
+            Assert.That(Message.IsHeaderField(901109, dd), Is.EqualTo(true));
         }
 
         [Test]


### PR DESCRIPTION
IsHeaderField(tag) without the DD param should be discouraged, because custom DDs might add other header fields that need to be matched.  Removed internal usages of it and deprecated it.

 resolves #562