### PR TITLE
Don't call socket task dispose

### DIFF
--- a/QuickFIXn/SocketInitiatorThread.cs
+++ b/QuickFIXn/SocketInitiatorThread.cs
@@ -196,7 +196,6 @@ public class SocketInitiatorThread : IResponder
 
         // just wait when read task will be cancelled
         _currentReadTask?.ContinueWith(_ => { }).Wait(1000);
-        _currentReadTask?.Dispose();
         _currentReadTask = null;
         _stream?.Close();
     }

--- a/QuickFIXn/SocketInitiatorThread.cs
+++ b/QuickFIXn/SocketInitiatorThread.cs
@@ -23,6 +23,7 @@ public class SocketInitiatorThread : IResponder
 
     private Thread? _thread;
     private readonly byte[] _readBuffer = new byte[BUF_SIZE];
+    private const int _readTimeoutMilliseconds = 1000;
     private readonly Parser _parser = new();
     private Stream? _stream;
     private readonly CancellationTokenSource _readCancellationTokenSource = new();
@@ -89,7 +90,7 @@ public class SocketInitiatorThread : IResponder
     {
         try
         {
-            int bytesRead = ReadSome(_readBuffer, 1000);
+            int bytesRead = ReadSome(_readBuffer, _readTimeoutMilliseconds);
             if (bytesRead > 0)
                 _parser.AddToStream(new ReadOnlySpan<byte>(_readBuffer, 0, bytesRead));
             else
@@ -195,7 +196,8 @@ public class SocketInitiatorThread : IResponder
         _readCancellationTokenSource.Dispose();
 
         // just wait when read task will be cancelled
-        _currentReadTask?.ContinueWith(_ => { }).Wait(1000);
+        _currentReadTask?.ContinueWith(_ => { }).Wait(_readTimeoutMilliseconds);
+        _currentReadTask = null;
 
         _stream?.Close();
     }

--- a/QuickFIXn/SocketInitiatorThread.cs
+++ b/QuickFIXn/SocketInitiatorThread.cs
@@ -196,7 +196,7 @@ public class SocketInitiatorThread : IResponder
 
         // just wait when read task will be cancelled
         _currentReadTask?.ContinueWith(_ => { }).Wait(1000);
-        _currentReadTask = null;
+
         _stream?.Close();
     }
 

--- a/QuickFIXn/SocketReader.cs
+++ b/QuickFIXn/SocketReader.cs
@@ -294,7 +294,6 @@ public class SocketReader : IDisposable
 
             // just wait when read task will be cancelled
             _currentReadTask?.ContinueWith(_ => { }).Wait(1000);
-            _currentReadTask = null;
 
             _stream.Dispose();
             _tcpClient.Close();

--- a/QuickFIXn/SocketReader.cs
+++ b/QuickFIXn/SocketReader.cs
@@ -292,6 +292,9 @@ public class SocketReader : IDisposable
             _readCancellationTokenSource.Cancel();
             _readCancellationTokenSource.Dispose();
 
+            // just wait when read task will be cancelled
+            _currentReadTask?.ContinueWith(_ => { }).Wait(1000);
+
             _stream.Dispose();
             _tcpClient.Close();
         }

--- a/QuickFIXn/SocketReader.cs
+++ b/QuickFIXn/SocketReader.cs
@@ -294,6 +294,7 @@ public class SocketReader : IDisposable
 
             // just wait when read task will be cancelled
             _currentReadTask?.ContinueWith(_ => { }).Wait(1000);
+            _currentReadTask = null;
 
             _stream.Dispose();
             _tcpClient.Close();

--- a/QuickFIXn/SocketReader.cs
+++ b/QuickFIXn/SocketReader.cs
@@ -14,6 +14,7 @@ public class SocketReader : IDisposable
 {
     public const int BUF_SIZE = 4096;
     private readonly byte[] _readBuffer = new byte[BUF_SIZE];
+    private const int _readTimeoutMilliseconds = 1000;
     private readonly Parser _parser = new();
     private Session? _qfSession;
     private readonly Stream _stream;
@@ -48,7 +49,7 @@ public class SocketReader : IDisposable
     {
         try
         {
-            int bytesRead = ReadSome(_readBuffer, 1000);
+            int bytesRead = ReadSome(_readBuffer, _readTimeoutMilliseconds);
             if (bytesRead > 0)
                 _parser.AddToStream(new ReadOnlySpan<byte>(_readBuffer, 0, bytesRead));
             else
@@ -293,7 +294,8 @@ public class SocketReader : IDisposable
             _readCancellationTokenSource.Dispose();
 
             // just wait when read task will be cancelled
-            _currentReadTask?.ContinueWith(_ => { }).Wait(1000);
+            _currentReadTask?.ContinueWith(_ => { }).Wait(_readTimeoutMilliseconds);
+            _currentReadTask = null;
 
             _stream.Dispose();
             _tcpClient.Close();

--- a/QuickFIXn/SocketReader.cs
+++ b/QuickFIXn/SocketReader.cs
@@ -292,10 +292,6 @@ public class SocketReader : IDisposable
             _readCancellationTokenSource.Cancel();
             _readCancellationTokenSource.Dispose();
 
-            // just wait when read task will be cancelled
-            _currentReadTask?.ContinueWith(_ => { }).Wait(1000);
-            _currentReadTask?.Dispose();
-
             _stream.Dispose();
             _tcpClient.Close();
         }


### PR DESCRIPTION
This PR removes the direct call to Task.Dispose in `QuickFIXn/SocketReader.cs`
fixes #1025 

The task does not always reach a completed state before the 1s timeout is reached and `Dispose` is called.
I don't believe that we strictly need to dispose the task here as the CancellationToken is cancelled. The task should complete eventually. 