### PR TITLE
deprecate DateTimeConverter.ParseToTimeOnly

### DIFF
--- a/QuickFIXn/DataDictionary/DataDictionary.cs
+++ b/QuickFIXn/DataDictionary/DataDictionary.cs
@@ -305,7 +305,7 @@ public class DataDictionary
             else if (type == typeof(DateOnlyField))
                 Fields.Converters.DateTimeConverter.ParseToDateOnly(field.ToString());
             else if (type == typeof(TimeOnlyField))
-                Fields.Converters.DateTimeConverter.ParseToTimeOnly(field.ToString());
+                Fields.Converters.DateTimeConverter.InternalParseToTimeOnly(field.ToString());
         }
         catch (FieldConvertError e)
         {

--- a/QuickFIXn/Fields/Converters/DateTimeConverter.cs
+++ b/QuickFIXn/Fields/Converters/DateTimeConverter.cs
@@ -245,9 +245,10 @@ public static class DateTimeConverter
 
         return time;
     }
-    
+
     /// <summary>
-    /// Converts the specified string to a <see cref="DateTime"/>.
+    /// Converts the specified string to a <see cref="DateTime"/> WHERE ONLY THE TIME PARTS ARE MEANINGFUL.
+    /// (The date parts of the return value will always be set to 1980-01-01, DateTime.Kind==Unspecified.)
     /// The string must be in the format "HH:mm:ss" optionally followed by fractional seconds
     /// and then optionally followed by UTC offset information.
     /// </summary>
@@ -268,8 +269,7 @@ public static class DateTimeConverter
     /// Consider calling the latter for flexibility.
     /// </remarks>
     /// <exception cref="FieldConvertError">The conversion cannot be performed successfully.</exception>
-    public static DateTime ParseToTimeOnly(string str) => new DateOnly(1980, 1, 1).ToDateTime(ParseToTimeOnly(str, out _));
-    // (^^Yes, it intentionally does return a DateTime.  For now.)
+    internal static DateTime InternalParseToTimeOnly(string str) => new DateOnly(1980, 1, 1).ToDateTime(ParseToTimeOnly(str, out _));
 
     /// <summary>
     /// For the given <paramref name="span"/>, read consecutive ASCII digits
@@ -621,4 +621,7 @@ public static class DateTimeConverter
             ? ToFIXTimeOnly(dt, TimeStampPrecision.Millisecond)
             : ToFIXTimeOnly(dt, TimeStampPrecision.Second);
     }
+
+    [Obsolete("Don't use this function, it probably doesn't do what you think it does.  Will be removed in v1.16.")]
+    public static DateTime ParseToTimeOnly(string str) => InternalParseToTimeOnly(str);
 }

--- a/QuickFIXn/Message/FieldMap.cs
+++ b/QuickFIXn/Message/FieldMap.cs
@@ -385,6 +385,8 @@ public class FieldMap : IEnumerable<KeyValuePair<int, IField>> {
 
     /// <summary>
     /// Gets the TimeOnly value of a field
+    /// as a DateTime WHERE ONLY THE TIME PARTS ARE MEANINGFUL.
+    /// (The date parts of the return value will always be set to 1980-01-01, DateTime.Kind==Unspecified.)
     /// </summary>
     /// <param name="tag">the FIX tag</param>
     /// <returns>the DateTime value</returns>
@@ -397,7 +399,7 @@ public class FieldMap : IEnumerable<KeyValuePair<int, IField>> {
         if (fld is FieldBase<DateTime> dateTimeField)
             return new DateTime(1980, 01, 01).Add(dateTimeField.Value.TimeOfDay);
 
-        return DateTimeConverter.ParseToTimeOnly(fld.ToString());
+        return DateTimeConverter.InternalParseToTimeOnly(fld.ToString());
     }
 
     /// <summary>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -37,6 +37,7 @@ What's New
 * #562 - deprecate Message.IsHeaderField without transport DD param (gbirchmeier)
 * #949 - new settings RedactFieldsInLogs & RedactionLogText (gbirchmeier)
 * #983 - new MessageFactoryNotFound exception provides better feedback (gbirchmeier)
+* #1014 - deprecate DateTimeConverter.ParseToTimeOnly (gbirchmeier)
 
 
 ### v1.14.0

--- a/UnitTests/Fields/Converters/DateTimeConverterTests.cs
+++ b/UnitTests/Fields/Converters/DateTimeConverterTests.cs
@@ -103,17 +103,17 @@ public class DateTimeConverterTests {
         var targetTicks = new DateTime(1980, 1, 1, 4, 22, 1, 0, DateTimeKind.Utc).Ticks;
         Assert.That(targetTicks, Is.EqualTo(624511453210000000)); // for human reader reference
 
-        DateTime rv = DateTimeConverter.ParseToTimeOnly("04:22:01");
+        DateTime rv = DateTimeConverter.InternalParseToTimeOnly("04:22:01");
 
         Assert.That(rv.Ticks, Is.EqualTo(targetTicks));
-        Assert.That(DateTimeConverter.ParseToTimeOnly("04:22:01.123").Ticks, Is.EqualTo(targetTicks + 1230000));
-        Assert.That(DateTimeConverter.ParseToTimeOnly("04:22:01.123456").Ticks, Is.EqualTo(targetTicks + 1234560));
+        Assert.That(DateTimeConverter.InternalParseToTimeOnly("04:22:01.123").Ticks, Is.EqualTo(targetTicks + 1230000));
+        Assert.That(DateTimeConverter.InternalParseToTimeOnly("04:22:01.123456").Ticks, Is.EqualTo(targetTicks + 1234560));
     }
 
     [Test]
     public void ParseToTimeOnlyTest_Exceptions() {
-        Assert.Throws(typeof(FieldConvertError), delegate { DateTimeConverter.ParseToTimeOnly(""); });
-        Assert.Throws(typeof(FieldConvertError), delegate { DateTimeConverter.ParseToTimeOnly("20021201-11:03:00"); });
+        Assert.Throws(typeof(FieldConvertError), delegate { DateTimeConverter.InternalParseToTimeOnly(""); });
+        Assert.Throws(typeof(FieldConvertError), delegate { DateTimeConverter.InternalParseToTimeOnly("20021201-11:03:00"); });
     }
 
     [Test]


### PR DESCRIPTION
resolves #1014