### PR TITLE
Make Session.MessagesLogLevel configurable

### DIFF
--- a/QuickFIXn/Session.cs
+++ b/QuickFIXn/Session.cs
@@ -29,8 +29,7 @@ public class Session : IDisposable
     private readonly SessionState _state;
     private readonly IMessageFactory _msgFactory;
     private readonly bool _appDoesEarlyIntercept;
-
-    private const LogLevel MessagesLogLevel = LogLevel.Information;
+    private readonly LogLevel _messagesLogLevel;
 
     #region Properties
 
@@ -239,7 +238,8 @@ public class Session : IDisposable
         int heartBtInt,
         IQuickFixLoggerFactory loggerFactory,
         IMessageFactory msgFactory,
-        string senderDefaultApplVerId)
+        string senderDefaultApplVerId,
+        LogLevel messagesLogLevel)
     {
         _schedule = sessionSchedule;
         _msgFactory = msgFactory;
@@ -249,13 +249,14 @@ public class Session : IDisposable
         SessionID = sessId;
         DataDictionaryProvider = new DataDictionaryProvider(dataDictProvider);
         SenderDefaultApplVerID = senderDefaultApplVerId;
-
+        
         SessionDataDictionary = DataDictionaryProvider.GetSessionDataDictionary(SessionID.BeginString);
         ApplicationDataDictionary = SessionID.IsFIXT
             ? DataDictionaryProvider.GetApplicationDataDictionary(SenderDefaultApplVerID)
             : SessionDataDictionary;
 
         ILogger logger = loggerFactory.CreateSessionLogger(sessId);
+        _messagesLogLevel = messagesLogLevel;
 
         _state = new SessionState(isInitiator, logger, heartBtInt, storeFactory.Create(sessId));
 
@@ -368,14 +369,14 @@ public class Session : IDisposable
             if (_responder is null)
                 return false;
 
-            if (Log.IsEnabled(MessagesLogLevel))
+            if (Log.IsEnabled(_messagesLogLevel))
             {
                 using (Log.BeginScope(new Dictionary<string, object>
                        {
                            { "MessageType", Message.GetMsgType(message) }
                        }))
                 {
-                    Log.Log(MessagesLogLevel, LogEventIds.OutgoingMessage, "{Message}",
+                    Log.Log(_messagesLogLevel, LogEventIds.OutgoingMessage, "{Message}",
                         LogAssist.RedactSensitiveFields(message, RedactFieldsInLogs, RedactionLogText));
                 }
             }
@@ -542,20 +543,20 @@ public class Session : IDisposable
     {
         try
         {
-            if (Log.IsEnabled(MessagesLogLevel))
+            if (Log.IsEnabled(_messagesLogLevel))
             {
                 using (Log.BeginScope(new Dictionary<string, object>
                        {
                            { "MessageType", Message.GetMsgType(msgStr) }
                        }))
                 {
-                    Log.Log(MessagesLogLevel, LogEventIds.IncomingMessage, "{Message}",
+                    Log.Log(_messagesLogLevel, LogEventIds.IncomingMessage, "{Message}",
                         LogAssist.RedactSensitiveFields(msgStr, RedactFieldsInLogs, RedactionLogText));
                 }
             }
         } catch (Exception)
         {
-            Log.Log(MessagesLogLevel, LogEventIds.IncomingMessage, "{Message}",
+            Log.Log(_messagesLogLevel, LogEventIds.IncomingMessage, "{Message}",
                 LogAssist.RedactSensitiveFields(msgStr, RedactFieldsInLogs, RedactionLogText));
         }
 

--- a/QuickFIXn/SessionFactory.cs
+++ b/QuickFIXn/SessionFactory.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
 using QuickFix.Logger;
 using QuickFix.Store;
 using QuickFix.Util;
@@ -99,6 +100,16 @@ internal class SessionFactory
         if(defaultApplVerId is not null)
             senderDefaultApplVerId = defaultApplVerId.Value;
 
+        LogLevel messagesLogLevel = LogLevel.Information;
+        string? messagesLogLevelName = null;
+        if(settings.Has(SessionSettings.MESSAGES_LOG_LEVEL))
+        {
+            messagesLogLevelName = settings.GetString(SessionSettings.MESSAGES_LOG_LEVEL);
+            if (!Enum.TryParse(messagesLogLevelName, true, out LogLevel logLevel))
+                throw new ConfigError($"Invalid {SessionSettings.MESSAGES_LOG_LEVEL} value: {messagesLogLevelName}");
+            messagesLogLevel = logLevel;
+        }
+
         Session session = new Session(
             isInitiator,
             _application,
@@ -109,7 +120,8 @@ internal class SessionFactory
             heartBtInt,
             _loggerFactory,
             sessionMsgFactory,
-            senderDefaultApplVerId);
+            senderDefaultApplVerId,
+            messagesLogLevel);
 
         if (settings.Has("MillisecondsInTimeStamp")) {
             throw new ApplicationException(

--- a/QuickFIXn/SessionSettings.cs
+++ b/QuickFIXn/SessionSettings.cs
@@ -38,6 +38,7 @@ public class SessionSettings
     public const string SOCKET_CONNECT_PORT = "SocketConnectPort";
     public const string RECONNECT_INTERVAL = "ReconnectInterval";
     public const string FILE_LOG_PATH = "FileLogPath";
+    public const string MESSAGES_LOG_LEVEL = "MessagesLogLevel";
     public const string FILE_STORE_PATH = "FileStorePath";
     public const string REFRESH_ON_LOGON = "RefreshOnLogon";
     public const string RESET_ON_LOGON = "ResetOnLogon";


### PR DESCRIPTION
Session.MessagesLogLevel is hard-coded to LogLevel.Information, and const, which produces useful information when debugging but a lot of possibly unwanted 'noise' in production.

This PR proposes to make it configurable, leveraging the existing mechanism i.e. config file -> SessionSettings -> SessionFactory -> Session.

If the config ket is missing, there is no change from the current behavior.   