### PR TITLE
#1030 Add UtcDateTimeField so UTCTIMESTAMP fields always carry DateTimeKind.Utc

### DIFF
--- a/DDTool/DDTool/Generators/GenFields.cs
+++ b/DDTool/DDTool/Generators/GenFields.cs
@@ -36,6 +36,7 @@ public static class GenFields {
             lines.Add("");
             switch (field.CsClass) {
                 case "DateTimeField":
+                case "UtcDateTimeField":
                     AppendDateTimeField(lines, field);
                     break;
                 case "TimeOnlyField":

--- a/DDTool/DDTool/Structures/DDField.cs
+++ b/DDTool/DDTool/Structures/DDField.cs
@@ -59,6 +59,9 @@ public class DDField : IElement {
                 baseType = "Decimal";
                 return;
             case "UTCTIMESTAMP":
+                csClass = "UtcDateTimeField";
+                baseType = "DateTime";
+                return;
             case "TZTIMESTAMP":
             case "TIME":
                 csClass = "DateTimeField";

--- a/DDTool/DDTool/Validations/FieldTypeInfo.cs
+++ b/DDTool/DDTool/Validations/FieldTypeInfo.cs
@@ -5,7 +5,7 @@ namespace DDTool.Validations;
 
 public enum QfnFieldClass
 {
-    CharField, IntField, DecimalField, DateTimeField, DateOnlyField, TimeOnlyField, BooleanField, StringField
+    CharField, IntField, DecimalField, DateTimeField, UtcDateTimeField, DateOnlyField, TimeOnlyField, BooleanField, StringField
 }
 
 public static class FieldTypeInfo {
@@ -32,6 +32,7 @@ public static class FieldTypeInfo {
             case "FLOAT":
                 return QfnFieldClass.DecimalField;
             case "UTCTIMESTAMP":
+                return QfnFieldClass.UtcDateTimeField;
             case "TZTIMESTAMP":
             case "TIME":
                 return QfnFieldClass.DateTimeField;
@@ -74,6 +75,7 @@ public static class FieldTypeInfo {
             case QfnFieldClass.DecimalField:
                 return "decimal";
             case QfnFieldClass.DateTimeField:
+            case QfnFieldClass.UtcDateTimeField:
                 return "DateTime";
             case QfnFieldClass.DateOnlyField:
                 return "DateOnly";

--- a/DDTool/UnitTests/Generators/GenFieldsTests.cs
+++ b/DDTool/UnitTests/Generators/GenFieldsTests.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using System.IO;
+using DDTool.Generators;
+using DDTool.Structures;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace UnitTests.Generators;
+
+[TestClass]
+public class GenFieldsTests {
+
+    [TestMethod]
+    public void UtcTimestampFieldIsGeneratedWithUtcDateTimeFieldBaseClass() {
+        string repoRoot = Path.Combine(Path.GetTempPath(), "GenFieldsTests_" + Path.GetRandomFileName());
+        Directory.CreateDirectory(Path.Combine(repoRoot, "QuickFIXn", "Fields"));
+
+        try {
+            var fields = new List<DDField> {
+                new(52, "SendingTime", new List<EnumValue>(), "UTCTIMESTAMP"),
+                new(1132, "TZTransactTime", new List<EnumValue>(), "TZTIMESTAMP"),
+            };
+
+            string writtenPath = GenFields.WriteFile(repoRoot, fields);
+            string generated = File.ReadAllText(writtenPath);
+
+            StringAssert.Contains(generated, "public sealed class SendingTime : UtcDateTimeField");
+            StringAssert.Contains(generated, "public sealed class TZTransactTime : DateTimeField");
+        } finally {
+            Directory.Delete(repoRoot, recursive: true);
+        }
+    }
+}

--- a/DDTool/UnitTests/Generators/GenFieldsTests.cs
+++ b/DDTool/UnitTests/Generators/GenFieldsTests.cs
@@ -9,9 +9,11 @@ namespace UnitTests.Generators;
 [TestClass]
 public class GenFieldsTests {
 
+    public TestContext TestContext { get; set; } = null!;
+
     [TestMethod]
     public void UtcTimestampFieldIsGeneratedWithUtcDateTimeFieldBaseClass() {
-        string repoRoot = Path.Combine(Path.GetTempPath(), "GenFieldsTests_" + Path.GetRandomFileName());
+        string repoRoot = Path.Combine(TestContext.TestRunDirectory!, Path.GetRandomFileName());
         Directory.CreateDirectory(Path.Combine(repoRoot, "QuickFIXn", "Fields"));
 
         try {

--- a/DDTool/UnitTests/Structures/DDFieldTests.cs
+++ b/DDTool/UnitTests/Structures/DDFieldTests.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using DDTool.Structures;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace UnitTests.Structures;
+
+[TestClass]
+public class DDFieldTests {
+
+    [TestMethod]
+    public void UtcTimestampMapsToUtcDateTimeField() {
+        var field = new DDField(52, "SendingTime", new List<EnumValue>(), "UTCTIMESTAMP");
+
+        Assert.AreEqual("UtcDateTimeField", field.CsClass);
+        Assert.AreEqual("DateTime", field.BaseType);
+    }
+
+    [TestMethod]
+    public void TzTimestampMapsToDateTimeField() {
+        var field = new DDField(1132, "TZTransactTime", new List<EnumValue>(), "TZTIMESTAMP");
+
+        Assert.AreEqual("DateTimeField", field.CsClass);
+        Assert.AreEqual("DateTime", field.BaseType);
+    }
+
+    [TestMethod]
+    public void TimeMapsToDateTimeField() {
+        var field = new DDField(273, "MDEntryTime", new List<EnumValue>(), "TIME");
+
+        Assert.AreEqual("DateTimeField", field.CsClass);
+        Assert.AreEqual("DateTime", field.BaseType);
+    }
+}

--- a/DDTool/UnitTests/Validations/FieldTypeInfoTests.cs
+++ b/DDTool/UnitTests/Validations/FieldTypeInfoTests.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using DDTool.Structures;
+using DDTool.Validations;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace UnitTests.Validations;
+
+[TestClass]
+public class FieldTypeInfoTests {
+
+    [TestMethod]
+    public void UtcTimestampResolvesToUtcDateTimeFieldClass() {
+        var field = new DDField(52, "SendingTime", new List<EnumValue>(), "UTCTIMESTAMP");
+
+        Assert.AreEqual(QfnFieldClass.UtcDateTimeField, FieldTypeInfo.GetQfnFieldClass(field));
+        Assert.AreEqual("DateTime", FieldTypeInfo.GetBaseType(field));
+    }
+
+    [TestMethod]
+    public void TzTimestampResolvesToDateTimeFieldClass() {
+        var field = new DDField(1132, "TZTransactTime", new List<EnumValue>(), "TZTIMESTAMP");
+
+        Assert.AreEqual(QfnFieldClass.DateTimeField, FieldTypeInfo.GetQfnFieldClass(field));
+        Assert.AreEqual("DateTime", FieldTypeInfo.GetBaseType(field));
+    }
+
+    [TestMethod]
+    public void TimeResolvesToDateTimeFieldClass() {
+        var field = new DDField(273, "MDEntryTime", new List<EnumValue>(), "TIME");
+
+        Assert.AreEqual(QfnFieldClass.DateTimeField, FieldTypeInfo.GetQfnFieldClass(field));
+        Assert.AreEqual("DateTime", FieldTypeInfo.GetBaseType(field));
+    }
+}

--- a/QuickFIXn/DataDictionary/DDField.cs
+++ b/QuickFIXn/DataDictionary/DDField.cs
@@ -58,7 +58,7 @@ public class DDField
             case "MULTIPLESTRINGVALUE": isMultipleValueFieldWithEnums = true; return typeof(Fields.StringField);
             case "MULTIPLECHARVALUE": isMultipleValueFieldWithEnums = true; return typeof(Fields.StringField);
             case "EXCHANGE": return typeof(Fields.StringField);
-            case "UTCTIMESTAMP": return typeof(Fields.DateTimeField);
+            case "UTCTIMESTAMP": return typeof(Fields.UtcDateTimeField);
             case "BOOLEAN": return typeof(Fields.BooleanField);
             case "LOCALMKTDATE": return typeof(Fields.StringField);
             case "LOCALMKTTIME": return typeof(Fields.StringField);

--- a/QuickFIXn/DataDictionary/DataDictionary.cs
+++ b/QuickFIXn/DataDictionary/DataDictionary.cs
@@ -300,7 +300,7 @@ public class DataDictionary
             else if (type == typeof(BooleanField))
                 Fields.Converters.BoolConverter.Convert(field.ToString());
 
-            else if (type == typeof(DateTimeField))
+            else if (type == typeof(DateTimeField) || type == typeof(UtcDateTimeField))
                 Fields.Converters.DateTimeConverter.ParseToDateTime(field.ToString());
             else if (type == typeof(DateOnlyField))
                 Fields.Converters.DateOnlyConverter.Convert(field.ToString());

--- a/QuickFIXn/Fields/FieldBase.cs
+++ b/QuickFIXn/Fields/FieldBase.cs
@@ -34,6 +34,8 @@ public abstract class FieldBase<T> : IField
         _stringField = "";
     }
 
+    // Virtual so UtcDateTimeField can normalize DateTimeKind on assignment; see UtcDateTimeField.Value
+    // for why the dispatch cost is negligible here.
     public virtual T Value
     {
         get => _value;

--- a/QuickFIXn/Fields/FieldBase.cs
+++ b/QuickFIXn/Fields/FieldBase.cs
@@ -34,7 +34,7 @@ public abstract class FieldBase<T> : IField
         _stringField = "";
     }
 
-    public T Value
+    public virtual T Value
     {
         get => _value;
         set

--- a/QuickFIXn/Fields/Fields.cs
+++ b/QuickFIXn/Fields/Fields.cs
@@ -945,7 +945,7 @@ public sealed class OrigClOrdID : StringField
 /// <summary>
 /// OrigTime Field
 /// </summary>
-public sealed class OrigTime : DateTimeField
+public sealed class OrigTime : UtcDateTimeField
 {
     public const int TAG = 42;
 
@@ -1125,7 +1125,7 @@ public sealed class SenderSubID : StringField
 /// <summary>
 /// SendingTime Field
 /// </summary>
-public sealed class SendingTime : DateTimeField
+public sealed class SendingTime : UtcDateTimeField
 {
     public const int TAG = 52;
 
@@ -1264,7 +1264,7 @@ public sealed class TimeInForce : CharField
 /// <summary>
 /// TransactTime Field
 /// </summary>
-public sealed class TransactTime : DateTimeField
+public sealed class TransactTime : UtcDateTimeField
 {
     public const int TAG = 60;
 
@@ -1300,7 +1300,7 @@ public sealed class Urgency : CharField
 /// <summary>
 /// ValidUntilTime Field
 /// </summary>
-public sealed class ValidUntilTime : DateTimeField
+public sealed class ValidUntilTime : UtcDateTimeField
 {
     public const int TAG = 62;
 
@@ -2267,7 +2267,7 @@ public sealed class ForexReq : BooleanField
 /// <summary>
 /// OrigSendingTime Field
 /// </summary>
-public sealed class OrigSendingTime : DateTimeField
+public sealed class OrigSendingTime : UtcDateTimeField
 {
     public const int TAG = 122;
 
@@ -2334,7 +2334,7 @@ public sealed class CxlType : CharField
 /// <summary>
 /// ExpireTime Field
 /// </summary>
-public sealed class ExpireTime : DateTimeField
+public sealed class ExpireTime : UtcDateTimeField
 {
     public const int TAG = 126;
 
@@ -3133,7 +3133,7 @@ public sealed class SecurityType : StringField
 /// <summary>
 /// EffectiveTime Field
 /// </summary>
-public sealed class EffectiveTime : DateTimeField
+public sealed class EffectiveTime : UtcDateTimeField
 {
     public const int TAG = 168;
 
@@ -5392,7 +5392,7 @@ public sealed class TradSesStatus : IntField
 /// <summary>
 /// TradSesStartTime Field
 /// </summary>
-public sealed class TradSesStartTime : DateTimeField
+public sealed class TradSesStartTime : UtcDateTimeField
 {
     public const int TAG = 341;
 
@@ -5410,7 +5410,7 @@ public sealed class TradSesStartTime : DateTimeField
 /// <summary>
 /// TradSesOpenTime Field
 /// </summary>
-public sealed class TradSesOpenTime : DateTimeField
+public sealed class TradSesOpenTime : UtcDateTimeField
 {
     public const int TAG = 342;
 
@@ -5428,7 +5428,7 @@ public sealed class TradSesOpenTime : DateTimeField
 /// <summary>
 /// TradSesPreCloseTime Field
 /// </summary>
-public sealed class TradSesPreCloseTime : DateTimeField
+public sealed class TradSesPreCloseTime : UtcDateTimeField
 {
     public const int TAG = 343;
 
@@ -5446,7 +5446,7 @@ public sealed class TradSesPreCloseTime : DateTimeField
 /// <summary>
 /// TradSesCloseTime Field
 /// </summary>
-public sealed class TradSesCloseTime : DateTimeField
+public sealed class TradSesCloseTime : UtcDateTimeField
 {
     public const int TAG = 344;
 
@@ -5464,7 +5464,7 @@ public sealed class TradSesCloseTime : DateTimeField
 /// <summary>
 /// TradSesEndTime Field
 /// </summary>
-public sealed class TradSesEndTime : DateTimeField
+public sealed class TradSesEndTime : UtcDateTimeField
 {
     public const int TAG = 345;
 
@@ -5761,7 +5761,7 @@ public sealed class AllocPrice : DecimalField
 /// <summary>
 /// QuoteSetValidUntilTime Field
 /// </summary>
-public sealed class QuoteSetValidUntilTime : DateTimeField
+public sealed class QuoteSetValidUntilTime : UtcDateTimeField
 {
     public const int TAG = 367;
 
@@ -5821,7 +5821,7 @@ public sealed class LastMsgSeqNumProcessed : SeqNumFieldType
 /// <summary>
 /// OnBehalfOfSendingTime Field
 /// </summary>
-public sealed class OnBehalfOfSendingTime : DateTimeField
+public sealed class OnBehalfOfSendingTime : UtcDateTimeField
 {
     public const int TAG = 370;
 
@@ -6918,7 +6918,7 @@ public sealed class ContraTradeQty : DecimalField
 /// <summary>
 /// ContraTradeTime Field
 /// </summary>
-public sealed class ContraTradeTime : DateTimeField
+public sealed class ContraTradeTime : UtcDateTimeField
 {
     public const int TAG = 438;
 
@@ -6994,7 +6994,7 @@ public sealed class MultiLegReportingType : CharField
 /// <summary>
 /// StrikeTime Field
 /// </summary>
-public sealed class StrikeTime : DateTimeField
+public sealed class StrikeTime : UtcDateTimeField
 {
     public const int TAG = 443;
 
@@ -8562,7 +8562,7 @@ public sealed class MailingInst : StringField
 /// <summary>
 /// TransBkdTime Field
 /// </summary>
-public sealed class TransBkdTime : DateTimeField
+public sealed class TransBkdTime : UtcDateTimeField
 {
     public const int TAG = 483;
 
@@ -9096,7 +9096,7 @@ public sealed class RegistTransType : CharField
 /// <summary>
 /// ExecValuationPoint Field
 /// </summary>
-public sealed class ExecValuationPoint : DateTimeField
+public sealed class ExecValuationPoint : UtcDateTimeField
 {
     public const int TAG = 515;
 
@@ -10327,7 +10327,7 @@ public sealed class MassStatusReqType : IntField
 /// <summary>
 /// OrigOrdModTime Field
 /// </summary>
-public sealed class OrigOrdModTime : DateTimeField
+public sealed class OrigOrdModTime : UtcDateTimeField
 {
     public const int TAG = 586;
 
@@ -10935,7 +10935,7 @@ public sealed class HopCompID : StringField
 /// <summary>
 /// HopSendingTime Field
 /// </summary>
-public sealed class HopSendingTime : DateTimeField
+public sealed class HopSendingTime : UtcDateTimeField
 {
     public const int TAG = 629;
 
@@ -13259,7 +13259,7 @@ public sealed class NoTrdRegTimestamps : IntField
 /// <summary>
 /// TrdRegTimestamp Field
 /// </summary>
-public sealed class TrdRegTimestamp : DateTimeField
+public sealed class TrdRegTimestamp : UtcDateTimeField
 {
     public const int TAG = 769;
 
@@ -13418,7 +13418,7 @@ public sealed class NoSettlInst : IntField
 /// <summary>
 /// LastUpdateTime Field
 /// </summary>
-public sealed class LastUpdateTime : DateTimeField
+public sealed class LastUpdateTime : UtcDateTimeField
 {
     public const int TAG = 779;
 
@@ -16407,7 +16407,7 @@ public sealed class HostCrossID : StringField
 /// <summary>
 /// SideTimeInForce Field
 /// </summary>
-public sealed class SideTimeInForce : DateTimeField
+public sealed class SideTimeInForce : UtcDateTimeField
 {
     public const int TAG = 962;
 
@@ -17094,7 +17094,7 @@ public sealed class MessageEventSource : StringField
 /// <summary>
 /// SideTrdRegTimestamp Field
 /// </summary>
-public sealed class SideTrdRegTimestamp : DateTimeField
+public sealed class SideTrdRegTimestamp : UtcDateTimeField
 {
     public const int TAG = 1012;
 
@@ -19055,7 +19055,7 @@ public sealed class ImpliedMarketIndicator : IntField
 /// <summary>
 /// EventTime Field
 /// </summary>
-public sealed class EventTime : DateTimeField
+public sealed class EventTime : UtcDateTimeField
 {
     public const int TAG = 1145;
 
@@ -20989,7 +20989,7 @@ public sealed class DerivativeEventDate : StringField
 /// <summary>
 /// DerivativeEventTime Field
 /// </summary>
-public sealed class DerivativeEventTime : DateTimeField
+public sealed class DerivativeEventTime : UtcDateTimeField
 {
     public const int TAG = 1289;
 
@@ -24064,7 +24064,7 @@ public sealed class NoComplexEventDates : IntField
 /// <summary>
 /// ComplexEventStartDate Field
 /// </summary>
-public sealed class ComplexEventStartDate : DateTimeField
+public sealed class ComplexEventStartDate : UtcDateTimeField
 {
     public const int TAG = 1492;
 
@@ -24082,7 +24082,7 @@ public sealed class ComplexEventStartDate : DateTimeField
 /// <summary>
 /// ComplexEventEndDate Field
 /// </summary>
-public sealed class ComplexEventEndDate : DateTimeField
+public sealed class ComplexEventEndDate : UtcDateTimeField
 {
     public const int TAG = 1493;
 
@@ -24249,7 +24249,7 @@ public sealed class StreamAsgnAckType : IntField
 /// <summary>
 /// RelSymTransactTime Field
 /// </summary>
-public sealed class RelSymTransactTime : DateTimeField
+public sealed class RelSymTransactTime : UtcDateTimeField
 {
     public const int TAG = 1504;
 

--- a/QuickFIXn/Fields/UtcDateTimeField.cs
+++ b/QuickFIXn/Fields/UtcDateTimeField.cs
@@ -1,0 +1,43 @@
+using System;
+
+namespace QuickFix.Fields;
+
+/// <summary>
+/// Base class for UTCTIMESTAMP fields (e.g. SendingTime, TransactTime). Per the FIX spec, UTCTIMESTAMP
+/// values are always UTC; this class normalizes <see cref="Value"/> to <see cref="DateTimeKind.Utc"/>
+/// on every assignment instead of leaving it <see cref="DateTimeKind.Unspecified"/>.
+/// </summary>
+/// <remarks>
+/// <see cref="Value"/> is hidden (not overridden) for performance, so normalization only applies when
+/// accessed through a variable/parameter statically typed as <see cref="UtcDateTimeField"/> or a
+/// subclass; code that upcasts to <see cref="DateTimeField"/> before assigning bypasses it.
+/// </remarks>
+public class UtcDateTimeField : DateTimeField
+{
+    public UtcDateTimeField(int tag)
+        : base(tag, DateTime.SpecifyKind(new DateTime(), DateTimeKind.Utc)) {}
+
+    public UtcDateTimeField(int tag, DateTime dt)
+        : base(tag, ToUtc(dt)) {}
+
+    [Obsolete("Use the ctor that takes TimePrecision instead.  This ctor will be removed in 1.15.")]
+    public UtcDateTimeField(int tag, DateTime dt, bool showMilliseconds)
+        : base(tag, ToUtc(dt), showMilliseconds) {}
+
+    public UtcDateTimeField(int tag, DateTime dt, TimePrecision timeFormatPrecision)
+        : base(tag, ToUtc(dt), timeFormatPrecision) {}
+
+    public new DateTime Value
+    {
+        get => base.Value;
+        set => base.Value = ToUtc(value);
+    }
+
+    private static DateTime ToUtc(DateTime dt) => dt.Kind switch
+    {
+        DateTimeKind.Utc => dt,
+        DateTimeKind.Local => dt.ToUniversalTime(),
+        DateTimeKind.Unspecified => DateTime.SpecifyKind(dt, DateTimeKind.Utc), // Unspecified: FIX spec guarantees UTCTIMESTAMP is already UTC
+        _ => throw new ArgumentOutOfRangeException(nameof(dt), "Invalid DateTimeKind")
+    };
+}

--- a/QuickFIXn/Fields/UtcDateTimeField.cs
+++ b/QuickFIXn/Fields/UtcDateTimeField.cs
@@ -11,7 +11,7 @@ namespace QuickFix.Fields;
 /// Note that <see cref="QuickFix.FieldMap.GetDateTime(int)"/> still returns
 /// <see cref="DateTimeKind.Unspecified"/> for a wire-parsed value, because a bare tag lookup has no
 /// DataDictionary context to know the field is a UTCTIMESTAMP. Use the typed <c>GetField</c> overloads
-/// to obtain a normalized value.
+/// or <see cref="QuickFix.FieldMap.GetUtcDateTime(int)"/> to obtain a normalized value.
 /// </remarks>
 public class UtcDateTimeField : DateTimeField
 {

--- a/QuickFIXn/Fields/UtcDateTimeField.cs
+++ b/QuickFIXn/Fields/UtcDateTimeField.cs
@@ -16,12 +16,12 @@ namespace QuickFix.Fields;
 public class UtcDateTimeField : DateTimeField
 {
     public UtcDateTimeField(int tag)
-        : base(tag, DateTime.SpecifyKind(new DateTime(), DateTimeKind.Utc)) {}
+        : base(tag, DateTime.SpecifyKind(default, DateTimeKind.Utc)) {}
 
     public UtcDateTimeField(int tag, DateTime dt)
         : base(tag, ToUtc(dt)) {}
 
-    [Obsolete("Use the ctor that takes TimePrecision instead.  This ctor will be removed in 1.15.")]
+    // Not [Obsolete] here, matching DateTimeField; the deprecation is applied to the generated field classes.
     public UtcDateTimeField(int tag, DateTime dt, bool showMilliseconds)
         : base(tag, ToUtc(dt), showMilliseconds) {}
 
@@ -44,7 +44,9 @@ public class UtcDateTimeField : DateTimeField
     {
         DateTimeKind.Utc => dt,
         DateTimeKind.Local => dt.ToUniversalTime(),
-        DateTimeKind.Unspecified => DateTime.SpecifyKind(dt, DateTimeKind.Utc), // Unspecified: FIX spec guarantees UTCTIMESTAMP is already UTC
-        _ => throw new ArgumentOutOfRangeException(nameof(dt), "Invalid DateTimeKind")
+        // Unspecified: per FIX spec a UTCTIMESTAMP is already UTC, so relabel without shifting.
+        // Used as the discard arm because DateTime.Kind cannot return an undeclared value
+        // (see UtcDateTimeFieldTests.DateTimeKindHasNoUnhandledMembers).
+        _ => DateTime.SpecifyKind(dt, DateTimeKind.Utc)
     };
 }

--- a/QuickFIXn/Fields/UtcDateTimeField.cs
+++ b/QuickFIXn/Fields/UtcDateTimeField.cs
@@ -8,9 +8,10 @@ namespace QuickFix.Fields;
 /// on every assignment instead of leaving it <see cref="DateTimeKind.Unspecified"/>.
 /// </summary>
 /// <remarks>
-/// <see cref="Value"/> is hidden (not overridden) for performance, so normalization only applies when
-/// accessed through a variable/parameter statically typed as <see cref="UtcDateTimeField"/> or a
-/// subclass; code that upcasts to <see cref="DateTimeField"/> before assigning bypasses it.
+/// Note that <see cref="QuickFix.FieldMap.GetDateTime(int)"/> still returns
+/// <see cref="DateTimeKind.Unspecified"/> for a wire-parsed value, because a bare tag lookup has no
+/// DataDictionary context to know the field is a UTCTIMESTAMP. Use the typed <c>GetField</c> overloads
+/// to obtain a normalized value.
 /// </remarks>
 public class UtcDateTimeField : DateTimeField
 {
@@ -27,7 +28,13 @@ public class UtcDateTimeField : DateTimeField
     public UtcDateTimeField(int tag, DateTime dt, TimePrecision timeFormatPrecision)
         : base(tag, ToUtc(dt), timeFormatPrecision) {}
 
-    public new DateTime Value
+    // Deliberately an override, not `new`-hiding, even though FieldBase<T>.Value is on a hot path.
+    // Hiding binds normalization at compile time, so assigning through a DateTimeField-typed reference
+    // would silently emit un-normalized (e.g. local) time into a UTCTIMESTAMP field -- a wire-correctness
+    // bug. The virtual cost is negligible: the generated field classes (SendingTime, TransactTime, ...)
+    // are sealed so the JIT devirtualizes access through them, and any remaining call sits next to
+    // DateTime formatting/parsing that costs orders of magnitude more.
+    public override DateTime Value
     {
         get => base.Value;
         set => base.Value = ToUtc(value);

--- a/QuickFIXn/Message/FieldMap.cs
+++ b/QuickFIXn/Message/FieldMap.cs
@@ -202,6 +202,19 @@ public class FieldMap : IEnumerable<KeyValuePair<int, IField>> {
     }
 
     /// <summary>
+    /// Gets a UTCTIMESTAMP datetime field; saves its value into the parameter object, which is also the return value.
+    /// </summary>
+    /// <param name="field">this field's tag is used to extract the value from the message; that value is saved back into this object</param>
+    /// <exception cref="FieldNotFoundException">thrown if <paramref name="field"/> isn't found</exception>
+    /// <exception cref="FieldConvertError">thrown if string value in the message cannot be converted to this type</exception>
+    /// <returns><paramref name="field"/></returns>
+    public UtcDateTimeField GetField(UtcDateTimeField field)
+    {
+        field.Value = GetDateTime(field.Tag);
+        return field;
+    }
+
+    /// <summary>
     /// Gets a DateOnly field; saves its value into the parameter object, which is also the return value.
     /// </summary>
     /// <param name="field">this field's tag is used to extract the value from the message; that value is saved back into this object</param>

--- a/QuickFIXn/Message/FieldMap.cs
+++ b/QuickFIXn/Message/FieldMap.cs
@@ -189,6 +189,19 @@ public class FieldMap : IEnumerable<KeyValuePair<int, IField>> {
     }
 
     /// <summary>
+    /// Gets a UTC datetime field; saves its value into the parameter object, which is also the return value.
+    /// </summary>
+    /// <param name="field">this field's tag is used to extract the value from the message; that value is saved back into this object</param>
+    /// <exception cref="FieldNotFoundException">thrown if <paramref name="field"/> isn't found</exception>
+    /// <exception cref="FieldConvertError">thrown if string value in the message cannot be converted to this type</exception>
+    /// <returns><paramref name="field"/></returns>
+    public UtcDateTimeField GetField(UtcDateTimeField field)
+    {
+        field.Value = GetUtcDateTime(field.Tag);
+        return field;
+    }
+
+    /// <summary>
     /// Gets a datetime field; saves its value into the parameter object, which is also the return value.
     /// </summary>
     /// <param name="field">this field's tag is used to extract the value from the message; that value is saved back into this object</param>
@@ -379,6 +392,35 @@ public class FieldMap : IEnumerable<KeyValuePair<int, IField>> {
             _ => DateTimeConverter.ParseToDateTime(fld.ToString())
         };
     }
+
+    /// <summary>
+    /// Gets the value of a field as a UTC DateTime, normalizing a wire-decoded UTCTIMESTAMP value to UTC.
+    /// </summary>
+    /// <param name="tag">the FIX tag</param>
+    /// <returns>the DateTime value with <see cref="DateTimeKind.Utc"/></returns>
+    /// <exception cref="FieldNotFoundException" />
+    /// <exception cref="FieldConvertError" />
+    public DateTime GetUtcDateTime(int tag)
+    {
+        if (!_fields.TryGetValue(tag, out IField? fld))
+            throw new FieldNotFoundException(tag);
+
+        return fld switch
+        {
+            DateOnlyField dateOnlyField => NormalizeUtc(dateOnlyField.Value.ToDateTime(new TimeOnly())),
+            TimeOnlyField timeOnlyField => NormalizeUtc(new DateTime(1980, 01, 01).Add(timeOnlyField.Value.ToTimeSpan())),
+            UtcDateTimeField utcDateTimeField => utcDateTimeField.Value,
+            FieldBase<DateTime> dateTimeField => NormalizeUtc(dateTimeField.Value),
+            _ => NormalizeUtc(DateTimeConverter.ParseToDateTime(fld.ToString()))
+        };
+    }
+
+    private static DateTime NormalizeUtc(DateTime dt) => dt.Kind switch
+    {
+        DateTimeKind.Utc => dt,
+        DateTimeKind.Local => dt.ToUniversalTime(),
+        _ => DateTime.SpecifyKind(dt, DateTimeKind.Utc)
+    };
 
     /// <summary>
     /// Gets the value of a field as a DateOnly

--- a/QuickFIXn/Message/FieldMap.cs
+++ b/QuickFIXn/Message/FieldMap.cs
@@ -396,31 +396,15 @@ public class FieldMap : IEnumerable<KeyValuePair<int, IField>> {
     /// <summary>
     /// Gets the value of a field as a UTC DateTime, normalizing a wire-decoded UTCTIMESTAMP value to UTC.
     /// </summary>
+    /// <remarks>
+    /// A <see cref="DateOnlyField"/>/<see cref="TimeOnlyField"/> is labelled UTC too, for consistency with
+    /// <see cref="GetDateTime"/>, even though e.g. LOCALMKTDATE is not actually a UTC value.
+    /// </remarks>
     /// <param name="tag">the FIX tag</param>
     /// <returns>the DateTime value with <see cref="DateTimeKind.Utc"/></returns>
     /// <exception cref="FieldNotFoundException" />
     /// <exception cref="FieldConvertError" />
-    public DateTime GetUtcDateTime(int tag)
-    {
-        if (!_fields.TryGetValue(tag, out IField? fld))
-            throw new FieldNotFoundException(tag);
-
-        return fld switch
-        {
-            DateOnlyField dateOnlyField => NormalizeUtc(dateOnlyField.Value.ToDateTime(new TimeOnly())),
-            TimeOnlyField timeOnlyField => NormalizeUtc(new DateTime(1980, 01, 01).Add(timeOnlyField.Value.ToTimeSpan())),
-            UtcDateTimeField utcDateTimeField => utcDateTimeField.Value,
-            FieldBase<DateTime> dateTimeField => NormalizeUtc(dateTimeField.Value),
-            _ => NormalizeUtc(DateTimeConverter.ParseToDateTime(fld.ToString()))
-        };
-    }
-
-    private static DateTime NormalizeUtc(DateTime dt) => dt.Kind switch
-    {
-        DateTimeKind.Utc => dt,
-        DateTimeKind.Local => dt.ToUniversalTime(),
-        _ => DateTime.SpecifyKind(dt, DateTimeKind.Utc)
-    };
+    public DateTime GetUtcDateTime(int tag) => NormalizeUtc(GetDateTime(tag));
 
     /// <summary>
     /// Gets the value of a field as a DateOnly
@@ -736,6 +720,14 @@ public class FieldMap : IEnumerable<KeyValuePair<int, IField>> {
             }
         }
     }
+
+    private static DateTime NormalizeUtc(DateTime dt) => dt.Kind switch
+    {
+        DateTimeKind.Utc => dt,
+        DateTimeKind.Local => dt.ToUniversalTime(),
+        // Unspecified: per FIX spec a UTCTIMESTAMP is already UTC, so relabel without shifting.
+        _ => DateTime.SpecifyKind(dt, DateTimeKind.Utc)
+    };
 
     // IEnumerable<KeyValuePair<int,IField>> Member
     public IEnumerator<KeyValuePair<int, IField>> GetEnumerator()

--- a/QuickFIXn/Message/FieldMap.cs
+++ b/QuickFIXn/Message/FieldMap.cs
@@ -202,19 +202,6 @@ public class FieldMap : IEnumerable<KeyValuePair<int, IField>> {
     }
 
     /// <summary>
-    /// Gets a UTCTIMESTAMP datetime field; saves its value into the parameter object, which is also the return value.
-    /// </summary>
-    /// <param name="field">this field's tag is used to extract the value from the message; that value is saved back into this object</param>
-    /// <exception cref="FieldNotFoundException">thrown if <paramref name="field"/> isn't found</exception>
-    /// <exception cref="FieldConvertError">thrown if string value in the message cannot be converted to this type</exception>
-    /// <returns><paramref name="field"/></returns>
-    public UtcDateTimeField GetField(UtcDateTimeField field)
-    {
-        field.Value = GetDateTime(field.Tag);
-        return field;
-    }
-
-    /// <summary>
     /// Gets a DateOnly field; saves its value into the parameter object, which is also the return value.
     /// </summary>
     /// <param name="field">this field's tag is used to extract the value from the message; that value is saved back into this object</param>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,19 +10,6 @@ What's New
 
 **IMPORTANT NOTICES:**  
 
-* **1.15 introduces a new `UtcDateTimeField` base class for UTCTIMESTAMP fields.**
-    * Fields whose FIX type is UTCTIMESTAMP (`SendingTime`, `TransactTime`, `ExpireTime`, etc.) now derive
-      from `UtcDateTimeField` instead of `DateTimeField`. Their `Value` is always returned with
-      `DateTime.Kind == Utc`, per the FIX spec, instead of `Unspecified`.
-    * **This can change the bytes on the wire.** If you construct such a field from a `DateTime` whose
-      `Kind` is `Local` (e.g. `new TransactTime(DateTime.Now)`), the value is now converted to UTC before
-      being written. Previously the local wall-clock time was written as-is. Applications that were
-      compensating for the old behavior will shift by their local UTC offset. `Unspecified` values are
-      relabeled only, never shifted.
-    * `TZTIMESTAMP` fields (`TZTransactTime`) are unaffected and remain on `DateTimeField`.
-    * `FieldMap.GetDateTime(int tag)` is unchanged and still returns `Unspecified` for a wire-parsed
-      value; a bare tag lookup has no DataDictionary context to know the field is a UTCTIMESTAMP.
-    * This is a binary-breaking (but source-compatible) change for pre-compiled consumers.
 * **1.15 introduces breaking changes to `TimeOnlyField`/`DateOnlyField` classes and derived FIX fields.**
     * These field types are now backed by C# `TimeOnly`/`DateOnly` instances instead of `DateTime`.
       Some ctors/functions were deprecated as per usual procedure, but certain ctors/functions have
@@ -65,7 +52,6 @@ What's New
 * #1021 - remove .NET 8 support; remove expired deprecations (gbirchmeier)
 * #1015 - rework DateOnlyField/TimeOnlyField to be backed by DateOnly/TimeOnly types instead of DateTime (gbirchmeier)
 * #1023 - new config setting "FieldSeparatorInMessageLogs" (gbirchmeier)
-* #1030 - new UtcDateTimeField base class so UTCTIMESTAMP fields always have DateTimeKind.Utc (stic)
 
 
 ### v1.14.1

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -65,7 +65,7 @@ What's New
 * #1021 - remove .NET 8 support; remove expired deprecations (gbirchmeier)
 * #1015 - rework DateOnlyField/TimeOnlyField to be backed by DateOnly/TimeOnly types instead of DateTime (gbirchmeier)
 * #1023 - new config setting "FieldSeparatorInMessageLogs" (gbirchmeier)
-* new UtcDateTimeField base class so UTCTIMESTAMP fields always have DateTimeKind.Utc (stic)
+* #1030 - new UtcDateTimeField base class so UTCTIMESTAMP fields always have DateTimeKind.Utc (stic)
 
 
 ### v1.14.1

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,19 @@ What's New
 
 **IMPORTANT NOTICES:**  
 
+* **1.15 introduces a new `UtcDateTimeField` base class for UTCTIMESTAMP fields.**
+    * Fields whose FIX type is UTCTIMESTAMP (`SendingTime`, `TransactTime`, `ExpireTime`, etc.) now derive
+      from `UtcDateTimeField` instead of `DateTimeField`. Their `Value` is always returned with
+      `DateTime.Kind == Utc`, per the FIX spec, instead of `Unspecified`.
+    * **This can change the bytes on the wire.** If you construct such a field from a `DateTime` whose
+      `Kind` is `Local` (e.g. `new TransactTime(DateTime.Now)`), the value is now converted to UTC before
+      being written. Previously the local wall-clock time was written as-is. Applications that were
+      compensating for the old behavior will shift by their local UTC offset. `Unspecified` values are
+      relabeled only, never shifted.
+    * `TZTIMESTAMP` fields (`TZTransactTime`) are unaffected and remain on `DateTimeField`.
+    * `FieldMap.GetDateTime(int tag)` is unchanged and still returns `Unspecified` for a wire-parsed
+      value; a bare tag lookup has no DataDictionary context to know the field is a UTCTIMESTAMP.
+    * This is a binary-breaking (but source-compatible) change for pre-compiled consumers.
 * **1.15 introduces breaking changes to `TimeOnlyField`/`DateOnlyField` classes and derived FIX fields.**
     * These field types are now backed by C# `TimeOnly`/`DateOnly` instances instead of `DateTime`.
       Some ctors/functions were deprecated as per usual procedure, but certain ctors/functions have
@@ -52,6 +65,7 @@ What's New
 * #1021 - remove .NET 8 support; remove expired deprecations (gbirchmeier)
 * #1015 - rework DateOnlyField/TimeOnlyField to be backed by DateOnly/TimeOnly types instead of DateTime (gbirchmeier)
 * #1023 - new config setting "FieldSeparatorInMessageLogs" (gbirchmeier)
+* new UtcDateTimeField base class so UTCTIMESTAMP fields always have DateTimeKind.Utc (stic)
 
 
 ### v1.14.1

--- a/UnitTests/DDFieldTests.cs
+++ b/UnitTests/DDFieldTests.cs
@@ -43,4 +43,32 @@ public class DDFieldTests
         Assert.That(ddf.IsMultipleValueFieldWithEnums, Is.True);
         Assert.That(ddf.HasEnums(), Is.False);
     }
+
+    [Test]
+    public void UtcTimestampResolvesToUtcDateTimeField()
+    {
+        DDField ddf = new(52, "SendingTime", new Dictionary<string, string>(), "UTCTIMESTAMP");
+        Assert.That(typeof(QuickFix.Fields.UtcDateTimeField), Is.EqualTo(ddf.FieldType));
+    }
+
+    [Test]
+    public void TzTimestampResolvesToStringField()
+    {
+        DDField ddf = new(1132, "TZTransactTime", new Dictionary<string, string>(), "TZTIMESTAMP");
+        Assert.That(typeof(QuickFix.Fields.StringField), Is.EqualTo(ddf.FieldType));
+    }
+
+    [Test]
+    public void CheckValidFormatStillValidatesUtcTimestampFields()
+    {
+        // regression test: CheckValidFormat's type check must recognize UtcDateTimeField, not just DateTimeField
+        var dd = new QuickFix.DataDictionary.DataDictionary();
+        dd.FieldsByTag[52] = new DDField(52, "SendingTime", new Dictionary<string, string>(), "UTCTIMESTAMP");
+
+        Assert.DoesNotThrow(() =>
+            dd.CheckValidFormat(new QuickFix.Fields.StringField(52, "20091211-12:12:44")));
+        Assert.Throws<QuickFix.IncorrectDataFormat>(() =>
+            dd.CheckValidFormat(new QuickFix.Fields.StringField(52, "not-a-timestamp")));
+    }
 }
+

--- a/UnitTests/FieldMapTests.cs
+++ b/UnitTests/FieldMapTests.cs
@@ -210,16 +210,16 @@ public class FieldMapTests
     [Test]
     public void GetUtcDateTimeTest()
     {
+        // Is.EqualTo ignores DateTime.Kind, so assert the instant with == and the Kind separately
         FieldMap fm = new();
 
-        var dt = new DateTime(2025, 10, 31, 17, 30, 59, DateTimeKind.Utc);
+        DateTime dt = new(2025, 10, 31, 17, 30, 59, DateTimeKind.Utc);
         fm.SetField(new UtcDateTimeField(Tags.SendingTime, dt));
-        Assert.That(fm.GetUtcDateTime(Tags.SendingTime), Is.EqualTo(dt));
+        Assert.That(fm.GetUtcDateTime(Tags.SendingTime) == dt, Is.True);
         Assert.That(fm.GetUtcDateTime(Tags.SendingTime).Kind, Is.EqualTo(DateTimeKind.Utc));
 
         fm.SetField(new StringField(Tags.SendingTime, "20251031-17:30:59"));
-        var expected = DateTime.SpecifyKind(new DateTime(2025, 10, 31, 17, 30, 59), DateTimeKind.Utc);
-        Assert.That(fm.GetUtcDateTime(Tags.SendingTime), Is.EqualTo(expected));
+        Assert.That(fm.GetUtcDateTime(Tags.SendingTime) == dt, Is.True);
         Assert.That(fm.GetUtcDateTime(Tags.SendingTime).Kind, Is.EqualTo(DateTimeKind.Utc));
 
         fm.SetField(new StringField(Tags.SendingTime, "oops"));
@@ -227,6 +227,50 @@ public class FieldMapTests
 
         Assert.Throws(typeof(FieldNotFoundException),
                 delegate { fm.GetUtcDateTime(99900); });
+    }
+
+    [Test]
+    public void GetUtcDateTimeConvertsLocalKindTest()
+    {
+        FieldMap fm = new();
+        DateTime local = DateTime.SpecifyKind(new DateTime(2025, 10, 31, 17, 30, 59), DateTimeKind.Local);
+        TimeSpan offset = TimeZoneInfo.Local.GetUtcOffset(local);
+        fm.SetField(new DateTimeField(Tags.TransactTime, local));
+
+        DateTime actual = fm.GetUtcDateTime(Tags.TransactTime);
+
+        Assert.That(actual.Kind, Is.EqualTo(DateTimeKind.Utc));
+        Assert.That(actual == DateTime.SpecifyKind(local - offset, DateTimeKind.Utc), Is.True);
+        if (offset != TimeSpan.Zero) // CI runs UTC, where a converted value is indistinguishable from a relabelled one
+            Assert.That(actual == DateTime.SpecifyKind(local, DateTimeKind.Utc), Is.False);
+    }
+
+    [Test]
+    public void GetUtcDateTimeWithWireOffsetTest()
+    {
+        FieldMap fm = new();
+        fm.SetField(new StringField(Tags.TransactTime, "20091211-12:12:44+02:00"));
+
+        DateTime actual = fm.GetUtcDateTime(Tags.TransactTime);
+
+        Assert.That(actual.Kind, Is.EqualTo(DateTimeKind.Utc));
+        Assert.That(actual == new DateTime(2009, 12, 11, 10, 12, 44, DateTimeKind.Utc), Is.True);
+    }
+
+    [Test]
+    public void GetUtcDateTimeFromDateOnlyAndTimeOnlyTest()
+    {
+        FieldMap fm = new();
+
+        fm.SetField(new DateOnlyField(Tags.MDEntryDate, new DateOnly(2009, 12, 10)));
+        DateTime fromDate = fm.GetUtcDateTime(Tags.MDEntryDate);
+        Assert.That(fromDate.Kind, Is.EqualTo(DateTimeKind.Utc));
+        Assert.That(fromDate == new DateTime(2009, 12, 10, 0, 0, 0, DateTimeKind.Utc), Is.True);
+
+        fm.SetField(new TimeOnlyField(Tags.MDEntryTime, new TimeOnly(1, 2, 3)));
+        DateTime fromTime = fm.GetUtcDateTime(Tags.MDEntryTime);
+        Assert.That(fromTime.Kind, Is.EqualTo(DateTimeKind.Utc));
+        Assert.That(fromTime == new DateTime(1980, 1, 1, 1, 2, 3, DateTimeKind.Utc), Is.True);
     }
 
     [Test]

--- a/UnitTests/FieldMapTests.cs
+++ b/UnitTests/FieldMapTests.cs
@@ -109,6 +109,32 @@ public class FieldMapTests
     }
 
     [Test]
+    public void SendingTimeParsedFromWireHasUtcKindTest()
+    {
+        // regression test: UTCTIMESTAMP fields parsed from the wire (no offset) must come back as
+        // DateTimeKind.Utc, not Unspecified
+        FieldMap fm = new();
+        fm.SetField(new StringField(Tags.SendingTime, "20091211-12:12:44"));
+        SendingTime st = new();
+        fm.GetField(st);
+
+        Assert.That(st.Value.Kind, Is.EqualTo(DateTimeKind.Utc));
+        Assert.That(st.Value, Is.EqualTo(new DateTime(2009, 12, 11, 12, 12, 44)));
+    }
+
+    [Test]
+    public void TZTransactTimeRetainsOffsetAwareParsingTest()
+    {
+        // TZTIMESTAMP fields must be unaffected by the UtcDateTimeField change
+        FieldMap fm = new();
+        fm.SetField(new StringField(Tags.TZTransactTime, "20091211-12:12:44+02:00"));
+        TZTransactTime tzt = new();
+        fm.GetField(tzt);
+
+        Assert.That(tzt.Value, Is.EqualTo(new DateTime(2009, 12, 11, 10, 12, 44)));
+    }
+
+    [Test]
     public void DateOnlyFieldTest()
     {
         FieldMap fm = new();

--- a/UnitTests/FieldMapTests.cs
+++ b/UnitTests/FieldMapTests.cs
@@ -208,6 +208,28 @@ public class FieldMapTests
     }
 
     [Test]
+    public void GetUtcDateTimeTest()
+    {
+        FieldMap fm = new();
+
+        var dt = new DateTime(2025, 10, 31, 17, 30, 59, DateTimeKind.Utc);
+        fm.SetField(new UtcDateTimeField(Tags.SendingTime, dt));
+        Assert.That(fm.GetUtcDateTime(Tags.SendingTime), Is.EqualTo(dt));
+        Assert.That(fm.GetUtcDateTime(Tags.SendingTime).Kind, Is.EqualTo(DateTimeKind.Utc));
+
+        fm.SetField(new StringField(Tags.SendingTime, "20251031-17:30:59"));
+        var expected = DateTime.SpecifyKind(new DateTime(2025, 10, 31, 17, 30, 59), DateTimeKind.Utc);
+        Assert.That(fm.GetUtcDateTime(Tags.SendingTime), Is.EqualTo(expected));
+        Assert.That(fm.GetUtcDateTime(Tags.SendingTime).Kind, Is.EqualTo(DateTimeKind.Utc));
+
+        fm.SetField(new StringField(Tags.SendingTime, "oops"));
+        Assert.Throws<FieldConvertError>(delegate { fm.GetUtcDateTime(Tags.SendingTime); });
+
+        Assert.Throws(typeof(FieldNotFoundException),
+                delegate { fm.GetUtcDateTime(99900); });
+    }
+
+    [Test]
     public void GetDateOnlyTest()
     {
         FieldMap fm = new();

--- a/UnitTests/FieldMapTests.cs
+++ b/UnitTests/FieldMapTests.cs
@@ -123,6 +123,17 @@ public class FieldMapTests
     }
 
     [Test]
+    public void SendingTimeParsedFromWireHasUtcKindViaBaseTypedReferenceTest()
+    {
+        FieldMap fm = new();
+        fm.SetField(new StringField(Tags.SendingTime, "20091211-12:12:44"));
+        DateTimeField st = new SendingTime();
+        fm.GetField(st);
+
+        Assert.That(st.Value.Kind, Is.EqualTo(DateTimeKind.Utc));
+    }
+
+    [Test]
     public void TZTransactTimeRetainsOffsetAwareParsingTest()
     {
         // TZTIMESTAMP fields must be unaffected by the UtcDateTimeField change

--- a/UnitTests/FieldMapTests.cs
+++ b/UnitTests/FieldMapTests.cs
@@ -119,7 +119,7 @@ public class FieldMapTests
         fm.GetField(st);
 
         Assert.That(st.Value.Kind, Is.EqualTo(DateTimeKind.Utc));
-        Assert.That(st.Value, Is.EqualTo(new DateTime(2009, 12, 11, 12, 12, 44)));
+        Assert.That(st.Value == new DateTime(2009, 12, 11, 12, 12, 44, DateTimeKind.Utc), Is.True);
     }
 
     [Test]

--- a/UnitTests/Fields/UtcDateTimeFieldTests.cs
+++ b/UnitTests/Fields/UtcDateTimeFieldTests.cs
@@ -1,0 +1,85 @@
+using System;
+using NUnit.Framework;
+using QuickFix.Fields;
+
+namespace UnitTests.Fields;
+
+[TestFixture]
+public class UtcDateTimeFieldTests
+{
+    [Test]
+    public void DefaultCtorTest()
+    {
+        UtcDateTimeField f = new(Tags.SendingTime);
+        Assert.That(f.Value.Kind, Is.EqualTo(DateTimeKind.Utc));
+    }
+
+    [Test]
+    public void CtorWithUnspecifiedKindTest()
+    {
+        DateTime dt = new(2025, 10, 31, 17, 30, 59);
+        UtcDateTimeField f = new(Tags.SendingTime, dt);
+
+        Assert.That(f.Value.Kind, Is.EqualTo(DateTimeKind.Utc));
+        Assert.That(f.Value, Is.EqualTo(DateTime.SpecifyKind(dt, DateTimeKind.Utc)));
+    }
+
+    [Test]
+    public void CtorWithLocalKindTest()
+    {
+        DateTime dt = DateTime.SpecifyKind(new DateTime(2025, 10, 31, 17, 30, 59), DateTimeKind.Local);
+        UtcDateTimeField f = new(Tags.SendingTime, dt);
+
+        Assert.That(f.Value.Kind, Is.EqualTo(DateTimeKind.Utc));
+        Assert.That(f.Value, Is.EqualTo(dt.ToUniversalTime()));
+    }
+
+    [Test]
+    public void CtorWithUtcKindTest()
+    {
+        DateTime dt = DateTime.SpecifyKind(new DateTime(2025, 10, 31, 17, 30, 59), DateTimeKind.Utc);
+        UtcDateTimeField f = new(Tags.SendingTime, dt);
+
+        Assert.That(f.Value.Kind, Is.EqualTo(DateTimeKind.Utc));
+        Assert.That(f.Value, Is.EqualTo(dt));
+    }
+
+    [Test]
+    public void ValueSetterForcesUtcTest()
+    {
+        UtcDateTimeField f = new(Tags.SendingTime);
+        f.Value = new DateTime(2025, 10, 31, 17, 30, 59);
+
+        Assert.That(f.Value.Kind, Is.EqualTo(DateTimeKind.Utc));
+    }
+
+    [Test]
+    public void ToStringTest()
+    {
+        UtcDateTimeField f = new(Tags.SendingTime, new DateTime(2009, 9, 4, 3, 44, 1));
+        Assert.That(f.ToString(), Is.EqualTo("20090904-03:44:01.000"));
+        Assert.That(f.ToStringField(), Is.EqualTo($"{Tags.SendingTime}=20090904-03:44:01.000"));
+    }
+
+    [Test]
+    public void LegacyCtorThatTakesShowMillisecondsTest()
+    {
+        DateTime dt = new(2025, 10, 31, 17, 30, 59);
+#pragma warning disable CS0618
+        UtcDateTimeField f = new(Tags.SendingTime, dt, false);
+#pragma warning restore CS0618
+
+        Assert.That(f.Value.Kind, Is.EqualTo(DateTimeKind.Utc));
+        Assert.That(f.ToString(), Is.EqualTo("20251031-17:30:59"));
+    }
+
+    [Test]
+    public void CtorWithTimePrecisionTest()
+    {
+        DateTime dt = new(2025, 10, 31, 17, 30, 59);
+        UtcDateTimeField f = new(Tags.SendingTime, dt, TimePrecision.Second);
+
+        Assert.That(f.Value.Kind, Is.EqualTo(DateTimeKind.Utc));
+        Assert.That(f.ToString(), Is.EqualTo("20251031-17:30:59"));
+    }
+}

--- a/UnitTests/Fields/UtcDateTimeFieldTests.cs
+++ b/UnitTests/Fields/UtcDateTimeFieldTests.cs
@@ -34,10 +34,12 @@ public class UtcDateTimeFieldTests
 
         UtcDateTimeField f = new(Tags.SendingTime, local);
 
+        DateTime expectedUtc = DateTime.SpecifyKind(local - offset, DateTimeKind.Utc);
+
         Assert.That(f.Value.Kind, Is.EqualTo(DateTimeKind.Utc));
-        Assert.That(f.Value, Is.EqualTo(local - offset));
+        Assert.That(f.Value == expectedUtc, Is.True);
         if (offset != TimeSpan.Zero) // CI runs UTC, where a converted value is indistinguishable from a relabeled one
-            Assert.That(f.Value, Is.Not.EqualTo(local));
+            Assert.That(f.Value == DateTime.SpecifyKind(local, DateTimeKind.Utc), Is.False);
     }
 
     [Test]
@@ -70,8 +72,10 @@ public class UtcDateTimeFieldTests
 
         f.Value = local;
 
+        DateTime expectedUtc = DateTime.SpecifyKind(local - offset, DateTimeKind.Utc);
+
         Assert.That(f.Value.Kind, Is.EqualTo(DateTimeKind.Utc));
-        Assert.That(f.Value, Is.EqualTo(local - offset));
+        Assert.That(f.Value == expectedUtc, Is.True);
     }
 
     [Test]

--- a/UnitTests/Fields/UtcDateTimeFieldTests.cs
+++ b/UnitTests/Fields/UtcDateTimeFieldTests.cs
@@ -27,11 +27,17 @@ public class UtcDateTimeFieldTests
     [Test]
     public void CtorWithLocalKindTest()
     {
-        DateTime dt = DateTime.SpecifyKind(new DateTime(2025, 10, 31, 17, 30, 59), DateTimeKind.Local);
-        UtcDateTimeField f = new(Tags.SendingTime, dt);
+        DateTime local = DateTime.SpecifyKind(new DateTime(2025, 10, 31, 17, 30, 59), DateTimeKind.Local);
+        // derive the expectation from TimeZoneInfo, not from ToUniversalTime, so this isn't just a
+        // restatement of the implementation
+        TimeSpan offset = TimeZoneInfo.Local.GetUtcOffset(local);
+
+        UtcDateTimeField f = new(Tags.SendingTime, local);
 
         Assert.That(f.Value.Kind, Is.EqualTo(DateTimeKind.Utc));
-        Assert.That(f.Value, Is.EqualTo(dt.ToUniversalTime()));
+        Assert.That(f.Value, Is.EqualTo(local - offset));
+        if (offset != TimeSpan.Zero) // CI runs UTC, where a converted value is indistinguishable from a relabeled one
+            Assert.That(f.Value, Is.Not.EqualTo(local));
     }
 
     [Test]
@@ -51,6 +57,21 @@ public class UtcDateTimeFieldTests
         f.Value = new DateTime(2025, 10, 31, 17, 30, 59);
 
         Assert.That(f.Value.Kind, Is.EqualTo(DateTimeKind.Utc));
+    }
+
+    [Test]
+    public void ValueSetterForcesUtcViaBaseTypedReferenceTest()
+    {
+        // Value must be an override, not `new`-hiding, or a base-typed reference would write local
+        // wall-clock time into a UTCTIMESTAMP field
+        DateTimeField f = new SendingTime();
+        DateTime local = DateTime.SpecifyKind(new DateTime(2025, 10, 31, 17, 30, 59), DateTimeKind.Local);
+        TimeSpan offset = TimeZoneInfo.Local.GetUtcOffset(local);
+
+        f.Value = local;
+
+        Assert.That(f.Value.Kind, Is.EqualTo(DateTimeKind.Utc));
+        Assert.That(f.Value, Is.EqualTo(local - offset));
     }
 
     [Test]

--- a/UnitTests/Fields/UtcDateTimeFieldTests.cs
+++ b/UnitTests/Fields/UtcDateTimeFieldTests.cs
@@ -75,20 +75,27 @@ public class UtcDateTimeFieldTests
     }
 
     [Test]
+    public void DateTimeKindHasNoUnhandledMembers()
+    {
+        // UtcDateTimeField.ToUtc treats anything that isn't Utc/Local as Unspecified; fail loudly if a
+        // future runtime adds a member that assumption would silently swallow
+        Assert.That(Enum.GetValues<DateTimeKind>(), Is.EquivalentTo(new[]
+            { DateTimeKind.Unspecified, DateTimeKind.Utc, DateTimeKind.Local }));
+    }
+
+    [Test]
     public void ToStringTest()
     {
         UtcDateTimeField f = new(Tags.SendingTime, new DateTime(2009, 9, 4, 3, 44, 1));
         Assert.That(f.ToString(), Is.EqualTo("20090904-03:44:01.000"));
-        Assert.That(f.ToStringField(), Is.EqualTo($"{Tags.SendingTime}=20090904-03:44:01.000"));
+        Assert.That(f.ToStringField(), Is.EqualTo("52=20090904-03:44:01.000"));
     }
 
     [Test]
     public void LegacyCtorThatTakesShowMillisecondsTest()
     {
         DateTime dt = new(2025, 10, 31, 17, 30, 59);
-#pragma warning disable CS0618
         UtcDateTimeField f = new(Tags.SendingTime, dt, false);
-#pragma warning restore CS0618
 
         Assert.That(f.Value.Kind, Is.EqualTo(DateTimeKind.Utc));
         Assert.That(f.ToString(), Is.EqualTo("20251031-17:30:59"));

--- a/UnitTests/MessageTests.cs
+++ b/UnitTests/MessageTests.cs
@@ -240,6 +240,20 @@ public class MessageTests
     }
 
     [Test]
+    public void SendingTimeFromParsedMessageHasUtcKindTest()
+    {
+        string msgStr = "8=FIX.4.2|9=55|35=0|34=3|49=TW|52=20000426-12:05:06|56=ISLD|1=acct123|10=123|"
+            .Replace('|', Message.SOH);
+        Message msg = new Message(msgStr);
+
+        SendingTime st = new();
+        msg.Header.GetField(st);
+
+        Assert.That(st.Value.Kind, Is.EqualTo(DateTimeKind.Utc));
+        Assert.That(st.Value, Is.EqualTo(new DateTime(2000, 4, 26, 12, 5, 6)));
+    }
+
+    [Test]
     public void EnumeratorTest()
     {
         string msgStr = "8=FIX.4.2|9=55|35=0|34=3|49=TW|52=20000426-12:05:06|56=ISLD|1=acct123|10=123|"

--- a/UnitTests/MessageTests.cs
+++ b/UnitTests/MessageTests.cs
@@ -250,7 +250,7 @@ public class MessageTests
         msg.Header.GetField(st);
 
         Assert.That(st.Value.Kind, Is.EqualTo(DateTimeKind.Utc));
-        Assert.That(st.Value, Is.EqualTo(new DateTime(2000, 4, 26, 12, 5, 6)));
+        Assert.That(st.Value == new DateTime(2000, 4, 26, 12, 5, 6, DateTimeKind.Utc), Is.True);
     }
 
     [Test]


### PR DESCRIPTION
Fixes #1030

### The issue

```csharp
var msg = new Message("8=FIX.4.2|9=55|35=0|34=3|49=TW|52=20000426-12:05:06|56=ISLD|1=acct123|10=123|");
var st = new SendingTime();
msg.Header.GetField(st);

st.Value.Kind   // before: Unspecified      after: Utc
```

Tag 52 is a UTCTIMESTAMP, so it's UTC by definition — but the value came back untyped. Callers
can't distinguish it from local time, and calling `ToUniversalTime()` on it silently double-shifts.

### Cause

UTCTIMESTAMP and TZTIMESTAMP both map to `DateTimeField`. When `DateTimeConverter.ParseToDateTime`
gained optional offset parsing for TZTIMESTAMP, the no-offset path — the normal case for every
UTCTIMESTAMP on the wire — was left returning `Kind = Unspecified`. Only the offset-bearing path
returns `Utc`.

Fixing the converter isn't viable: it's public and shared by `FieldMap.GetDateTime` for all datetime
fields, so forcing `Utc` there re-breaks TZTIMESTAMP. "This field is always UTC" is a fact from the
DataDictionary, not from the string, so it belongs in the type.

### Change

New `UtcDateTimeField : DateTimeField` normalizes on assignment; codegen repointed so UTCTIMESTAMP
fields derive from it. TZTIMESTAMP (`TZTransactTime`) is untouched.

| Input `Kind` | Action | Rationale |
|---|---|---|
| `Utc` | pass through | already correct |
| `Unspecified` | relabel, **no shift** | wire value is already UTC per spec |
| `Local` | `ToUniversalTime()`, **real shift** | carries genuine offset information |

`Fields.cs` is regenerated via DDTool rather than hand-edited; 29 field classes change base.

### Two calls that need your judgement

**1. `FieldBase<T>.Value` is now `virtual`.** CONTRIBUTING asks to avoid public interface changes and
this sits at the base of every field type, so I want to flag it explicitly. I implemented it with
`new`-hiding first precisely to avoid this, but that's unsound:

```csharp
DateTimeField f = new SendingTime();
f.Value = someLocalDateTime;
// -> 52=20251031-17:30:59.000     local wall-clock emitted as UTC
```

Hiding binds at compile time, so any base-typed reference bypassed normalization and wrote a wrong
SendingTime — and the original bug still reproduced through such a reference. Cost is minimal: the
generated field classes are `sealed`, so the JIT devirtualizes access through them, and remaining
calls sit next to `DateTime` formatting that dominates. Rationale is commented at both sites, with a
regression test that assigns through a base-typed reference.

**2. `Local` input now converts.** `new TransactTime(DateTime.Now)` previously wrote local wall-clock
time; it now writes correct UTC. That's a fix, but it changes bytes on the wire for anyone
compensating for the old behaviour. I chose conversion over throwing because `GetField` writes
through `.Value` on every parse, so a strict setter would throw on ordinary inbound messages.

Blast radius is limited to user-supplied values: the only `DateTime.Now` in the engine is in
`SslCertCache` (certificate validity); everything the engine timestamps itself uses `DateTime.UtcNow`.

### Also included

`DataDictionary.CheckValidFormat` matched `type == typeof(DateTimeField)` exactly, so remapping
UTCTIMESTAMP would have silently disabled format validation for those fields. Fixed, with a
regression test. Happy to split this into its own PR if you'd prefer.

### Deliberately not changed

`FieldMap.GetDateTime(int tag)` still returns `Unspecified` — a lookup by tag alone has no
DataDictionary context to know the field is a UTCTIMESTAMP. Documented in the XML docs rather than
guessed at. Can add a DD-aware overload if you want one.

### Tests

`UnitTests` 881 · `DDTool/UnitTests` 23 · `AcceptanceTest` 490 · build clean, 0 warnings.

New coverage: per-`Kind` normalization (the `Local` expectation is derived from `TimeZoneInfo` rather
than restating the implementation, and guarded for UTC CI runners); base-typed-reference assignment;
`FieldMap` and `Message`-level round-trips; `TZTransactTime` offset parsing still intact; DDTool
mapping/generation; DataDictionary type resolution and format validation.

<details>
<summary>Suggested RELEASE_NOTES.md wording (not committed, per CONTRIBUTING)</summary>

Under **IMPORTANT NOTICES**:

* **1.16 introduces a new `UtcDateTimeField` class for UTCTIMESTAMP fields.**
    * Fields whose FIX type is UTCTIMESTAMP (`SendingTime`, `TransactTime`, `ExpireTime`, etc.) now
      derive from `UtcDateTimeField` instead of `DateTimeField`.  Their `Value` always has
      `DateTime.Kind == Utc`, as the FIX spec requires, instead of `Unspecified`.
    * **This can change the values you put on the wire.**  If you construct one of these fields from a
      `DateTime` whose `Kind` is `Local` (e.g. `new TransactTime(DateTime.Now)`), it is now converted to
      UTC before being written; previously the local wall-clock time was written as-is.  Applications
      that were compensating for the old behavior will need to stop doing so.  `Unspecified` values are
      relabeled only, never shifted.
    * `FieldBase<T>.Value` is now `virtual` so the new class can normalize on assignment.  TZTIMESTAMP
      fields (`TZTransactTime`) are unaffected and remain on `DateTimeField`.
    * `FieldMap.GetDateTime(int tag)` is unchanged and still returns `Unspecified`, because a lookup by
      tag alone has no DataDictionary context to know the field is a UTCTIMESTAMP.
    * These changes are introduced in Issue #1030/Pull Request #NNNN.

Under **upcoming for v1.16.0**:

* #1030 - new UtcDateTimeField class so UTCTIMESTAMP fields always have DateTimeKind.Utc (stic)

</details>

---

CLA signed. I've left `RELEASE_NOTES.md` untouched per CONTRIBUTING. This is a behaviour change to
public interface code and the mailing list has been quiet, so I've brought it here directly — if
you'd rather it went through a deprecation cycle, took a different shape, or isn't wanted, say so and
I'll rework or drop it.